### PR TITLE
feat: add tool result truncation to prevent context overflow

### DIFF
--- a/internal/cmd/chat.go
+++ b/internal/cmd/chat.go
@@ -39,7 +39,7 @@ func runChat(cmd *cobra.Command, _ []string) error {
 	// Fetch agent card from well-known endpoint.
 	card, err := fetchAgentCard(agentURL)
 	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(),
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 			"Warning: could not fetch agent card: %v\n", err)
 	} else {
 		agentName = card.Name
@@ -77,7 +77,7 @@ func fetchAgentCard(agentURL string) (*a2a.AgentCard, error) {
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d from %s",

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -280,7 +280,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return nil, fmt.Errorf("document service request failed: %w", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		if resp.StatusCode == http.StatusForbidden {
 			return nil, fmt.Errorf("access denied")

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -110,14 +110,14 @@ func (h *ColorHandler) Handle(ctx context.Context, r slog.Record) error {
 	}
 
 	// Format: emoji [COMPONENT] message attrs...
-	fmt.Fprintf(h.out, "%s%s [%s]%s %s", color, levelEmoji, h.component, reset, r.Message)
+	_, _ = fmt.Fprintf(h.out, "%s%s [%s]%s %s", color, levelEmoji, h.component, reset, r.Message)
 
 	// Add any attributes
 	r.Attrs(func(a slog.Attr) bool {
-		fmt.Fprintf(h.out, " %s=%v", a.Key, a.Value)
+		_, _ = fmt.Fprintf(h.out, " %s=%v", a.Key, a.Value)
 		return true
 	})
-	fmt.Fprintln(h.out)
+	_, _ = fmt.Fprintln(h.out)
 
 	return nil
 }

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -195,7 +195,7 @@ func (p *OpenAICompatProvider) Complete(ctx context.Context, systemPrompt, userP
 	if err != nil {
 		return "", fmt.Errorf("API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -327,7 +327,7 @@ func (p *OpenAICompatProvider) CompleteWithTools(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("API request failed: %w", err)
 	}
-	defer httpResp.Body.Close()
+	defer func() { _ = httpResp.Body.Close() }()
 
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {

--- a/internal/webfetch/webfetch.go
+++ b/internal/webfetch/webfetch.go
@@ -91,7 +91,7 @@ func (t *webFetchTool) Execute(ctx context.Context, args map[string]any) *tools.
 	if err != nil {
 		return tools.Errorf("fetch failed: %s", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 100000))
 	if err != nil {

--- a/pkg/tools/loop.go
+++ b/pkg/tools/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/redhat-et/docsclaw/pkg/llm"
 )
@@ -13,7 +14,7 @@ const defaultMaxResultBytes = 32768 // 32KB
 // LoopConfig controls the agentic loop behavior.
 type LoopConfig struct {
 	MaxIterations  int
-	MaxResultBytes int // per-tool output limit; 0 uses default (32KB)
+	MaxResultBytes int // per-tool output limit; 0 disables truncation
 }
 
 // DefaultLoopConfig returns sensible defaults.
@@ -118,7 +119,9 @@ func truncateResult(s string, maxBytes int) string {
 	}
 	slog.Warn("tool output truncated",
 		"original_bytes", len(s), "max_bytes", maxBytes)
-	return s[:maxBytes] + fmt.Sprintf("\n\n[Truncated: showing first %d bytes of %d total]", maxBytes, len(s))
+	// Don't split a multi-byte UTF-8 character.
+	truncated := strings.ToValidUTF8(s[:maxBytes], "")
+	return truncated + fmt.Sprintf("\n\n[Truncated: showing first %d bytes of %d total]", maxBytes, len(s))
 }
 
 func truncateLog(s string) string {

--- a/pkg/tools/loop.go
+++ b/pkg/tools/loop.go
@@ -117,11 +117,11 @@ func truncateResult(s string, maxBytes int) string {
 	if maxBytes <= 0 || len(s) <= maxBytes {
 		return s
 	}
-	slog.Warn("tool output truncated",
-		"original_bytes", len(s), "max_bytes", maxBytes)
 	// Don't split a multi-byte UTF-8 character.
 	truncated := strings.ToValidUTF8(s[:maxBytes], "")
-	return truncated + fmt.Sprintf("\n\n[Truncated: showing first %d bytes of %d total]", maxBytes, len(s))
+	slog.Warn("tool output truncated",
+		"original_bytes", len(s), "retained_bytes", len(truncated))
+	return truncated + fmt.Sprintf("\n\n[Truncated: showing first %d bytes of %d total]", len(truncated), len(s))
 }
 
 func truncateLog(s string) string {

--- a/pkg/tools/loop.go
+++ b/pkg/tools/loop.go
@@ -8,15 +8,19 @@ import (
 	"github.com/redhat-et/docsclaw/pkg/llm"
 )
 
+const defaultMaxResultBytes = 32768 // 32KB
+
 // LoopConfig controls the agentic loop behavior.
 type LoopConfig struct {
-	MaxIterations int
+	MaxIterations  int
+	MaxResultBytes int // per-tool output limit; 0 uses default (32KB)
 }
 
 // DefaultLoopConfig returns sensible defaults.
 func DefaultLoopConfig() LoopConfig {
 	return LoopConfig{
-		MaxIterations: 10,
+		MaxIterations:  10,
+		MaxResultBytes: defaultMaxResultBytes,
 	}
 }
 
@@ -63,9 +67,10 @@ func RunToolLoop(ctx context.Context, provider llm.Provider,
 		var results []llm.ToolResultContent
 		for _, tc := range resp.ToolCalls {
 			result := executeTool(ctx, registry, tc, nil)
+			output := truncateResult(result.Output, config.MaxResultBytes)
 			results = append(results, llm.ToolResultContent{
 				ToolUseID: tc.ID,
-				Output:    result.Output,
+				Output:    output,
 				IsError:   result.Error,
 			})
 		}
@@ -105,6 +110,15 @@ func executeTool(ctx context.Context, registry *Registry,
 	}
 
 	return result
+}
+
+func truncateResult(s string, maxBytes int) string {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s
+	}
+	slog.Warn("tool output truncated",
+		"original_bytes", len(s), "max_bytes", maxBytes)
+	return s[:maxBytes] + fmt.Sprintf("\n\n[Truncated: showing first %d bytes of %d total]", maxBytes, len(s))
 }
 
 func truncateLog(s string) string {

--- a/pkg/tools/loop_test.go
+++ b/pkg/tools/loop_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/redhat-et/docsclaw/pkg/llm"
@@ -148,5 +149,67 @@ func TestRunToolLoopUnknownTool(t *testing.T) {
 	}
 	if result != "Tool not found, sorry." {
 		t.Fatalf("expected error recovery response, got %q", result)
+	}
+}
+
+func TestRunToolLoopTruncatesLargeOutput(t *testing.T) {
+	largeOutput := strings.Repeat("x", 50000)
+	provider := &mockProvider{
+		responses: []*llm.Response{
+			{
+				StopReason: llm.StopReasonToolUse,
+				ToolCalls: []llm.ToolCall{
+					{ID: "tc1", Name: "big_tool", Args: map[string]any{}},
+				},
+				Usage: llm.Usage{InputTokens: 100, OutputTokens: 20, TotalTokens: 120},
+			},
+			{
+				StopReason: llm.StopReasonEndTurn,
+				Content:    "Done.",
+				Usage:      llm.Usage{InputTokens: 200, OutputTokens: 10, TotalTokens: 210},
+			},
+		},
+	}
+
+	registry := NewRegistry(nil)
+	registry.Register(&mockTool{name: "big_tool", output: largeOutput})
+
+	cfg := DefaultLoopConfig()
+	cfg.MaxResultBytes = 1000
+
+	messages := []llm.Message{
+		{Role: "user", Content: "Run the tool"},
+	}
+
+	result, err := RunToolLoop(context.Background(), provider, messages,
+		registry, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Done." {
+		t.Fatalf("expected 'Done.', got %q", result)
+	}
+}
+
+func TestTruncateResult(t *testing.T) {
+	// No truncation when under limit
+	short := "hello"
+	if got := truncateResult(short, 100); got != short {
+		t.Fatalf("expected no truncation, got %q", got)
+	}
+
+	// No truncation when limit is 0 (disabled)
+	long := strings.Repeat("x", 1000)
+	if got := truncateResult(long, 0); got != long {
+		t.Fatal("expected no truncation with limit 0")
+	}
+
+	// Truncation applies
+	got := truncateResult(long, 100)
+	if !strings.HasPrefix(got, strings.Repeat("x", 100)) {
+		t.Fatal("expected output to start with 100 x's")
+	}
+	if !strings.Contains(got, "[Truncated: showing first 100 bytes of 1000 total]") {
+		t.Fatalf("expected truncation notice, got %q", got)
 	}
 }

--- a/pkg/tools/loop_test.go
+++ b/pkg/tools/loop_test.go
@@ -212,4 +212,16 @@ func TestTruncateResult(t *testing.T) {
 	if !strings.Contains(got, "[Truncated: showing first 100 bytes of 1000 total]") {
 		t.Fatalf("expected truncation notice, got %q", got)
 	}
+
+	// UTF-8 safe: don't split multi-byte characters
+	// "日" is 3 bytes (E6 97 A5); cutting at byte 2 would produce invalid UTF-8
+	utf8Str := strings.Repeat("日", 10) // 30 bytes
+	got = truncateResult(utf8Str, 5)
+	// Should back up to nearest valid rune boundary (3 bytes = 1 char)
+	if !strings.HasPrefix(got, "日") {
+		t.Fatal("expected UTF-8 safe prefix")
+	}
+	if strings.ContainsRune(got[:strings.Index(got, "\n")], '�') {
+		t.Fatal("truncation produced invalid UTF-8")
+	}
 }


### PR DESCRIPTION
## Summary

- Add `MaxResultBytes` field to `LoopConfig` (default 32KB) to cap tool output before sending to the LLM
- Universal safety net applied after any tool returns, in the agentic loop
- Truncated output includes notice: `[Truncated: showing first N bytes of M total]`
- Fix all pre-existing errcheck lint violations (unchecked `resp.Body.Close` and `fmt.Fprintf`)

The exec tool already had its own `MaxOutput` truncation, but readfile, webfetch, and fetchdoc had none. This prevents a single large tool result from consuming the entire context window.

## Test plan

- [x] `make test` passes — new unit tests for `truncateResult` and integration test for large tool output
- [x] `make lint` passes — **zero issues** (down from 8 pre-existing)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup and error handling across HTTP response operations to prevent potential issues with connection management.

* **New Features**
  * Tool outputs are now automatically truncated to prevent unbounded responses, with a 32KB default limit that can be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->