### PR TITLE
docs: demo scenarios for skill-equipped agents

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,285 @@
+# DocsClaw + SkillImage demo
+
+End-to-end demo of specialized agents powered by DocsClaw with
+skills delivered as OCI images from the
+[skillimage](https://github.com/redhat-et/skillimage) registry.
+
+## What this shows
+
+Two agents, same runtime, different personalities and skills —
+deployed side-by-side in a single namespace:
+
+| Agent | Skill image | Role | User stories |
+| ----- | ----------- | ---- | ------------ |
+| Executive Assistant | `quay.io/skillimage/document-summarizer:1.0.0-testing` | Summarizes reports, meeting notes, budgets for leadership | Campaign narrative, Budget variance, Capacity planning |
+| HR Analyst | `quay.io/skillimage/document-reviewer:1.0.0-draft` | Reviews resumes, policies, onboarding checklists | Resume screening, Policy comparison, Onboarding audit |
+
+Skills are mounted as OCI image volumes directly into
+`/config/agent/skills/` — no init containers, no ConfigMap
+duplication. The agent discovers them at startup.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  OpenShift namespace: panni-docsclaw                    │
+│                                                         │
+│  ┌──────────────────────┐  ┌──────────────────────────┐ │
+│  │  executive-assistant  │  │  hr-analyst              │ │
+│  │                       │  │                          │ │
+│  │  ConfigMap:           │  │  ConfigMap:              │ │
+│  │   system-prompt.txt   │  │   system-prompt.txt      │ │
+│  │   agent-card.json     │  │   agent-card.json        │ │
+│  │   agent-config.yaml   │  │   agent-config.yaml      │ │
+│  │                       │  │                          │ │
+│  │  Image volume:        │  │  Image volume:           │ │
+│  │   document-summarizer │  │   document-reviewer      │ │
+│  │   → /config/agent/    │  │   → /config/agent/       │ │
+│  │     skills/document-  │  │     skills/document-     │ │
+│  │     summarizer/       │  │     reviewer/            │ │
+│  └──────────┬────────────┘  └────────────┬─────────────┘ │
+│             │                            │               │
+│        Route/Service              Route/Service          │
+│             │                            │               │
+└─────────────┼────────────────────────────┼───────────────┘
+              │                            │
+         a2a CLI / curl                a2a CLI / curl
+```
+
+## Prerequisites
+
+- OpenShift 4.20+ (for image volume support)
+- `oc` CLI logged in to the cluster
+- Cluster-admin access (one-time SCC setup)
+- An Anthropic API key
+- `a2a` CLI (from [a2a-go](https://github.com/a2a-go/a2a-go))
+
+## Deploy
+
+### One-time setup: SCC for image volumes
+
+OpenShift's default `restricted` SCC does not allow the `image`
+volume type. Create a custom SCC that extends `restricted-v2`
+with image volume support. This step requires cluster-admin:
+
+```bash
+oc apply -f image-volume-scc.yaml
+```
+
+This creates:
+
+| Resource | Name | Scope |
+| -------- | ---- | ----- |
+| SecurityContextConstraints | `restricted-with-image-volumes` | Cluster |
+| ServiceAccount | `docsclaw-agent` | Namespace |
+| ClusterRole | `use-image-volume-scc` | Cluster |
+| RoleBinding | `docsclaw-image-volume-scc` | Namespace |
+
+### Deploy the agents
+
+```bash
+# 1. Switch to the demo namespace
+oc project panni-docsclaw
+
+# 2. Create the LLM API key secret
+oc create secret generic llm-secret \
+  --from-literal=LLM_API_KEY=sk-ant-...
+
+# 3. Deploy both agents
+oc apply -f executive-assistant.yaml
+oc apply -f hr-analyst.yaml
+
+# 4. Wait for rollout
+oc rollout status deployment/executive-assistant
+oc rollout status deployment/hr-analyst
+
+# 5. Get the routes
+oc get routes
+```
+
+## Demo scenario 1: Executive briefing
+
+The executive assistant summarizes a quarterly report for a VP
+meeting — demonstrating the "Campaign performance narrative" and
+"Budget variance explanation" user stories.
+
+```bash
+EXEC_ROUTE=$(oc get route executive-assistant \
+  -o jsonpath='{.spec.host}')
+
+# Summarize a quarterly cloud spend report
+a2a send --timeout 120s "https://$EXEC_ROUTE" \
+  "Summarize this for the VP infrastructure review:
+
+   Q1 Cloud Spend Report — Total: \$2.4M (up 18% from Q4)
+
+   Three projects drove the increase:
+   - Project Atlas: \$400K (database migration to Aurora, completing
+     in Q2 — costs will drop to \$50K/quarter steady state)
+   - Project Beacon: \$200K (new GPU instances for ML pipeline,
+     expected to generate \$1.2M in efficiency gains by Q3)
+   - DR failover event (Feb 14): \$150K unplanned, triggered by
+     us-east-1 degradation. Post-mortem identified missing
+     auto-scaling rules.
+
+   Remaining \$1.65M is baseline (compute, storage, networking),
+   in line with Q4. Q2 forecast: \$2.1M as Atlas completes.
+   Action needed: approve Beacon GPU reservation for 1-year RI
+   (saves 35%, \$70K/quarter)."
+```
+
+Expected output: a structured summary with key decisions, risks,
+and action items — not a wall of text.
+
+## Demo scenario 2: Resume screening
+
+The HR analyst reviews a resume against job requirements —
+demonstrating the "Resume screening and candidate ranking" user
+story.
+
+```bash
+HR_ROUTE=$(oc get route hr-analyst \
+  -o jsonpath='{.spec.host}')
+
+# Review a candidate resume against job requirements
+a2a send --timeout 120s "https://$HR_ROUTE" \
+  "Review this resume for a Senior Product Manager role.
+
+   Job requirements:
+   - 5+ years product management experience
+   - B2B SaaS background
+   - Data-driven decision making with metrics
+   - Cross-functional leadership (engineering, design, sales)
+   - Experience with API or platform products (preferred)
+
+   Resume — Jane Chen:
+   Experience:
+   - Datadog, Group Product Manager (2022-present): Leads API
+     platform team of 12 engineers. Shipped usage-based billing
+     that grew ARR 40%. Defined 3-year platform roadmap.
+   - Datadog, Senior Product Manager (2020-2022): Owned developer
+     integrations. Launched 15 new integrations, drove 25% increase
+     in weekly active users.
+   - Stripe, Associate Product Manager (2018-2020): Payments API
+     team. Led developer documentation redesign that reduced
+     support tickets 30%.
+   Education: MS Computer Science, Stanford (2018)
+
+   Gaps to evaluate:
+   - No mention of user research or customer discovery methods
+   - No B2B enterprise sales cycle experience listed
+   - Short tenure at Stripe (2 years)"
+```
+
+Expected output: structured review with severity levels
+(Critical/Important/Suggestion), fit score, and specific
+feedback on each gap.
+
+## Demo scenario 3: Policy review
+
+The HR analyst reviews an updated policy for completeness —
+demonstrating the "Policy document comparison" user story.
+
+```bash
+a2a send --timeout 120s "https://$HR_ROUTE" \
+  "Review this updated remote work policy draft for completeness
+   and consistency:
+
+   REMOTE WORK POLICY v2.0 (Draft)
+
+   1. Eligibility: All full-time employees after 90-day
+      probationary period. Contractors are excluded.
+
+   2. Schedule: Employees may work remotely up to 3 days per
+      week. Core hours are 10am-3pm local time for meetings.
+
+   3. Equipment: Company provides laptop and monitor. Employees
+      are responsible for internet (minimum 50 Mbps). See the
+      equipment policy for reimbursement details.
+
+   4. Security: All work must be done on company-managed devices.
+      VPN required for accessing internal systems.
+
+   5. Performance: Managers will evaluate remote employees using
+      the same criteria as on-site employees.
+
+   6. Termination of remote work: The company reserves the right
+      to require on-site presence with 2 weeks notice.
+
+   Questions to address in your review:
+   - Does this cover international remote work?
+   - Is the equipment reimbursement section sufficient?
+   - Are there any compliance gaps for US labor law?"
+```
+
+## Verifying skill discovery
+
+After deployment, confirm the agent discovered the mounted skill:
+
+```bash
+# Check the pod logs for skill discovery
+oc logs deployment/executive-assistant | grep -i skill
+
+# Expected output:
+#   level=INFO msg="discovered skill" name=document-summarizer ...
+
+# Inspect what's mounted in the skills directory
+oc exec deployment/executive-assistant -- ls /config/agent/skills/
+oc exec deployment/executive-assistant -- \
+  ls /config/agent/skills/document-summarizer/
+```
+
+## Cleanup
+
+```bash
+oc delete -f executive-assistant.yaml
+oc delete -f hr-analyst.yaml
+oc delete secret llm-secret
+
+# Remove SCC resources (cluster-admin)
+oc delete -f image-volume-scc.yaml
+```
+
+## How skills inform agent config
+
+Each skill image contains a `skill.yaml` (SkillCard) that declares
+the tools it needs and resource hints. You can inspect a skill
+before deploying to ensure your `agent-config.yaml` allows the
+right tools:
+
+```bash
+skillctl inspect quay.io/skillimage/document-summarizer:1.0.0-testing
+```
+
+The SkillCard `tools` field (e.g. `[read_file]`) should be a
+subset of the tools listed in `agent-config.yaml`. The `resources`
+field provides CPU/memory hints for pod sizing.
+
+See [skillimage.dev](https://skillimage.dev) for the full
+SkillCard schema and CLI reference. The site provides
+`/llms.txt` and `/llms-full.txt` for agent-friendly access.
+
+## Fallback: init container pull
+
+If running on OpenShift < 4.20 (no image volume support), replace
+the image volume with an init container that uses
+[skillctl](https://github.com/redhat-et/skillimage) to pull the
+skill at startup:
+
+```yaml
+initContainers:
+  - name: skill-puller
+    image: ghcr.io/redhat-et/skillctl:latest
+    command:
+      - skillctl
+      - pull
+      - --verify
+      - -o
+      - /config/agent/skills
+      - quay.io/skillimage/document-summarizer:1.0.0-testing
+    volumeMounts:
+      - name: skills-vol
+        mountPath: /config/agent/skills
+```
+
+See `deploy/agent-with-skills.yaml` for the ConfigMap approach.

--- a/docs/demo/executive-assistant.yaml
+++ b/docs/demo/executive-assistant.yaml
@@ -1,0 +1,209 @@
+# Executive Assistant Agent — document summarizer skill
+#
+# Demonstrates an agent that summarizes documents for busy
+# executives: meeting notes, budget reports, capacity analyses,
+# and campaign performance data.
+#
+# Maps to user stories:
+#   - Campaign performance narrative (Marketing)
+#   - Budget variance explanation (Finance)
+#   - Capacity planning report (IT Ops)
+#
+# Skill image: quay.io/skillimage/document-summarizer:1.0.0-testing
+#
+# Prerequisites:
+#   oc project panni-docsclaw
+#   oc apply -f image-volume-scc.yaml   (one-time, needs cluster-admin)
+#   oc apply -f llm-secret.yaml
+#
+# Deploy:
+#   oc apply -f executive-assistant.yaml
+#
+# Test:
+#   ROUTE=$(oc get route executive-assistant -o jsonpath='{.spec.host}')
+#
+#   a2a send --timeout 120s https://$ROUTE \
+#     "Summarize this quarterly report for the VP meeting: Our Q1
+#      cloud spend was $2.4M, up 18% from Q4. Three projects drove
+#      the increase: Project Atlas ($400K migration costs), Project
+#      Beacon ($200K new GPU instances), and an unplanned DR failover
+#      ($150K). We expect Q2 to normalize to $2.1M as Atlas completes."
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: executive-assistant-config
+  namespace: panni-docsclaw
+  labels:
+    app: executive-assistant
+data:
+  system-prompt.txt: |
+    You are an executive assistant AI deployed by the CTO office.
+
+    Your job is to help busy leaders process information quickly.
+    When given documents, reports, or meeting notes, produce
+    structured summaries that surface decisions, risks, and
+    action items.
+
+    Adapt your output to the audience:
+    - For VP-level: focus on business impact and decisions needed
+    - For team leads: include technical context and timelines
+    - For standup updates: keep it under 5 bullet points
+
+    When a task matches a known skill, load it first for guidance.
+    Be concise. Executives do not read walls of text.
+  agent-card.json: |
+    {
+      "name": "executive-assistant",
+      "description": "Summarizes documents and reports for executive review",
+      "version": "1.0.0",
+      "protocolVersion": "0.3.0",
+      "url": "http://executive-assistant:8000",
+      "skills": [
+        {
+          "id": "document-summarizer",
+          "name": "Document Summarizer",
+          "description": "Produces structured summaries of technical documents, reports, and meeting notes",
+          "tags": ["summarization", "documents", "productivity"],
+          "examples": [
+            "Summarize this quarterly report for the VP meeting",
+            "Give me a standup update from these meeting notes",
+            "Extract action items from the architecture review doc"
+          ]
+        }
+      ],
+      "capabilities": {},
+      "defaultInputModes": ["application/json"],
+      "defaultOutputModes": ["text/plain"]
+    }
+  agent-config.yaml: |
+    tools:
+      allowed:
+        - read_file
+        - write_file
+        - web_fetch
+      workspace: /tmp/agent-workspace
+    loop:
+      max_iterations: 5
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: executive-assistant
+  namespace: panni-docsclaw
+  labels:
+    app: executive-assistant
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: executive-assistant
+  template:
+    metadata:
+      labels:
+        app: executive-assistant
+    spec:
+      serviceAccountName: docsclaw-agent
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: docsclaw
+          image: ghcr.io/redhat-et/docsclaw:602ac9a
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - serve
+            - --config-dir
+            - /config/agent
+            - --listen-plain-http
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8100
+              name: health
+          envFrom:
+            - secretRef:
+                name: llm-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            - name: skill-document-summarizer
+              mountPath: /config/agent/skills/document-summarizer
+              readOnly: true
+            - name: workspace
+              mountPath: /tmp/agent-workspace
+      volumes:
+        - name: agent-config
+          configMap:
+            name: executive-assistant-config
+        - name: skill-document-summarizer
+          image:
+            reference: quay.io/skillimage/business/document-summarizer:1.0.0-testing
+            pullPolicy: IfNotPresent
+        - name: workspace
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: executive-assistant
+  namespace: panni-docsclaw
+  labels:
+    app: executive-assistant
+spec:
+  selector:
+    app: executive-assistant
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: executive-assistant
+  namespace: panni-docsclaw
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
+  labels:
+    app: executive-assistant
+spec:
+  to:
+    kind: Service
+    name: executive-assistant
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/docs/demo/hr-analyst.yaml
+++ b/docs/demo/hr-analyst.yaml
@@ -1,0 +1,216 @@
+# HR Analyst Agent — document reviewer skill
+#
+# Demonstrates an agent that reviews HR documents: resumes
+# against job descriptions, policy drafts, and onboarding
+# checklists for completeness and consistency.
+#
+# Maps to user stories:
+#   - Resume screening and candidate ranking (HR)
+#   - Policy document comparison (HR)
+#   - Employee onboarding checklist audit (HR)
+#
+# Skill image: quay.io/skillimage/document-reviewer:1.0.0-draft
+#
+# Prerequisites:
+#   oc project panni-docsclaw
+#   oc apply -f image-volume-scc.yaml   (one-time, needs cluster-admin)
+#   oc apply -f llm-secret.yaml
+#
+# Deploy:
+#   oc apply -f hr-analyst.yaml
+#
+# Test:
+#   ROUTE=$(oc get route hr-analyst -o jsonpath='{.spec.host}')
+#
+#   a2a send --timeout 120s https://$ROUTE \
+#     "Review this resume for a Senior Product Manager role.
+#      Requirements: 5+ years PM experience, B2B SaaS background,
+#      data-driven decision making, cross-functional leadership.
+#
+#      Resume: Jane Chen — 7 years at Datadog (Sr PM, then Group PM).
+#      Led API platform team (12 engineers). Shipped usage-based
+#      billing that grew ARR 40%. Before that: 2 years at Stripe
+#      (Associate PM, payments API). MS Computer Science, Stanford.
+#      Gaps: No mention of user research or customer discovery.
+#      No B2B enterprise sales cycle experience listed."
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hr-analyst-config
+  namespace: panni-docsclaw
+  labels:
+    app: hr-analyst
+data:
+  system-prompt.txt: |
+    You are an HR analyst AI supporting the talent acquisition
+    and HR operations teams.
+
+    Your job is to review HR documents with a critical eye:
+    - Resumes: evaluate against job requirements, flag strengths
+      and gaps, provide a fit score with justification
+    - Policies: check for completeness, consistency with labor
+      regulations, and clarity for employees
+    - Onboarding checklists: verify coverage of required steps,
+      consistency across departments
+
+    Always provide structured, actionable feedback. HR decisions
+    affect people's careers — be thorough but fair. Flag genuine
+    gaps without bias toward pedigree or background.
+
+    When a task matches a known skill, load it first for guidance.
+    Organize findings by severity: Critical, Important, Suggestion.
+  agent-card.json: |
+    {
+      "name": "hr-analyst",
+      "description": "Reviews HR documents — resumes, policies, and onboarding checklists",
+      "version": "1.0.0",
+      "protocolVersion": "0.3.0",
+      "url": "http://hr-analyst:8000",
+      "skills": [
+        {
+          "id": "document-reviewer",
+          "name": "Document Reviewer",
+          "description": "Reviews documents for clarity, completeness, and consistency with structured severity-based feedback",
+          "tags": ["review", "documents", "quality", "hr"],
+          "examples": [
+            "Review this resume against the job description",
+            "Check this policy draft for gaps and inconsistencies",
+            "Audit these onboarding checklists for completeness"
+          ]
+        }
+      ],
+      "capabilities": {},
+      "defaultInputModes": ["application/json"],
+      "defaultOutputModes": ["text/plain"]
+    }
+  agent-config.yaml: |
+    tools:
+      allowed:
+        - read_file
+        - write_file
+      workspace: /tmp/agent-workspace
+    loop:
+      max_iterations: 5
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hr-analyst
+  namespace: panni-docsclaw
+  labels:
+    app: hr-analyst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hr-analyst
+  template:
+    metadata:
+      labels:
+        app: hr-analyst
+    spec:
+      serviceAccountName: docsclaw-agent
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: docsclaw
+          image: ghcr.io/redhat-et/docsclaw:602ac9a
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - serve
+            - --config-dir
+            - /config/agent
+            - --listen-plain-http
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8100
+              name: health
+          envFrom:
+            - secretRef:
+                name: llm-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            - name: skill-document-reviewer
+              mountPath: /config/agent/skills/document-reviewer
+              readOnly: true
+            - name: workspace
+              mountPath: /tmp/agent-workspace
+      volumes:
+        - name: agent-config
+          configMap:
+            name: hr-analyst-config
+        - name: skill-document-reviewer
+          image:
+            reference: quay.io/skillimage/business/document-reviewer:1.0.0-draft
+            pullPolicy: IfNotPresent
+        - name: workspace
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hr-analyst
+  namespace: panni-docsclaw
+  labels:
+    app: hr-analyst
+spec:
+  selector:
+    app: hr-analyst
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hr-analyst
+  namespace: panni-docsclaw
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
+  labels:
+    app: hr-analyst
+spec:
+  to:
+    kind: Service
+    name: hr-analyst
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/docs/demo/image-volume-scc.yaml
+++ b/docs/demo/image-volume-scc.yaml
@@ -1,0 +1,90 @@
+# Security context constraint for image volumes.
+#
+# OpenShift's default "restricted" SCC does not allow the "image"
+# volume type. This SCC extends restricted-v2 with image volume
+# support so that skill images can be mounted directly into pods.
+#
+# Requires cluster-admin to create the SCC. The ServiceAccount
+# and RoleBinding are namespace-scoped.
+#
+# Apply:
+#   oc apply -f image-volume-scc.yaml
+
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: restricted-with-image-volumes
+  annotations:
+    kubernetes.io/description: >-
+      Like restricted-v2 but allows image volume mounts for
+      OCI-based skill delivery.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - image
+  - persistentVolumeClaim
+  - projected
+  - secret
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: docsclaw-agent
+  namespace: panni-docsclaw
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-image-volume-scc
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - restricted-with-image-volumes
+    verbs:
+      - use
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: docsclaw-image-volume-scc
+  namespace: panni-docsclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: use-image-volume-scc
+subjects:
+  - kind: ServiceAccount
+    name: docsclaw-agent
+    namespace: panni-docsclaw

--- a/docs/demo/llm-secret.yaml
+++ b/docs/demo/llm-secret.yaml
@@ -1,0 +1,16 @@
+# LLM API key secret — required by all demo agents.
+#
+# Create with:
+#   oc -n panni-docsclaw create secret generic llm-secret \
+#     --from-literal=LLM_API_KEY=sk-ant-...
+#
+# Or edit this file and apply:
+#   oc apply -f llm-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-secret
+  namespace: panni-docsclaw
+type: Opaque
+stringData:
+  LLM_API_KEY: "REPLACE_WITH_YOUR_API_KEY"


### PR DESCRIPTION
## Summary

- Two specialized agents (Executive Assistant, HR Analyst) deployed side-by-side on OpenShift with skills delivered as OCI image volumes from `quay.io/skillimage/`
- Custom SCC (`restricted-with-image-volumes`) for image volume support on OpenShift
- Three demo scenarios mapped to user stories: executive briefing, resume screening, policy review
- Tested end-to-end on OpenShift 4.20 in `panni-docsclaw` namespace using `a2a` CLI

## Test plan

- [x] Deploy executive-assistant with document-summarizer skill
- [x] Deploy hr-analyst with document-reviewer skill
- [x] Verify skill discovery in pod logs
- [x] Test scenario 1: executive briefing via `a2a send`
- [x] Test scenario 2: resume screening via `a2a send`
- [ ] Test scenario 3: policy review via `a2a send`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive end-to-end demo guide with step-by-step deployment instructions, runnable demo scenarios, and verification steps.
  * Added ready-to-deploy configurations for executive assistant and HR analyst demo agents with system prompts and skill integrations.
  * Added OpenShift security setup manifest for image volume support.
  * Added LLM API key secret configuration template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->