### PR TITLE
feat(chat): add client-side conversation memory (#11)

### DIFF
--- a/deploy/agent-with-skills.yaml
+++ b/deploy/agent-with-skills.yaml
@@ -247,6 +247,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: docsclaw-skills
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
   labels:
     app: docsclaw-skills
 spec:

--- a/deploy/standalone-agent.yaml
+++ b/deploy/standalone-agent.yaml
@@ -164,6 +164,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: docsclaw
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
   labels:
     app: docsclaw
 spec:

--- a/docs/dev/2026-04-10-chat-client-memory-design.md
+++ b/docs/dev/2026-04-10-chat-client-memory-design.md
@@ -1,0 +1,66 @@
+# Client-side conversation memory for CLI chat
+
+**Issue:** #11
+**Date:** 2026-04-10
+**Status:** Approved
+
+## Goal
+
+Give the chat client conversational context so follow-up questions
+work as users expect. The agent should see prior turns when
+processing each new message.
+
+## Approach
+
+Client-side history injection. Before sending each message, the chat
+client formats the full conversation history into the message text.
+The bridge and A2A protocol layer remain untouched.
+
+This is a stopgap until server-side memory (#5) is implemented. It
+will be removed or made optional once the server tracks context
+natively. The bridge is also slated for an a2a-go v2 upgrade (#14),
+so no bridge changes should be made now.
+
+## Message format
+
+First message (no history) is sent as-is. Subsequent messages
+prepend conversation history:
+
+```text
+[Conversation history]
+User: What tools do you have?
+Agent: I can summarize documents and fetch web pages.
+
+[Current message]
+User: Summarize DOC-42
+```
+
+- Each turn rendered as `User: <text>` / `Agent: <text>`
+- Blank line between turns for readability
+- `[Conversation history]` and `[Current message]` delimiters
+  make the structure explicit for the LLM
+- Error messages from failed requests are excluded from history
+
+## Token management
+
+Send the full history every time. The conversation is bounded by
+the chat session (no persistence across restarts), so payloads
+stay manageable in practice. A sliding window or token budget can
+be added later if needed.
+
+## Scope
+
+| What | Changes? |
+|------|----------|
+| `internal/chat/model.go` (`sendMessage`) | Yes — build context string from `m.messages` |
+| `internal/bridge/` | No |
+| `InvokeRequest` | No |
+| `updateViewport()` | No |
+| Display / UI | No |
+
+## Not in scope
+
+- Server-side memory / context threading (#5)
+- Persistent conversation history across sessions
+- Token budget / sliding window
+- Bridge or A2A protocol changes (#14)

--- a/internal/chat/model.go
+++ b/internal/chat/model.go
@@ -259,18 +259,54 @@ func (m *Model) updateViewport() {
 }
 
 // sendMessage dispatches a message to the agent in a goroutine.
+// It prepends conversation history so the agent has context for
+// follow-up questions.
 func (m *Model) sendMessage(text string) tea.Cmd {
 	client := m.client
 	agentURL := m.agentURL
+	messageText := m.buildMessageWithHistory(text)
 
 	return func() tea.Msg {
 		result, err := client.Invoke(context.Background(), &bridge.InvokeRequest{
 			AgentURL:    agentURL,
-			MessageText: text,
+			MessageText: messageText,
 		})
 		if err != nil {
 			return errMsg{err: err}
 		}
 		return responseMsg{text: result.Text}
 	}
+}
+
+// buildMessageWithHistory formats conversation history into the message
+// text so the agent sees prior turns. On the first message, returns the
+// raw text with no formatting.
+func (m *Model) buildMessageWithHistory(text string) string {
+	// Collect prior turns, excluding error messages and the current
+	// user message (which is already appended to m.messages).
+	var history []ChatMessage
+	for _, msg := range m.messages[:len(m.messages)-1] {
+		if msg.Role == "agent" && strings.HasPrefix(msg.Text, "Error:") {
+			continue
+		}
+		history = append(history, msg)
+	}
+
+	if len(history) == 0 {
+		return text
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[Conversation history]\n")
+	for _, msg := range history {
+		label := m.userName
+		if msg.Role == "agent" {
+			label = m.agentName
+		}
+		sb.WriteString(label + ": " + msg.Text + "\n\n")
+	}
+	sb.WriteString("[Current message]\n")
+	sb.WriteString(m.userName + ": " + text)
+
+	return sb.String()
 }


### PR DESCRIPTION
## Summary

- Prepend conversation history to each message so the agent sees prior turns and follow-up questions work naturally
- Exclude error messages from history to keep context clean
- First message sent as-is with no formatting overhead
- Bump OpenShift Route timeout from 30s default to 120s in both deploy manifests to prevent 504s on long-running agent requests

## Test plan

- [x] Simple chat works as before
- [x] Follow-up questions retain context (agent remembers names, prior topics)
- [x] Error messages are excluded from history
- [x] First message has no `[Conversation history]` prefix
- [ ] Reapply Route and verify long-running requests (e.g., blog summarization) no longer 504

Closes #11 partially (client-side memory only; server-side memory tracked in #5)

@coderabbitai ignore