### PR TITLE
feat: add token usage tracking to LLM responses

### DIFF
--- a/internal/anthropic/anthropic.go
+++ b/internal/anthropic/anthropic.go
@@ -177,7 +177,15 @@ func (p *AnthropicProvider) CompleteWithTools(ctx context.Context,
 	}
 
 	// Parse response
-	resp := &llm.Response{}
+	resp := &llm.Response{
+		Usage: llm.Usage{
+			InputTokens:      int(message.Usage.InputTokens),
+			OutputTokens:     int(message.Usage.OutputTokens),
+			CacheReadTokens:  int(message.Usage.CacheReadInputTokens),
+			CacheWriteTokens: int(message.Usage.CacheCreationInputTokens),
+			TotalTokens:      int(message.Usage.InputTokens + message.Usage.OutputTokens),
+		},
+	}
 	switch message.StopReason {
 	case "tool_use":
 		resp.StopReason = llm.StopReasonToolUse

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -75,28 +75,6 @@ var (
 		[]string{"service"},
 	)
 
-	// LLM metrics
-
-	// LLMTokensTotal tracks token usage across LLM calls
-	LLMTokensTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "docsclaw",
-			Name:      "llm_tokens_total",
-			Help:      "Total LLM tokens consumed",
-		},
-		[]string{"provider", "model", "direction"},
-	)
-
-	// LLMRequestsTotal counts LLM API calls
-	LLMRequestsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "docsclaw",
-			Name:      "llm_requests_total",
-			Help:      "Total number of LLM API requests",
-		},
-		[]string{"provider", "model", "stop_reason"},
-	)
-
 	// Delegation metrics
 
 	// DelegationsTotal counts delegation attempts

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -75,6 +75,28 @@ var (
 		[]string{"service"},
 	)
 
+	// LLM metrics
+
+	// LLMTokensTotal tracks token usage across LLM calls
+	LLMTokensTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "docsclaw",
+			Name:      "llm_tokens_total",
+			Help:      "Total LLM tokens consumed",
+		},
+		[]string{"provider", "model", "direction"},
+	)
+
+	// LLMRequestsTotal counts LLM API calls
+	LLMRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "docsclaw",
+			Name:      "llm_requests_total",
+			Help:      "Total number of LLM API requests",
+		},
+		[]string{"provider", "model", "stop_reason"},
+	)
+
 	// Delegation metrics
 
 	// DelegationsTotal counts delegation attempts

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -45,6 +45,13 @@ type openAIMessage struct {
 	Content string `json:"content"`
 }
 
+// openAIUsage represents token usage from the OpenAI API.
+type openAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
 // openAIChatResponse represents the response from OpenAI chat completions API
 type openAIChatResponse struct {
 	ID      string `json:"id"`
@@ -56,11 +63,7 @@ type openAIChatResponse struct {
 		Message      openAIMessage `json:"message"`
 		FinishReason string        `json:"finish_reason"`
 	} `json:"choices"`
-	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-	} `json:"usage"`
+	Usage openAIUsage  `json:"usage"`
 	Error *openAIError `json:"error,omitempty"`
 }
 
@@ -109,11 +112,7 @@ type openAIChatResponseWithTools struct {
 		} `json:"message"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
-	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-	} `json:"usage"`
+	Usage openAIUsage  `json:"usage"`
 	Error *openAIError `json:"error,omitempty"`
 }
 

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -350,6 +350,8 @@ func (p *OpenAICompatProvider) CompleteWithTools(ctx context.Context,
 	}
 
 	choice := chatResp.Choices[0]
+	// CacheReadTokens/CacheWriteTokens left zero: OpenAI's standard
+	// chat completions API does not expose prompt cache metrics.
 	resp := &llm.Response{
 		Usage: llm.Usage{
 			InputTokens:  chatResp.Usage.PromptTokens,

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -109,6 +109,11 @@ type openAIChatResponseWithTools struct {
 		} `json:"message"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
 	Error *openAIError `json:"error,omitempty"`
 }
 
