### PR TITLE
docs: add skills architecture reference and OpenCode resource comparison

### DIFF
--- a/docs/dev/2026-04-11-opencode-resource-comparison.md
+++ b/docs/dev/2026-04-11-opencode-resource-comparison.md
@@ -1,0 +1,59 @@
+# OpenCode vs DocsClaw Resource Comparison
+
+## Context
+
+Evaluated whether deploying an existing open-source agent (OpenCode)
+on OpenShift is a viable alternative to building DocsClaw. OpenCode
+is a TypeScript-based coding agent running on the Bun runtime.
+
+**Cluster:** OpenShift (namespace `panni-opencode`)
+**Date:** 2026-04-11
+
+## Deployment observations
+
+OpenCode required workarounds for OpenShift's non-root security model:
+
+- Container writes to `/.local`, `/.cache`, `/.config` at startup,
+  causing `EACCES` errors under non-root. Fixed with `emptyDir`
+  volume mounts.
+- OOMKilled at 512Mi memory limit; required raising to 2Gi.
+
+## Resource comparison (idle/steady-state)
+
+| Agent | Runtime | Memory (each) | Memory limit |
+|-------|---------|---------------|--------------|
+| OpenCode | Bun/Node (TypeScript) | 487Mi | 2Gi |
+| docsclaw | Go | 9Mi | 256Mi |
+| docsclaw-skills | Go | 12Mi | 256Mi |
+
+Both agents show negligible CPU at idle (1m each) since LLM inference
+happens server-side.
+
+## Key takeaway
+
+OpenCode uses **~23x more memory** than both DocsClaw instances
+combined (487Mi vs 21Mi). For deploying multiple specialized agents
+for business users on OpenShift, the Go-based approach is significantly
+more efficient. A cluster running 50 specialized DocsClaw agents would
+use roughly 500Mi total — about the same as a single OpenCode instance.
+
+## Implications for DocsClaw
+
+| Factor | OpenCode | DocsClaw |
+|--------|----------|----------|
+| Memory per agent | ~500Mi | ~10Mi |
+| Multi-agent deployment | Expensive | Practical |
+| Target audience | Developers | Business users (configurable) |
+| Specialization model | Single general agent | Many lightweight specialized agents |
+| OpenShift compatibility | Requires workarounds | Runs natively as non-root |
+
+The resource efficiency of Go makes it feasible to run a fleet of
+specialized agents (finance, legal, HR, etc.) on the same cluster
+where a single OpenCode instance would consume equivalent resources.
+This directly supports the skills-based architecture: one lightweight
+runtime, many domain-specific configurations.
+
+## Source
+
+Full evaluation report: external experiment at
+`~/work/experiments/opencode/REPORT.md`

--- a/docs/dev/2026-04-11-skills-architecture-reference.md
+++ b/docs/dev/2026-04-11-skills-architecture-reference.md
@@ -1,0 +1,109 @@
+# Skills Architecture Reference
+
+## Source
+
+**Talk:** "Don't Build Agents, Build Skills Instead"
+**Speakers:** Barry Zhang & Mahesh Murag, Anthropic
+**Event:** AI Engineer conference (2025)
+**Video:** https://www.youtube.com/watch?v=CEvIs9y1uog
+
+## Core thesis
+
+A single general-purpose agent with code execution (bash + file system)
+is sufficient for any domain. Domain specialization comes from
+**skills** (organized folders of procedural knowledge), not from
+building separate agents. MCP provides connectivity to external
+systems; skills provide the expertise for using those connections
+effectively.
+
+## Emerging general agent architecture
+
+| Layer | Role | DocsClaw equivalent |
+|-------|------|---------------------|
+| Agent loop | Manages context, token flow | `pkg/tools/` agentic loop |
+| Runtime environment | File system, code execution | `internal/exec/`, `internal/readfile/`, `internal/writefile/` |
+| MCP servers | External tools and data | A2A bridge (`internal/bridge/`), tool registry |
+| Skills library | On-demand procedural knowledge | `pkg/skills/`, ConfigMap-driven config |
+
+## Computing analogy (from the talk)
+
+| Computing | AI equivalent |
+|-----------|---------------|
+| CPU | LLM model |
+| Operating system | Agent runtime |
+| Applications | Skills |
+
+DocsClaw positions itself as the **OS layer**: a universal runtime that
+orchestrates models, tools, and skills.
+
+## What DocsClaw already implements
+
+- **Progressive disclosure**: `Discover()` reads only frontmatter
+  metadata; `BuildSummary()` shows a compact list; `LoadContent()`
+  loads full content on demand via `load_skill` tool
+- **Skills as folders**: each skill is a subdirectory with `SKILL.md`
+  containing YAML frontmatter (`name`, `description`) and markdown
+  instructions
+- **Universal agent**: single binary configured via `system-prompt.txt`,
+  `agent-card.json`, `agent-config.yaml`, and a skills directory
+- **ConfigMap packaging**: `configmap-gen` generates Kubernetes
+  ConfigMaps for both agent config and skills
+
+## Enhancement opportunities from the talk
+
+### 1. Scripts as tools within skills
+
+The talk describes skills that include executable scripts (Python,
+bash) as reusable tools. Currently DocsClaw skills are markdown-only.
+Adding support for scripts inside skill directories would let skills
+package their own tooling.
+
+**Relevant code:** `pkg/skills/loader.go` — `LoadContent()` could
+discover and register scripts in the skill directory.
+
+### 2. Skill dependencies
+
+Skills that explicitly declare dependencies on other skills or MCP
+servers. This makes agent behavior more predictable across different
+runtime environments.
+
+**Possible approach:** extend `SKILL.md` frontmatter with `depends:`
+field listing required skills or tools.
+
+### 3. Skill testing and evaluation
+
+Treat skills like software: automated testing that a skill triggers
+correctly and produces expected output quality.
+
+**Possible approach:** `SKILL_TEST.md` or test fixtures within skill
+directories, run via `make test-skills`.
+
+### 4. Skill versioning
+
+Track how a skill evolves over time and how that affects agent
+behavior. Git already provides versioning for the skill files;
+the gap is surfacing version info at runtime.
+
+**Possible approach:** add `version:` to frontmatter, expose in
+`BuildSummary()`.
+
+### 5. Agent-created skills
+
+The talk emphasizes that agents should create skills for themselves
+during use, making learning transferable across sessions. This is
+described as "concrete steps towards continuous learning."
+
+**Possible approach:** a `save_skill` tool that packages a successful
+multi-step workflow into a new skill directory.
+
+## Key quotes
+
+> "We used to think agents in different domains will look very
+> different. [...] The agent underneath is actually more universal
+> than we thought."
+
+> "MCP is providing the connection to the outside world while skills
+> are providing the expertise."
+
+> "Our goal is that Claude on day 30 of working with you is going to
+> be a lot better than Claude on day one."


### PR DESCRIPTION
## Summary

- Add skills architecture reference doc capturing key insights from Barry Zhang & Mahesh Murag's Anthropic talk on building effective agents with tool-use patterns
- Add OpenCode vs DocsClaw resource comparison showing DocsClaw's 9Mi memory footprint vs OpenCode's 487Mi on OpenShift

## Context

These docs support the OCI-based skill distribution work planned in #4 by documenting the architectural rationale for the skills approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added resource comparison documentation for agent deployments on OpenShift, including memory consumption analysis and performance metrics across different implementations
  * Added skills architecture reference guide documenting system design patterns, capabilities, and enhancement opportunities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->