### PR TITLE
feat: add ConfigMap generation and apply Makefile targets (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ deploy/environments/*.env
 !deploy/environments/*_example.env
 deploy/secrets/*.yaml
 !deploy/secrets/*_example.yaml
+
+# Generated ConfigMap YAML files
+deploy/generated/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,14 @@ ifdef PODMAN_CONNECTION
   CONTAINER_ENGINE := podman --connection $(PODMAN_CONNECTION)
 endif
 
-.PHONY: build test lint fmt clean image image-push
+# ConfigMap generation
+CONFIG_DIR ?=
+NAME ?= $(notdir $(patsubst %/,%,$(CONFIG_DIR)))
+OUTDIR ?= deploy/generated/$(NAME)
+NAMESPACE ?=
+KUBECTL ?= oc
+
+.PHONY: build test lint fmt clean image image-push configmap-gen configmap-apply
 
 build:
 	go build -o $(BINDIR)/$(BINARY) ./cmd/docsclaw
@@ -36,3 +43,41 @@ image:
 
 image-push: image
 	$(CONTAINER_ENGINE) push $(REGISTRY):$(DEV_TAG)
+
+# --- ConfigMap generation ---
+
+configmap-gen:
+ifndef CONFIG_DIR
+	$(error CONFIG_DIR is required. Usage: make configmap-gen CONFIG_DIR=testdata/standalone)
+endif
+	@test -d "$(CONFIG_DIR)" || { echo "ERROR: $(CONFIG_DIR) does not exist"; exit 1; }
+	@test -f "$(CONFIG_DIR)/system-prompt.txt" || { echo "ERROR: $(CONFIG_DIR)/system-prompt.txt is required"; exit 1; }
+	@mkdir -p $(OUTDIR)
+	@echo "Generating ConfigMap YAML files in $(OUTDIR)..."
+	@# --- Agent config ConfigMap ---
+	@CONFIG_FILES=""; \
+	for f in system-prompt.txt agent-card.json agent-config.yaml prompts.json; do \
+		[ -f "$(CONFIG_DIR)/$$f" ] && CONFIG_FILES="$$CONFIG_FILES --from-file=$$f=$(CONFIG_DIR)/$$f"; \
+	done; \
+	$(KUBECTL) create configmap $(NAME)-config \
+		$$CONFIG_FILES \
+		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+		--dry-run=client -o yaml > $(OUTDIR)/config.yaml
+	@echo "  Created $(OUTDIR)/config.yaml"
+	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
+		SKILL_FILES=""; \
+		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
+			skill_name=$$(basename "$$skill_dir"); \
+			[ -f "$$skill_dir/SKILL.md" ] && \
+				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
+		done; \
+		$(KUBECTL) create configmap $(NAME)-skills \
+			$$SKILL_FILES \
+			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+			--dry-run=client -o yaml > $(OUTDIR)/skills.yaml; \
+		echo "  Created $(OUTDIR)/skills.yaml"; \
+	else \
+		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+	fi
+	@echo "Done. Apply with: $(KUBECTL) apply -f $(OUTDIR)/"

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,38 @@ endif
 		echo "  No skills/ directory found, skipping skills ConfigMap"; \
 	fi
 	@echo "Done. Apply with: $(KUBECTL) apply -f $(OUTDIR)/"
+
+configmap-apply:
+ifndef CONFIG_DIR
+	$(error CONFIG_DIR is required. Usage: make configmap-apply CONFIG_DIR=testdata/standalone)
+endif
+	@test -d "$(CONFIG_DIR)" || { echo "ERROR: $(CONFIG_DIR) does not exist"; exit 1; }
+	@test -f "$(CONFIG_DIR)/system-prompt.txt" || { echo "ERROR: $(CONFIG_DIR)/system-prompt.txt is required"; exit 1; }
+	@echo "Applying ConfigMaps from $(CONFIG_DIR)..."
+	@# --- Agent config ConfigMap ---
+	@CONFIG_FILES=""; \
+	for f in system-prompt.txt agent-card.json agent-config.yaml prompts.json; do \
+		[ -f "$(CONFIG_DIR)/$$f" ] && CONFIG_FILES="$$CONFIG_FILES --from-file=$$f=$(CONFIG_DIR)/$$f"; \
+	done; \
+	$(KUBECTL) create configmap $(NAME)-config \
+		$$CONFIG_FILES \
+		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+		--dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@echo "  Applied $(NAME)-config"
+	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
+		SKILL_FILES=""; \
+		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
+			skill_name=$$(basename "$$skill_dir"); \
+			[ -f "$$skill_dir/SKILL.md" ] && \
+				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
+		done; \
+		$(KUBECTL) create configmap $(NAME)-skills \
+			$$SKILL_FILES \
+			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+			--dry-run=client -o yaml | $(KUBECTL) apply -f -; \
+		echo "  Applied $(NAME)-skills"; \
+	else \
+		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+	fi
+	@echo "Done."

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,15 @@ endif
 			[ -f "$$skill_dir/SKILL.md" ] && \
 				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
 		done; \
-		$(KUBECTL) create configmap $(NAME)-skills \
-			$$SKILL_FILES \
-			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
-			--dry-run=client -o yaml > $(OUTDIR)/skills.yaml; \
-		echo "  Created $(OUTDIR)/skills.yaml"; \
+		if [ -n "$$SKILL_FILES" ]; then \
+			$(KUBECTL) create configmap $(NAME)-skills \
+				$$SKILL_FILES \
+				$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+				--dry-run=client -o yaml > $(OUTDIR)/skills.yaml; \
+			echo "  Created $(OUTDIR)/skills.yaml"; \
+		else \
+			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skills ConfigMap"; \
+		fi; \
 	else \
 		echo "  No skills/ directory found, skipping skills ConfigMap"; \
 	fi
@@ -107,11 +111,15 @@ endif
 			[ -f "$$skill_dir/SKILL.md" ] && \
 				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
 		done; \
-		$(KUBECTL) create configmap $(NAME)-skills \
-			$$SKILL_FILES \
-			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
-			--dry-run=client -o yaml | $(KUBECTL) apply -f -; \
-		echo "  Applied $(NAME)-skills"; \
+		if [ -n "$$SKILL_FILES" ]; then \
+			$(KUBECTL) create configmap $(NAME)-skills \
+				$$SKILL_FILES \
+				$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+				--dry-run=client -o yaml | $(KUBECTL) apply -f -; \
+			echo "  Applied $(NAME)-skills"; \
+		else \
+			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skills ConfigMap"; \
+		fi; \
 	else \
 		echo "  No skills/ directory found, skipping skills ConfigMap"; \
 	fi

--- a/docs/dev/2026-04-10-cli-chat-client-design.md
+++ b/docs/dev/2026-04-10-cli-chat-client-design.md
@@ -1,0 +1,124 @@
+# Interactive CLI chat client with Bubble Tea
+
+**Issue:** #11
+**Date:** 2026-04-10
+**Status:** Approved
+
+## Goal
+
+Add a `docsclaw chat` subcommand that provides an interactive terminal
+chat interface to any DocsClaw A2A agent, built with Bubble Tea and
+the Charm ecosystem.
+
+## Command
+
+```bash
+docsclaw chat --agent-url http://localhost:8080
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--agent-url` | (required) | A2A agent endpoint URL |
+| `--name` | Agent Card name | Override display name for the agent |
+
+## Connection flow
+
+1. Parse flags
+2. Fetch `/.well-known/agent-card.json` from the agent URL
+3. Display agent name, description, and available skills in header
+4. Enter interactive chat loop
+
+## UI layout
+
+```text
++-------------------------------------------------+
+| DocsClaw Chat · connected to:                   |
+| Research Agent — Summarizes documents            |
++-------------------------------------------------+
+|                                                 |
+| You: What can you help me with?                 |
+|                                                 |
+| Research Agent: I can summarize documents,      |
+| review code, and fetch web pages. Send me a     |
+| document ID or ask a question.                  |
+|                                                 |
+| You: Summarize DOC-42                           |
+|                                                 |
+| · Thinking...                                   |
+|                                                 |
++-------------------------------------------------+
+| > _                                  Ctrl+C quit |
++-------------------------------------------------+
+```
+
+The agent label uses the Agent Card `name` field by default,
+overridden with `--name`.
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `bubbletea` | TUI framework, event loop |
+| `bubbles` | Viewport, text input, spinner |
+| `lipgloss` | Header, message labels, status bar styling |
+| `glamour` | Markdown rendering of agent responses |
+
+## Code structure
+
+| File | Responsibility |
+|------|----------------|
+| `internal/cmd/chat.go` | Cobra subcommand, flag parsing, Agent Card fetch |
+| `internal/chat/model.go` | Bubble Tea model: state, Update, View |
+| `internal/chat/messages.go` | Bubble Tea message types (response, error) |
+| `internal/chat/styles.go` | Lip Gloss style definitions |
+
+## Key behaviors
+
+**Input:** Single-line text input at the bottom, send on Enter.
+
+**Sending:** Uses existing `A2AClient.Invoke()` with `MessageText`
+(gateway mode). Runs in a goroutine via Bubble Tea `Cmd`, sends a
+message on completion.
+
+**Waiting:** Spinner component while the request is in flight. Input
+disabled during wait.
+
+**Rendering:** Agent responses rendered through Glamour for Markdown
+(code blocks, lists, bold). User messages displayed as plain text.
+
+**Scrolling:** Viewport component for chat history, scrollable with
+arrow keys and mouse wheel.
+
+**Quit:** Ctrl+C.
+
+**Errors:** Connection failures and timeouts displayed inline as
+styled error messages.
+
+## Conversation model
+
+Each message is independent on the server side (single-turn). The
+client stores the full conversation in a `[]ChatMessage` slice for
+display purposes. This slice is ready for multi-turn when the server
+supports conversation context.
+
+## Not in scope (v1)
+
+- Multi-turn server-side context (depends on #5)
+- Streaming/SSE (current API is blocking request/response)
+- Authentication (bearer token, SPIFFE identity)
+- Conversation save/load
+- File attachments
+- In-chat slash commands (e.g., `/name`, `/clear`, `/agents`)
+
+## Future extensions
+
+- **Streaming:** When the server implements `tasks/sendSubscribe`
+  (SSE), swap the blocking `Invoke()` call for a streaming handler.
+  The UI separation (goroutine + Bubble Tea message) makes this a
+  localized change.
+- **Slash commands:** Add in-chat commands like `/name`, `/clear`,
+  `/agents` for runtime configuration.
+- **Multi-turn:** Send conversation history with each request once
+  the server or memory layer (#5) supports it.

--- a/docs/dev/2026-04-10-cli-chat-client-plan.md
+++ b/docs/dev/2026-04-10-cli-chat-client-plan.md
@@ -1,0 +1,649 @@
+# CLI Chat Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `docsclaw chat` subcommand with an interactive Bubble
+Tea TUI that connects to any A2A agent, fetches its Agent Card, and
+provides a chat interface with Markdown-rendered responses.
+
+**Architecture:** Cobra subcommand in `internal/cmd/chat.go` delegates
+to a Bubble Tea model in `internal/chat/`. The model manages input,
+chat history viewport, and async agent communication via goroutines.
+Agent Card is fetched on startup via HTTP GET to
+`/.well-known/agent-card.json`.
+
+**Tech Stack:** Bubble Tea, Bubbles (viewport, textinput, spinner),
+Lip Gloss, Glamour, existing `internal/bridge.A2AClient`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `internal/cmd/chat.go` | Create | Cobra subcommand, flag parsing, Agent Card fetch, launch TUI |
+| `internal/chat/model.go` | Create | Bubble Tea model: state, Init, Update, View |
+| `internal/chat/messages.go` | Create | Bubble Tea command/message types |
+| `internal/chat/styles.go` | Create | Lip Gloss style definitions |
+| `cmd/docsclaw/main.go` | Modify | Blank import `internal/cmd` (already done, verify only) |
+| `go.mod` | Modify | Add Charm dependencies |
+
+---
+
+### Task 1: Add Charm dependencies
+
+**Files:**
+- Modify: `go.mod`
+
+- [ ] **Step 1: Add Bubble Tea and related packages**
+
+```bash
+go get github.com/charmbracelet/bubbletea@latest
+go get github.com/charmbracelet/bubbles@latest
+go get github.com/charmbracelet/lipgloss@latest
+go get github.com/charmbracelet/glamour@latest
+```
+
+- [ ] **Step 2: Tidy modules**
+
+```bash
+go mod tidy
+```
+
+- [ ] **Step 3: Verify build still works**
+
+```bash
+make build
+```
+
+Expected: successful build, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -s -m "deps: add Charm libraries for TUI chat client (#11)"
+```
+
+---
+
+### Task 2: Create Lip Gloss styles
+
+**Files:**
+- Create: `internal/chat/styles.go`
+
+- [ ] **Step 1: Write the styles file**
+
+```go
+package chat
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Header bar: agent name and description.
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15")).
+			Background(lipgloss.Color("62")).
+			Padding(0, 1)
+
+	// User message label.
+	userLabelStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("12"))
+
+	// Agent message label.
+	agentLabelStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("10"))
+
+	// Error messages shown inline.
+	errorStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("9"))
+
+	// Status bar at the bottom.
+	statusStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241"))
+
+	// Input prompt indicator.
+	promptStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("12")).
+			Bold(true)
+)
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+go build ./internal/chat/
+```
+
+Expected: success (package compiles standalone).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/chat/styles.go
+git commit -s -m "feat(chat): add Lip Gloss style definitions (#11)"
+```
+
+---
+
+### Task 3: Create Bubble Tea message types
+
+**Files:**
+- Create: `internal/chat/messages.go`
+
+- [ ] **Step 1: Write the message types file**
+
+```go
+package chat
+
+// ChatMessage represents a single message in the chat history.
+type ChatMessage struct {
+	Role string // "user" or "agent"
+	Text string // raw text (Markdown for agent responses)
+}
+
+// responseMsg is sent when the agent responds.
+type responseMsg struct {
+	text string
+}
+
+// errMsg is sent when a request fails.
+type errMsg struct {
+	err error
+}
+
+func (e errMsg) Error() string { return e.err.Error() }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+go build ./internal/chat/
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/chat/messages.go
+git commit -s -m "feat(chat): add Bubble Tea message types (#11)"
+```
+
+---
+
+### Task 4: Create the Bubble Tea model
+
+**Files:**
+- Create: `internal/chat/model.go`
+
+- [ ] **Step 1: Write the model file**
+
+This is the main TUI logic. The model manages the chat history
+viewport, text input, spinner, and async agent communication.
+
+```go
+package chat
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/redhat-et/docsclaw/internal/bridge"
+)
+
+// Model is the Bubble Tea model for the chat TUI.
+type Model struct {
+	agentURL  string
+	agentName string
+	userName  string
+	client    *bridge.A2AClient
+
+	viewport viewport.Model
+	input    textinput.Model
+	spinner  spinner.Model
+
+	messages []ChatMessage
+	waiting  bool
+	width    int
+	height   int
+	ready    bool
+}
+
+// NewModel creates a new chat model.
+func NewModel(agentURL, agentName, userName string) Model {
+	ti := textinput.New()
+	ti.Placeholder = "Type a message..."
+	ti.Focus()
+
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+
+	return Model{
+		agentURL:  agentURL,
+		agentName: agentName,
+		userName:  userName,
+		client:    bridge.NewA2AClient(&http.Client{}, slog.Default()),
+		input:     ti,
+		spinner:   sp,
+		messages:  []ChatMessage{},
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyEnter:
+			if m.waiting || strings.TrimSpace(m.input.Value()) == "" {
+				return m, nil
+			}
+			text := m.input.Value()
+			m.messages = append(m.messages, ChatMessage{Role: "user", Text: text})
+			m.input.Reset()
+			m.waiting = true
+			m.viewport.SetContent(m.renderHistory())
+			m.viewport.GotoBottom()
+			return m, tea.Batch(m.spinner.Tick, m.sendMessage(text))
+		}
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		headerHeight := 3 // header + separator
+		inputHeight := 3  // input + status
+		vpHeight := m.height - headerHeight - inputHeight
+		if !m.ready {
+			m.viewport = viewport.New(m.width, vpHeight)
+			m.ready = true
+		} else {
+			m.viewport.Width = m.width
+			m.viewport.Height = vpHeight
+		}
+		m.input.Width = m.width - 4
+		m.viewport.SetContent(m.renderHistory())
+
+	case responseMsg:
+		m.messages = append(m.messages, ChatMessage{Role: "agent", Text: msg.text})
+		m.waiting = false
+		m.viewport.SetContent(m.renderHistory())
+		m.viewport.GotoBottom()
+		return m, nil
+
+	case errMsg:
+		m.messages = append(m.messages, ChatMessage{
+			Role: "agent",
+			Text: "Error: " + msg.err.Error(),
+		})
+		m.waiting = false
+		m.viewport.SetContent(m.renderHistory())
+		m.viewport.GotoBottom()
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.waiting {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	// Update sub-components.
+	if !m.waiting {
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	cmds = append(cmds, cmd)
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m Model) View() string {
+	if !m.ready {
+		return "Initializing..."
+	}
+
+	// Header.
+	header := headerStyle.Width(m.width).Render(
+		fmt.Sprintf(" DocsClaw Chat · %s", m.agentName),
+	)
+
+	// Chat area.
+	chatArea := m.viewport.View()
+
+	// Input area.
+	var inputArea string
+	if m.waiting {
+		inputArea = fmt.Sprintf("  %s Thinking...", m.spinner.View())
+	} else {
+		inputArea = promptStyle.Render("> ") + m.input.View()
+	}
+
+	// Status bar.
+	status := statusStyle.Width(m.width).Render(
+		fmt.Sprintf("  %s  %s",
+			m.agentURL,
+			"Ctrl+C quit",
+		),
+	)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		chatArea,
+		inputArea,
+		status,
+	)
+}
+
+// sendMessage sends a message to the agent asynchronously.
+func (m Model) sendMessage(text string) tea.Cmd {
+	return func() tea.Msg {
+		result, err := m.client.Invoke(context.Background(), &bridge.InvokeRequest{
+			AgentURL:    m.agentURL,
+			MessageText: text,
+		})
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return responseMsg{text: result.Text}
+	}
+}
+
+// renderHistory renders all chat messages into a single string.
+func (m Model) renderHistory() string {
+	if len(m.messages) == 0 {
+		return statusStyle.Render("  Send a message to start the conversation.")
+	}
+
+	var sb strings.Builder
+	renderer, _ := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(m.width-4),
+	)
+
+	for _, msg := range m.messages {
+		sb.WriteString("\n")
+		if msg.Role == "user" {
+			label := userLabelStyle.Render(m.userName + ":")
+			sb.WriteString(fmt.Sprintf("  %s %s\n", label, msg.Text))
+		} else {
+			label := agentLabelStyle.Render(m.agentName + ":")
+			sb.WriteString(fmt.Sprintf("  %s\n", label))
+			// Render agent responses as Markdown.
+			rendered := msg.Text
+			if renderer != nil {
+				if r, err := renderer.Render(msg.Text); err == nil {
+					rendered = r
+				}
+			}
+			sb.WriteString(rendered)
+		}
+	}
+
+	if m.waiting {
+		sb.WriteString("\n")
+		label := agentLabelStyle.Render(m.agentName + ":")
+		sb.WriteString(fmt.Sprintf("  %s\n", label))
+		sb.WriteString(fmt.Sprintf("  %s Thinking...\n", m.spinner.View()))
+	}
+
+	return sb.String()
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+go build ./internal/chat/
+```
+
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/chat/model.go
+git commit -s -m "feat(chat): add Bubble Tea model with viewport and async send (#11)"
+```
+
+---
+
+### Task 5: Create the Cobra subcommand
+
+**Files:**
+- Create: `internal/cmd/chat.go`
+
+- [ ] **Step 1: Write the chat command**
+
+This registers the `chat` subcommand, parses flags, fetches the
+Agent Card, and launches the Bubble Tea program.
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/docsclaw/internal/chat"
+)
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Interactive chat with a DocsClaw agent",
+	Long:  "Connect to an A2A agent and start an interactive terminal chat session.",
+	RunE:  runChat,
+}
+
+func init() {
+	chatCmd.Flags().String("agent-url", "", "A2A agent endpoint URL (required)")
+	chatCmd.Flags().String("name", "", "Override display name for the agent")
+	_ = chatCmd.MarkFlagRequired("agent-url")
+	rootCmd.AddCommand(chatCmd)
+}
+
+func runChat(cmd *cobra.Command, args []string) error {
+	agentURL, _ := cmd.Flags().GetString("agent-url")
+	nameOverride, _ := cmd.Flags().GetString("name")
+
+	// Normalize URL: strip trailing slash.
+	agentURL = strings.TrimRight(agentURL, "/")
+
+	// Fetch Agent Card.
+	agentName := "Agent"
+	card, err := fetchAgentCard(agentURL)
+	if err != nil {
+		fmt.Printf("Warning: could not fetch Agent Card: %v\n", err)
+		fmt.Println("Proceeding without agent metadata.")
+	} else {
+		agentName = card.Name
+		fmt.Printf("Connected to: %s\n", card.Name)
+		if card.Description != "" {
+			fmt.Printf("  %s\n", card.Description)
+		}
+		if len(card.Skills) > 0 {
+			fmt.Printf("  Skills:")
+			for _, s := range card.Skills {
+				fmt.Printf(" [%s]", s.Name)
+			}
+			fmt.Println()
+		}
+		fmt.Println()
+	}
+
+	// Apply name override.
+	if nameOverride != "" {
+		agentName = nameOverride
+	}
+
+	// Launch TUI.
+	model := chat.NewModel(agentURL, agentName, "You")
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	_, err = p.Run()
+	return err
+}
+
+// fetchAgentCard fetches the Agent Card from the well-known endpoint.
+func fetchAgentCard(agentURL string) (*a2a.AgentCard, error) {
+	cardURL := agentURL + "/.well-known/agent-card.json"
+	resp, err := http.Get(cardURL)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", cardURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", cardURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var card a2a.AgentCard
+	if err := json.Unmarshal(body, &card); err != nil {
+		return nil, fmt.Errorf("parsing Agent Card: %w", err)
+	}
+
+	return &card, nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+make build
+```
+
+Expected: successful build.
+
+- [ ] **Step 3: Verify the subcommand is registered**
+
+```bash
+./bin/docsclaw --help
+```
+
+Expected: `chat` appears in the list of available commands.
+
+```bash
+./bin/docsclaw chat --help
+```
+
+Expected: shows `--agent-url` (required) and `--name` flags.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cmd/chat.go
+git commit -s -m "feat(chat): add Cobra subcommand for interactive A2A chat (#11)"
+```
+
+---
+
+### Task 6: Integration test — end-to-end chat session
+
+**Files:**
+- No new files, manual test
+
+- [ ] **Step 1: Start a local DocsClaw agent**
+
+In a separate terminal:
+
+```bash
+export LLM_API_KEY=<your-key>
+./bin/docsclaw serve \
+  --config-dir testdata/standalone \
+  --llm-provider anthropic \
+  --listen-plain-http
+```
+
+Wait for `Server listening on :8000`.
+
+- [ ] **Step 2: Run the chat client**
+
+```bash
+./bin/docsclaw chat --agent-url http://localhost:8000
+```
+
+Expected: the TUI launches, header shows the agent name from the
+Agent Card, and the input prompt is active.
+
+- [ ] **Step 3: Send a test message**
+
+Type `Hello, what can you do?` and press Enter.
+
+Expected: spinner shows "Thinking...", then agent response appears
+rendered as Markdown.
+
+- [ ] **Step 4: Test the name override**
+
+Quit with Ctrl+C, then relaunch:
+
+```bash
+./bin/docsclaw chat --agent-url http://localhost:8000 --name "Rex"
+```
+
+Expected: agent messages are labeled "Rex:" instead of the Agent
+Card name.
+
+- [ ] **Step 5: Test error handling**
+
+```bash
+./bin/docsclaw chat --agent-url http://localhost:9999
+```
+
+Expected: warning about failed Agent Card fetch, then chat launches
+with fallback name "Agent". Sending a message shows an inline error.
+
+- [ ] **Step 6: Run linter and tests**
+
+```bash
+make lint
+make test
+```
+
+Expected: no new lint errors, all tests pass.
+
+- [ ] **Step 7: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -s -m "feat(chat): finalize interactive CLI chat client (#11)"
+```

--- a/docs/dev/2026-04-10-skill-to-configmap-design.md
+++ b/docs/dev/2026-04-10-skill-to-configmap-design.md
@@ -42,8 +42,9 @@ Contains all non-skill files from the config directory root:
 
 ### `<name>-skills`
 
-Contains all skill files, keyed as `<skill-name>/SKILL.md`. Only
-generated if the `skills/` subdirectory exists.
+Contains all skill files, keyed as `<skill-name>.SKILL.md`. Only
+generated if the `skills/` subdirectory exists and contains at
+least one `SKILL.md` file.
 
 ## Generated output structure
 

--- a/docs/dev/2026-04-10-skill-to-configmap-design.md
+++ b/docs/dev/2026-04-10-skill-to-configmap-design.md
@@ -1,0 +1,102 @@
+# Skill-to-ConfigMap conversion tooling
+
+**Issue:** #6
+**Date:** 2026-04-10
+**Status:** Approved
+
+## Goal
+
+Provide Makefile targets that convert a local agent config directory
+into Kubernetes ConfigMap YAML files and optionally apply them to a
+cluster. The source directory is the single source of truth.
+
+## Makefile targets
+
+| Target | Purpose |
+|--------|---------|
+| `configmap-gen` | Generate ConfigMap YAML files from a config directory |
+| `configmap-apply` | Generate and apply to cluster (idempotent) |
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONFIG_DIR` | (required) | Path to agent config directory |
+| `NAME` | basename of `CONFIG_DIR` | Prefix for ConfigMap names |
+| `OUTDIR` | `deploy/generated/$(NAME)/` | Output directory for YAML files |
+| `NAMESPACE` | current context namespace | Target K8s namespace |
+| `KUBECTL` | `oc` | CLI tool (`oc` or `kubectl`) |
+
+## Generated ConfigMaps
+
+Two ConfigMaps are generated per agent config directory:
+
+### `<name>-config`
+
+Contains all non-skill files from the config directory root:
+
+- `system-prompt.txt` (required)
+- `agent-card.json` (if present)
+- `agent-config.yaml` (if present)
+- `prompts.json` (if present)
+
+### `<name>-skills`
+
+Contains all skill files, keyed as `<skill-name>/SKILL.md`. Only
+generated if the `skills/` subdirectory exists.
+
+## Generated output structure
+
+```
+deploy/generated/<name>/
+├── config.yaml     # ConfigMap: <name>-config
+└── skills.yaml     # ConfigMap: <name>-skills
+```
+
+## Apply mechanism
+
+The `configmap-apply` target uses the `create --dry-run=client`
+pattern for idempotent updates:
+
+```bash
+kubectl create configmap <name>-config \
+  --from-file=system-prompt.txt=<path> \
+  --from-file=agent-config.yaml=<path> \
+  ... \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+This always regenerates from the source directory. Adding a new
+skill means adding the `SKILL.md` file and re-running
+`make configmap-apply`.
+
+## .gitignore
+
+Add `deploy/generated/` to `.gitignore`. These are derived
+artifacts. Users who want to version them can override `OUTDIR`.
+
+## Usage examples
+
+Generate YAML files with defaults (name derived from directory):
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/standalone
+```
+
+Generate with custom name and output:
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/standalone NAME=my-agent OUTDIR=deploy/my-agent/
+```
+
+Apply directly to cluster:
+
+```bash
+make configmap-apply CONFIG_DIR=testdata/standalone NAMESPACE=agents
+```
+
+Use kubectl instead of oc:
+
+```bash
+make configmap-apply CONFIG_DIR=testdata/standalone KUBECTL=kubectl
+```

--- a/docs/dev/2026-04-10-skill-to-configmap-plan.md
+++ b/docs/dev/2026-04-10-skill-to-configmap-plan.md
@@ -1,0 +1,286 @@
+# Skill-to-ConfigMap Tooling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Makefile targets that generate Kubernetes ConfigMap YAML
+files from an agent config directory and optionally apply them to a
+cluster.
+
+**Architecture:** Two shell-based Makefile targets (`configmap-gen`,
+`configmap-apply`) that use `kubectl`/`oc` with `--from-file` and
+`--dry-run=client -o yaml` to produce idempotent ConfigMap manifests.
+No Go code needed.
+
+**Tech Stack:** Make, kubectl/oc CLI
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `Makefile` | Modify | Add `configmap-gen` and `configmap-apply` targets |
+| `.gitignore` | Modify | Add `deploy/generated/` |
+
+---
+
+### Task 1: Add `configmap-gen` target to Makefile
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add variables to Makefile**
+
+Add these lines after the existing `CONTAINER_ENGINE` / `PODMAN_CONNECTION`
+block (after line 12):
+
+```makefile
+# ConfigMap generation
+CONFIG_DIR ?=
+NAME ?= $(notdir $(patsubst %/,%,$(CONFIG_DIR)))
+OUTDIR ?= deploy/generated/$(NAME)
+NAMESPACE ?=
+KUBECTL ?= oc
+```
+
+- [ ] **Step 2: Add the `configmap-gen` target**
+
+Add after the `image-push` target. The target generates two YAML files:
+`config.yaml` (agent config files) and `skills.yaml` (all skills).
+
+```makefile
+# --- ConfigMap generation ---
+
+.PHONY: configmap-gen configmap-apply
+
+configmap-gen:
+ifndef CONFIG_DIR
+	$(error CONFIG_DIR is required. Usage: make configmap-gen CONFIG_DIR=testdata/standalone)
+endif
+	@mkdir -p $(OUTDIR)
+	@echo "Generating ConfigMap YAML files in $(OUTDIR)..."
+	@# --- Agent config ConfigMap ---
+	@CONFIG_FILES=""; \
+	for f in system-prompt.txt agent-card.json agent-config.yaml prompts.json; do \
+		[ -f "$(CONFIG_DIR)/$$f" ] && CONFIG_FILES="$$CONFIG_FILES --from-file=$$f=$(CONFIG_DIR)/$$f"; \
+	done; \
+	$(KUBECTL) create configmap $(NAME)-config \
+		$$CONFIG_FILES \
+		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+		--dry-run=client -o yaml > $(OUTDIR)/config.yaml
+	@echo "  Created $(OUTDIR)/config.yaml"
+	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
+		SKILL_FILES=""; \
+		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
+			skill_name=$$(basename "$$skill_dir"); \
+			[ -f "$$skill_dir/SKILL.md" ] && \
+				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name/SKILL.md=$$skill_dir/SKILL.md"; \
+		done; \
+		$(KUBECTL) create configmap $(NAME)-skills \
+			$$SKILL_FILES \
+			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+			--dry-run=client -o yaml > $(OUTDIR)/skills.yaml; \
+		echo "  Created $(OUTDIR)/skills.yaml"; \
+	else \
+		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+	fi
+	@echo "Done. Apply with: $(KUBECTL) apply -f $(OUTDIR)/"
+```
+
+- [ ] **Step 3: Update the `.PHONY` declaration**
+
+Change line 14 from:
+
+```makefile
+.PHONY: build test lint fmt clean image image-push
+```
+
+to:
+
+```makefile
+.PHONY: build test lint fmt clean image image-push configmap-gen configmap-apply
+```
+
+- [ ] **Step 4: Test `configmap-gen` with `testdata/standalone`**
+
+Run:
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/standalone
+```
+
+Expected output:
+
+```
+Generating ConfigMap YAML files in deploy/generated/standalone/...
+  Created deploy/generated/standalone/config.yaml
+  Created deploy/generated/standalone/skills.yaml
+Done. Apply with: oc apply -f deploy/generated/standalone/
+```
+
+Verify the generated files:
+
+```bash
+cat deploy/generated/standalone/config.yaml
+```
+
+Expected: a valid ConfigMap YAML with `name: standalone-config` containing
+keys `system-prompt.txt`, `agent-card.json`, `agent-config.yaml`.
+
+```bash
+cat deploy/generated/standalone/skills.yaml
+```
+
+Expected: a valid ConfigMap YAML with `name: standalone-skills` containing
+keys `code-review/SKILL.md` and `url-summary/SKILL.md`.
+
+- [ ] **Step 5: Test with custom NAME**
+
+Run:
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/standalone NAME=my-agent OUTDIR=deploy/generated/my-agent
+```
+
+Expected: files in `deploy/generated/my-agent/` with ConfigMap names
+`my-agent-config` and `my-agent-skills`.
+
+- [ ] **Step 6: Test with a config directory that has no skills**
+
+Run:
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/summarizer-hr
+```
+
+Expected output:
+
+```
+Generating ConfigMap YAML files in deploy/generated/summarizer-hr/...
+  Created deploy/generated/summarizer-hr/config.yaml
+  No skills/ directory found, skipping skills ConfigMap
+Done. Apply with: oc apply -f deploy/generated/summarizer-hr/
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Makefile
+git commit -s -m "feat: add configmap-gen Makefile target (#6)"
+```
+
+---
+
+### Task 2: Add `configmap-apply` target
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add the `configmap-apply` target**
+
+Add immediately after the `configmap-gen` target:
+
+```makefile
+configmap-apply:
+ifndef CONFIG_DIR
+	$(error CONFIG_DIR is required. Usage: make configmap-apply CONFIG_DIR=testdata/standalone)
+endif
+	@echo "Applying ConfigMaps from $(CONFIG_DIR)..."
+	@# --- Agent config ConfigMap ---
+	@CONFIG_FILES=""; \
+	for f in system-prompt.txt agent-card.json agent-config.yaml prompts.json; do \
+		[ -f "$(CONFIG_DIR)/$$f" ] && CONFIG_FILES="$$CONFIG_FILES --from-file=$$f=$(CONFIG_DIR)/$$f"; \
+	done; \
+	$(KUBECTL) create configmap $(NAME)-config \
+		$$CONFIG_FILES \
+		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+		--dry-run=client -o yaml | $(KUBECTL) apply -f -
+	@echo "  Applied $(NAME)-config"
+	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
+		SKILL_FILES=""; \
+		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
+			skill_name=$$(basename "$$skill_dir"); \
+			[ -f "$$skill_dir/SKILL.md" ] && \
+				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name/SKILL.md=$$skill_dir/SKILL.md"; \
+		done; \
+		$(KUBECTL) create configmap $(NAME)-skills \
+			$$SKILL_FILES \
+			$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
+			--dry-run=client -o yaml | $(KUBECTL) apply -f -; \
+		echo "  Applied $(NAME)-skills"; \
+	else \
+		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+	fi
+	@echo "Done."
+```
+
+- [ ] **Step 2: Test `configmap-apply` with dry-run**
+
+If you don't have a cluster available, verify the command generation
+works by checking the `configmap-gen` output (which uses the same
+logic). If a cluster is available:
+
+```bash
+make configmap-apply CONFIG_DIR=testdata/standalone NAMESPACE=docsclaw
+```
+
+Expected:
+
+```
+Applying ConfigMaps from testdata/standalone...
+  Applied standalone-config
+  Applied standalone-skills
+Done.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -s -m "feat: add configmap-apply Makefile target (#6)"
+```
+
+---
+
+### Task 3: Add `deploy/generated/` to `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add the gitignore entry**
+
+Add to the end of `.gitignore`:
+
+```gitignore
+
+# Generated ConfigMap YAML files
+deploy/generated/
+```
+
+- [ ] **Step 2: Clean up any generated files from testing**
+
+```bash
+rm -rf deploy/generated/
+```
+
+- [ ] **Step 3: Verify gitignore works**
+
+```bash
+make configmap-gen CONFIG_DIR=testdata/standalone
+git status
+```
+
+Expected: `deploy/generated/` should NOT appear in `git status` output.
+Only `.gitignore` should show as modified.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore
+git commit -s -m "chore: gitignore generated ConfigMap YAML files (#6)"
+```


### PR DESCRIPTION
## Summary

- Add `make configmap-gen` target to generate Kubernetes ConfigMap YAML files from an agent config directory
- Add `make configmap-apply` target to generate and apply ConfigMaps directly to a cluster (idempotent via `create --dry-run=client | apply`)
- Add `deploy/generated/` to `.gitignore`

Two ConfigMaps are generated per agent config directory:
- `<name>-config` — agent config files (system-prompt.txt, agent-card.json, agent-config.yaml, prompts.json)
- `<name>-skills` — all SKILL.md files (only if skills/ directory exists)

Usage:
```bash
make configmap-gen CONFIG_DIR=testdata/standalone
make configmap-gen CONFIG_DIR=testdata/standalone NAME=my-agent
make configmap-apply CONFIG_DIR=testdata/standalone NAMESPACE=docsclaw
make configmap-apply CONFIG_DIR=testdata/standalone KUBECTL=kubectl
```

Closes #6

## Test plan

- [x] `make configmap-gen CONFIG_DIR=testdata/standalone` generates config.yaml and skills.yaml
- [x] `make configmap-gen CONFIG_DIR=testdata/standalone NAME=my-agent` uses custom ConfigMap name prefix
- [x] `make configmap-gen CONFIG_DIR=testdata/summarizer-hr` skips skills ConfigMap (no skills/ dir)
- [x] `make configmap-gen CONFIG_DIR=testdata/nonexistent` fails with clear error
- [x] `make configmap-apply CONFIG_DIR=testdata/standalone` dry-run parses correctly
- [x] Generated files are excluded by .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `configmap-gen` and `configmap-apply` Make targets to generate and deploy Kubernetes ConfigMaps from agent configuration directories.
  * Planned support for `docsclaw chat` CLI subcommand for interactive terminal-based chat with agents.

* **Chores**
  * Updated `.gitignore` to exclude generated ConfigMap files.
  * Added implementation and design documentation for upcoming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->