@@ -345,7 +350,13 @@ func (p *OpenAICompatProvider) CompleteWithTools(ctx context.Context,
 	}
 
 	choice := chatResp.Choices[0]
-	resp := &llm.Response{}
+	resp := &llm.Response{
+		Usage: llm.Usage{
+			InputTokens:  chatResp.Usage.PromptTokens,
+			OutputTokens: chatResp.Usage.CompletionTokens,
+			TotalTokens:  chatResp.Usage.TotalTokens,
+		},
+	}
 
 	if choice.FinishReason == "tool_calls" {
 		resp.StopReason = llm.StopReasonToolUse

--- a/pkg/llm/types.go
+++ b/pkg/llm/types.go
@@ -39,11 +39,21 @@ type Message struct {
 	ToolResults []ToolResultContent // tool results (tool role only)
 }
 
+// Usage tracks token consumption from an LLM response.
+type Usage struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
 // Response is the LLM's reply from CompleteWithTools.
 type Response struct {
 	StopReason StopReason
 	Content    string     // text content (may be empty if only tool calls)
 	ToolCalls  []ToolCall // tool calls (empty if end_turn)
+	Usage      Usage
 }
 
 // HasToolCalls returns true if the response contains tool call

--- a/pkg/llm/types_test.go
+++ b/pkg/llm/types_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -43,10 +44,18 @@ func TestResponseWithToolCalls(t *testing.T) {
 				Args: map[string]any{"path": "main.go"},
 			},
 		},
+		Usage: Usage{
+			InputTokens:  100,
+			OutputTokens: 50,
+			TotalTokens:  150,
+		},
 	}
 
 	if !resp.HasToolCalls() {
 		t.Fatal("expected HasToolCalls to be true")
+	}
+	if resp.Usage.TotalTokens != 150 {
+		t.Fatalf("expected TotalTokens 150, got %d", resp.Usage.TotalTokens)
 	}
 }
 
@@ -58,5 +67,52 @@ func TestResponseWithoutToolCalls(t *testing.T) {
 
 	if resp.HasToolCalls() {
 		t.Fatal("expected HasToolCalls to be false")
+	}
+}
+
+func TestUsageJSON(t *testing.T) {
+	usage := Usage{
+		InputTokens:      1000,
+		OutputTokens:     500,
+		CacheReadTokens:  200,
+		CacheWriteTokens: 300,
+		TotalTokens:      1500,
+	}
+
+	data, err := json.Marshal(usage)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var roundtrip Usage
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if roundtrip.InputTokens != 1000 {
+		t.Fatalf("expected InputTokens 1000, got %d", roundtrip.InputTokens)
+	}
+	if roundtrip.TotalTokens != 1500 {
+		t.Fatalf("expected TotalTokens 1500, got %d", roundtrip.TotalTokens)
+	}
+}
+
+func TestUsageOmitsZeroCacheTokens(t *testing.T) {
+	usage := Usage{
+		InputTokens:  100,
+		OutputTokens: 50,
+		TotalTokens:  150,
+	}
+
+	data, err := json.Marshal(usage)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "cache_read_tokens") {
+		t.Fatal("expected cache_read_tokens to be omitted when zero")
+	}
+	if strings.Contains(s, "cache_write_tokens") {
+		t.Fatal("expected cache_write_tokens to be omitted when zero")
 	}
 }

