### PR TITLE
docs: deploy slide decks to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,36 @@
+name: Deploy slides to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/slides/**'
+      - '.github/workflows/pages.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/slides
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/slides/index.html
+++ b/docs/slides/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DocsClaw Presentations</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    max-width: 640px;
+    margin: 4rem auto;
+    padding: 0 1rem;
+    color: #1a1a1a;
+    line-height: 1.6;
+  }
+  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+  p.subtitle { color: #666; margin-top: 0; }
+  ul { list-style: none; padding: 0; }
+  li { margin: 1rem 0; }
+  a {
+    display: block;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    text-decoration: none;
+    color: #1a1a1a;
+    transition: border-color 0.2s;
+  }
+  a:hover { border-color: #e00; }
+  .title { font-weight: 600; }
+  .desc { color: #666; font-size: 0.9rem; margin-top: 0.25rem; }
+</style>
+</head>
+<body>
+<h1>DocsClaw Presentations</h1>
+<p class="subtitle">Slide decks for the DocsClaw project</p>
+<ul>
+  <li>
+    <a href="docsclaw-intro.html">
+      <div class="title">DocsClaw Introduction</div>
+      <div class="desc">Overview of the ConfigMap-driven agent runtime</div>
+    </a>
+  </li>
+  <li>
+    <a href="oci-skill-distribution-deck.html">
+      <div class="title">OCI Skill Distribution</div>
+      <div class="desc">Packaging, signing, and distributing skills as OCI artifacts</div>
+    </a>
+  </li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to deploy `docs/slides/` to GitHub Pages
- Add index page linking to all presentations
- Only triggers on changes to slides or the workflow itself

## URL

https://redhat-et.github.io/docsclaw/

Direct links after merge:
- [DocsClaw Introduction](https://redhat-et.github.io/docsclaw/docsclaw-intro.html)
- [OCI Skill Distribution](https://redhat-et.github.io/docsclaw/oci-skill-distribution-deck.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Introduced presentations index page featuring links to available slide decks, including DocsClaw Intro and OCI Skill Distribution Deck.

* **Chores**
  * Configured automated deployment of documentation slides to GitHub Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->