### PR TITLE
Add GoReleaser workflow for automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,87 @@
+version: 2
+
+project_name: docsclaw
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - main: ./cmd/docsclaw
+    binary: docsclaw
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/redhat-et/docsclaw/internal/cmd.version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: redhat-et
+    name: docsclaw
+
+brews:
+  - name: docsclaw
+    repository:
+      owner: pavelanni
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/redhat-et/docsclaw
+    description: Universal AI agent runtime with ConfigMap-driven personality
+    license: Apache-2.0
+    install: |
+      bin.install "docsclaw"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/redhat-et/docsclaw:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-amd64"
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/redhat-et/docsclaw:latest"
+    image_templates:
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-amd64"
+      - "ghcr.io/redhat-et/docsclaw:{{ .Version }}-arm64"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,31 @@ make build       # Build binary to bin/docsclaw
 make test        # Run all tests
 make lint        # Run golangci-lint
 make fmt         # Format code
+make image       # Build container image (local dev)
+make image-push  # Build and push to GHCR
 ```
+
+## Release
+
+Releases use [GoReleaser](https://goreleaser.com/) triggered by
+version tags (`v*`). Config in `.goreleaser.yaml`, workflow in
+`.github/workflows/release.yaml`.
+
+```bash
+git tag v0.1.0 && git push --tags
+```
+
+Produces binaries (linux/darwin/windows, amd64/arm64), multi-arch
+container images on `ghcr.io/redhat-et/docsclaw`, and a Homebrew
+formula. Version is injected via ldflags into
+`internal/cmd.version`.
+
+Two Dockerfiles:
+- `Dockerfile` — local dev builds (multi-stage with Go builder)
+- `Dockerfile.release` — GoReleaser builds (scratch, pre-built binary)
+
+Required repo secret: `HOMEBREW_TAP_TOKEN` (write access to
+`pavelanni/homebrew-tap`).
 
 ## Project structure
 
@@ -65,3 +89,4 @@ The agent reads personality from a config directory:
 - **A2A (a2a-go)** for agent protocol
 - **log/slog** for structured logging
 - **Prometheus** for metrics
+- **GoReleaser** for automated releases

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,14 @@
+FROM alpine:3.23 AS base
+RUN apk add --no-cache ca-certificates \
+ && mkdir -p /home/docsclaw/.local/share \
+ && chown -R 65534:0 /home/docsclaw \
+ && chmod -R g+rwX /home/docsclaw
+
+FROM scratch
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /home/docsclaw /home/docsclaw
+COPY --chmod=0755 docsclaw /usr/local/bin/docsclaw
+ENV HOME=/home/docsclaw
+USER 65534
+ENTRYPOINT ["docsclaw"]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Set via environment variables:
 make build          # Build binary to bin/docsclaw
 make test           # Run tests
 make lint           # Run golangci-lint
-make image          # Build container image
+make image          # Build container image (local dev)
 make image-push     # Build and push to GHCR
 ```
 
@@ -224,6 +224,22 @@ Override defaults:
 make image REGISTRY=my-registry.io/docsclaw DEV_TAG=v1.0
 make image CONTAINER_ENGINE=docker
 ```
+
+## Release
+
+Releases are automated via [GoReleaser](https://goreleaser.com/).
+Tag a commit and push to trigger the workflow:
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+This produces:
+- Binaries for linux/darwin/windows (amd64, arm64)
+- Multi-arch container images on `ghcr.io/redhat-et/docsclaw`
+- Homebrew formula (`brew install pavelanni/tap/docsclaw`)
+- SHA256 checksums
 
 ## License
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,12 +12,14 @@ import (
 var (
 	cfgFile string
 	v       *viper.Viper
+	version = "dev"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "docsclaw",
-	Short: "DocsClaw Agent Runtime",
-	Long:  "Universal AI agent runtime with ConfigMap-driven personality.",
+	Use:     "docsclaw",
+	Short:   "DocsClaw Agent Runtime",
+	Long:    "Universal AI agent runtime with ConfigMap-driven personality.",
+	Version: version,
 }
 
 func Execute() {


### PR DESCRIPTION
## Summary

- Add GoReleaser config with multi-platform builds, multi-arch
  container images, Homebrew formula, and changelog
- Add release workflow triggered on version tags (`v*`)
- Add `Dockerfile.release` (scratch-based, for GoReleaser)
- Add `--version` flag to docsclaw CLI

## Release artifacts

| Artifact | Details |
|----------|---------|
| Binaries | linux/darwin/windows, amd64/arm64 |
| Container | `ghcr.io/redhat-et/docsclaw:<version>` (multi-arch) |
| Homebrew | `brew install pavelanni/tap/docsclaw` |
| Checksums | SHA256 in `checksums.txt` |

## Files

| File | Purpose |
|------|---------|
| `.goreleaser.yaml` | GoReleaser config |
| `.github/workflows/release.yaml` | Release workflow |
| `Dockerfile.release` | Scratch image for releases |
| `internal/cmd/root.go` | Version variable + `--version` flag |
| `README.md` | Release section added |
| `CLAUDE.md` | Release docs added |

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] Version injection works: `docsclaw --version` shows injected version
- [x] `HOMEBREW_TAP_TOKEN` secret configured in repo
- [ ] Tag `v0.1.0` after merge to trigger first release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated multi-platform binary releases for Linux, macOS, and Windows (amd64/arm64 architectures).
  * Added container image publishing to a registry.
  * Added Homebrew installation support.

* **Documentation**
  * Updated build and release instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->