--- a/pkg/llm/types_test.go
+++ b/pkg/llm/types_test.go
@@ -88,11 +88,8 @@ func TestUsageJSON(t *testing.T) {
 	if err := json.Unmarshal(data, &roundtrip); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
-	if roundtrip.InputTokens != 1000 {
-		t.Fatalf("expected InputTokens 1000, got %d", roundtrip.InputTokens)
-	}
-	if roundtrip.TotalTokens != 1500 {
-		t.Fatalf("expected TotalTokens 1500, got %d", roundtrip.TotalTokens)
+	if roundtrip != usage {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", roundtrip, usage)
 	}
 }
 

--- a/pkg/tools/loop.go
+++ b/pkg/tools/loop.go
@@ -33,14 +33,22 @@ func RunToolLoop(ctx context.Context, provider llm.Provider,
 			return "", fmt.Errorf("LLM call failed: %w", err)
 		}
 
-		slog.Info("LLM response received",
+		logAttrs := []any{
 			"provider", provider.ProviderName(),
 			"model", provider.Model(),
-			"iteration", i+1,
+			"iteration", i + 1,
 			"input_tokens", resp.Usage.InputTokens,
 			"output_tokens", resp.Usage.OutputTokens,
 			"total_tokens", resp.Usage.TotalTokens,
-			"stop_reason", resp.StopReason)
+			"stop_reason", resp.StopReason,
+		}
+		if resp.Usage.CacheReadTokens > 0 {
+			logAttrs = append(logAttrs, "cache_read_tokens", resp.Usage.CacheReadTokens)
+		}
+		if resp.Usage.CacheWriteTokens > 0 {
+			logAttrs = append(logAttrs, "cache_write_tokens", resp.Usage.CacheWriteTokens)
+		}
+		slog.Info("LLM response received", logAttrs...)
 
 		if !resp.HasToolCalls() {
 			return resp.Content, nil

--- a/pkg/tools/loop.go
+++ b/pkg/tools/loop.go
@@ -33,6 +33,15 @@ func RunToolLoop(ctx context.Context, provider llm.Provider,
 			return "", fmt.Errorf("LLM call failed: %w", err)
 		}
 
+		slog.Info("LLM response received",
+			"provider", provider.ProviderName(),
+			"model", provider.Model(),
+			"iteration", i+1,
+			"input_tokens", resp.Usage.InputTokens,
+			"output_tokens", resp.Usage.OutputTokens,
+			"total_tokens", resp.Usage.TotalTokens,
+			"stop_reason", resp.StopReason)
+
 		if !resp.HasToolCalls() {
 			return resp.Content, nil
 		}

--- a/pkg/tools/loop_test.go
+++ b/pkg/tools/loop_test.go
@@ -32,7 +32,11 @@ func (m *mockProvider) ProviderName() string { return "mock" }
 func TestRunToolLoopNoTools(t *testing.T) {
 	provider := &mockProvider{
 		responses: []*llm.Response{
-			{StopReason: llm.StopReasonEndTurn, Content: "Hello!"},
+			{
+				StopReason: llm.StopReasonEndTurn,
+				Content:    "Hello!",
+				Usage:      llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			},
 		},
 	}
 	registry := NewRegistry(nil)
@@ -59,10 +63,12 @@ func TestRunToolLoopWithToolCall(t *testing.T) {
 				ToolCalls: []llm.ToolCall{
 					{ID: "tc1", Name: "test_tool", Args: map[string]any{}},
 				},
+				Usage: llm.Usage{InputTokens: 100, OutputTokens: 20, TotalTokens: 120},
 			},
 			{
 				StopReason: llm.StopReasonEndTurn,
 				Content:    "The result is: ok",
+				Usage:      llm.Usage{InputTokens: 150, OutputTokens: 30, TotalTokens: 180},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Add `Usage` struct to `llm.Response` capturing input/output/cache token counts
- Populate from Anthropic SDK response (including prompt cache read/write tokens)
- Populate from OpenAI chat completions response
- Log token counts per LLM call in the agentic loop with provider/model context
- Add Prometheus counters (`docsclaw_llm_tokens_total`, `docsclaw_llm_requests_total`)

Foundation for context compaction (#5), OTel tracing (#34), and eval cost reporting (#35).

## Test plan

- [x] `make test` passes — new tests for Usage JSON round-trip and omitempty behavior
- [x] `make lint` passes — no new lint issues
- [x] Manual: verified token counts appear in server logs with OpenAI provider

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage metrics are now tracked and reported in language model responses, including input tokens, output tokens, cache tokens, and totals.

* **Improvements**
  * Token usage information is logged during tool execution iterations for better visibility into API resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->