### PR TITLE
feat: add server-side session management for multi-turn conversations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Required repo secret: `HOMEBREW_TAP_TOKEN` (write access to
 | `internal/fetchdoc/` | Document service fetch tool |
 | `internal/workspace/` | Workspace path validation |
 | `internal/bridge/` | A2A protocol bridge (executor, client, delegation) |
+| `internal/session/` | In-memory session store for multi-turn conversations |
 | `internal/config/` | Viper configuration |
 | `internal/logger/` | Color-coded slog logger |
 | `internal/metrics/` | Prometheus metrics |

--- a/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
+++ b/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
@@ -107,7 +107,7 @@ the protocol's terminal task states).
 
 ### Session lifecycle
 
-```
+```text
 TUI: "hello"  →  Server: x-session-id=S1 → create session S1
                   S1.Messages = [system, user("hello")]
                   LLM call with S1.Messages
@@ -133,9 +133,9 @@ additional configuration needed.
 | `internal/session/store.go` | **New**: session store |
 | `internal/session/store_test.go` | **New**: store tests |
 | `internal/bridge/executor.go` | Add Sessions + SystemPrompt fields, session management in Execute |
-| `internal/bridge/client.go` | Add TaskID to InvokeRequest/InvokeResult, pass to A2A |
-| `internal/cmd/serve.go` | Create store, wire to executor, update ProcessMessage signature |
-| `internal/chat/model.go` | Store taskID, skip history prepending when set |
+| `internal/bridge/client.go` | Add `SessionID` to `InvokeRequest`, send as `x-session-id` header via ServiceParams |
+| `internal/cmd/serve.go` | Create store, wire to executor, update `ProcessMessage` signature |
+| `internal/chat/model.go` | Generate `sessionID`, skip history prepending when `sessionConfirmed` |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
+++ b/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
@@ -90,34 +90,33 @@ executor.ProcessMessage = func(ctx context.Context,
 
 ### Client changes (`internal/bridge/client.go`, `internal/chat/model.go`)
 
-**InvokeRequest** gains `TaskID string` field. When set, the A2A
-client sends `message/send` with the existing task ID instead of
-creating a new task.
-
-**InvokeResult** gains `TaskID string` field, populated from the
-A2A response task.
+**InvokeRequest** gains `SessionID string` field. The client
+generates a stable UUID-like session ID per TUI instance and
+sends it as an `x-session-id` header via ServiceParams on every
+request. Each message creates an independent A2A task (respecting
+the protocol's terminal task states).
 
 **Chat TUI** (`internal/chat/model.go`):
-- Store `taskID` from first response
-- Pass `taskID` in subsequent `InvokeRequest`
-- When `taskID` is set, `buildMessageWithHistory` returns the
-  raw text without prepending history (server has it)
+- Generates `sessionID` in `NewModel` via `crypto/rand`
+- Sends `sessionID` in every `InvokeRequest`
+- After first successful response (`sessionConfirmed`), skips
+  history prepending (server has it)
+- First message still includes history (backward compat with
+  servers without session support)
 - Display still shows local messages for scroll buffer
 
 ### Session lifecycle
 
 ```
-TUI: "hello"  →  Server: no taskId → create session S1
+TUI: "hello"  →  Server: x-session-id=S1 → create session S1
                   S1.Messages = [system, user("hello")]
                   LLM call with S1.Messages
                   S1.Messages += [assistant("Hi!")]
-                  Response includes taskId=S1
 
-TUI: "how?"   →  Server: taskId=S1 → load session S1
+TUI: "how?"   →  Server: x-session-id=S1 → load session S1
                   S1.Messages += [user("how?")]
                   LLM call with S1.Messages
                   S1.Messages += [assistant("...")]
-                  Response includes taskId=S1
 
 (30 min idle) →  Reaper deletes S1
 ```

--- a/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
+++ b/docs/superpowers/specs/2026-05-04-server-side-sessions-design.md
@@ -1,0 +1,155 @@
+# Server-Side Session Management Design
+
+**Date**: 2026-05-04
+**Issue**: #5 (Phase 1)
+**Status**: Draft
+
+## Problem
+
+DocsClaw's server is stateless. The chat TUI works around this by
+prepending the full conversation as plaintext into every A2A request.
+This wastes tokens (the entire history is re-tokenized each turn),
+loses message structure (roles become text labels), and doesn't
+persist across client restarts.
+
+## Design
+
+### Session Store (`internal/session/store.go`)
+
+In-memory store with TTL-based expiry:
+
+```go
+type Session struct {
+    ID         string
+    Messages   []llm.Message
+    CreatedAt  time.Time
+    LastActive time.Time
+}
+
+type Store struct {
+    mu       sync.RWMutex
+    sessions map[string]*Session
+    ttl      time.Duration
+}
+```
+
+**API**:
+- `NewStore(ttl)` — constructor, default TTL 30 minutes
+- `GetOrCreate(id, systemPrompt)` — returns existing session or
+  creates one with the system prompt as the first message
+- `Append(id, msg)` — adds a message and updates LastActive
+- `Get(id)` — returns session or nil
+- `StartReaper(ctx)` — background goroutine that deletes sessions
+  idle beyond TTL, runs every minute
+
+The store is safe for concurrent use (RWMutex).
+
+### Executor changes (`internal/bridge/executor.go`)
+
+The `MessageProcessor` type changes to accept full history:
+
+```go
+// Before
+type MessageProcessor func(ctx context.Context, userMessage string) (string, error)
+
+// After
+type MessageProcessor func(ctx context.Context, messages []llm.Message) (string, error)
+```
+
+The executor gains a `Sessions` field (`*session.Store`). In
+`Execute`:
+
+1. Create or resume task — `execCtx.StoredTask` is nil on first
+   call, non-nil on subsequent calls to the same taskId
+2. Extract user text from `execCtx.Message`
+3. Get session via `store.GetOrCreate(taskId, systemPrompt)`
+4. Append user message to session
+5. Call `ProcessMessage(ctx, session.Messages)`
+6. Append assistant response to session
+7. Return result as artifact
+
+The executor also gains a `SystemPrompt` field so it can
+initialize new sessions with the correct prompt.
+
+### Serve command changes (`internal/cmd/serve.go`)
+
+- Create session store: `sessions := session.NewStore(30 * time.Minute)`
+- Start reaper: `sessions.StartReaper(ctx)`
+- Set `executor.Sessions = sessions`
+- Set `executor.SystemPrompt = systemPrompt + skillsSummary`
+- Update `ProcessMessage` closure to accept `[]llm.Message`
+  instead of building them from scratch:
+
+```go
+executor.ProcessMessage = func(ctx context.Context,
+    messages []llm.Message) (string, error) {
+    return tools.RunToolLoop(ctx, llmProvider, messages,
+        toolRegistry, loopCfg)
+}
+```
+
+### Client changes (`internal/bridge/client.go`, `internal/chat/model.go`)
+
+**InvokeRequest** gains `TaskID string` field. When set, the A2A
+client sends `message/send` with the existing task ID instead of
+creating a new task.
+
+**InvokeResult** gains `TaskID string` field, populated from the
+A2A response task.
+
+**Chat TUI** (`internal/chat/model.go`):
+- Store `taskID` from first response
+- Pass `taskID` in subsequent `InvokeRequest`
+- When `taskID` is set, `buildMessageWithHistory` returns the
+  raw text without prepending history (server has it)
+- Display still shows local messages for scroll buffer
+
+### Session lifecycle
+
+```
+TUI: "hello"  →  Server: no taskId → create session S1
+                  S1.Messages = [system, user("hello")]
+                  LLM call with S1.Messages
+                  S1.Messages += [assistant("Hi!")]
+                  Response includes taskId=S1
+
+TUI: "how?"   →  Server: taskId=S1 → load session S1
+                  S1.Messages += [user("how?")]
+                  LLM call with S1.Messages
+                  S1.Messages += [assistant("...")]
+                  Response includes taskId=S1
+
+(30 min idle) →  Reaper deletes S1
+```
+
+### Enablement
+
+Sessions are always enabled in phase 2 (tool-use) mode. No
+additional configuration needed.
+
+## Files to modify or create
+
+| File | Change |
+|------|--------|
+| `internal/session/store.go` | **New**: session store |
+| `internal/session/store_test.go` | **New**: store tests |
+| `internal/bridge/executor.go` | Add Sessions + SystemPrompt fields, session management in Execute |
+| `internal/bridge/client.go` | Add TaskID to InvokeRequest/InvokeResult, pass to A2A |
+| `internal/cmd/serve.go` | Create store, wire to executor, update ProcessMessage signature |
+| `internal/chat/model.go` | Store taskID, skip history prepending when set |
+
+## Testing
+
+- `TestStoreGetOrCreate`: new session gets system prompt
+- `TestStoreAppend`: messages accumulate, LastActive updates
+- `TestStoreReaper`: expired sessions are deleted
+- `TestStoreGetOrCreateExisting`: second call returns same session
+- Integration: manual test with `docsclaw serve` + `docsclaw chat`
+  verifying multi-turn conversation works without history prepending
+
+## Future work
+
+- Redis backend for multi-replica deployments
+- SQLite for persistence across restarts
+- Max message count per session (bounded memory)
+- Context compaction integration (#5 Phase 3)

--- a/internal/bridge/client.go
+++ b/internal/bridge/client.go
@@ -31,6 +31,7 @@ type InvokeRequest struct {
 	DocumentID    string // Legacy: used by Go agents
 	MessageText   string // New: used by gateway mode (e.g., "Summarize s3://...")
 	ReviewType    string
+	TaskID        string // Continue an existing task/session
 	BearerToken   string // Optional JWT forwarded from the caller (user delegation)
 	UserSPIFFEID  string // User SPIFFE ID — sent as X-Delegation-User header
 	AgentSPIFFEID string // Agent SPIFFE ID — sent as X-Delegation-Agent header
@@ -38,15 +39,15 @@ type InvokeRequest struct {
 
 // InvokeResult holds the response from an A2A agent invocation.
 type InvokeResult struct {
-	Text  string `json:"text"`
-	State string `json:"state"`
+	Text   string `json:"text"`
+	State  string `json:"state"`
+	TaskID string `json:"task_id,omitempty"`
 }
 
 // Invoke sends a message/send request to an A2A agent.
 func (c *A2AClient) Invoke(ctx context.Context, req *InvokeRequest) (*InvokeResult, error) {
 	var msg *a2a.Message
 	if req.MessageText != "" {
-		// Gateway mode: send plain text message
 		msg = a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart(req.MessageText))
 	} else {
 		// Legacy mode: send structured DataPart
@@ -57,6 +58,10 @@ func (c *A2AClient) Invoke(ctx context.Context, req *InvokeRequest) (*InvokeResu
 			data["review_type"] = req.ReviewType
 		}
 		msg = a2a.NewMessage(a2a.MessageRoleUser, a2a.NewDataPart(data))
+	}
+
+	if req.TaskID != "" {
+		msg.TaskID = a2a.TaskID(req.TaskID)
 	}
 
 	params := &a2a.SendMessageRequest{
@@ -132,6 +137,7 @@ func (c *A2AClient) parseResult(result a2a.SendMessageResult) (*InvokeResult, er
 
 func (c *A2AClient) parseTask(task *a2a.Task) (*InvokeResult, error) {
 	state := string(task.Status.State)
+	taskID := string(task.ID)
 
 	// Check for failure or rejection
 	if task.Status.State == a2a.TaskStateFailed || task.Status.State == a2a.TaskStateRejected {
@@ -141,24 +147,24 @@ func (c *A2AClient) parseTask(task *a2a.Task) (*InvokeResult, error) {
 				reason = text
 			}
 		}
-		return &InvokeResult{Text: reason, State: state}, nil
+		return &InvokeResult{Text: reason, State: state, TaskID: taskID}, nil
 	}
 
 	// Extract text from artifacts
 	for _, artifact := range task.Artifacts {
 		if text := extractTextFromParts(artifact.Parts); text != "" {
-			return &InvokeResult{Text: text, State: state}, nil
+			return &InvokeResult{Text: text, State: state, TaskID: taskID}, nil
 		}
 	}
 
 	// Fall back to status message
 	if task.Status.Message != nil {
 		if text := extractTextFromParts(task.Status.Message.Parts); text != "" {
-			return &InvokeResult{Text: text, State: state}, nil
+			return &InvokeResult{Text: text, State: state, TaskID: taskID}, nil
 		}
 	}
 
-	return &InvokeResult{Text: "", State: state}, nil
+	return &InvokeResult{Text: "", State: state, TaskID: taskID}, nil
 }
 
 func (c *A2AClient) parseMessage(msg *a2a.Message) (*InvokeResult, error) {

--- a/internal/bridge/client.go
+++ b/internal/bridge/client.go
@@ -31,7 +31,7 @@ type InvokeRequest struct {
 	DocumentID    string // Legacy: used by Go agents
 	MessageText   string // New: used by gateway mode (e.g., "Summarize s3://...")
 	ReviewType    string
-	TaskID        string // Continue an existing task/session
+	SessionID     string // Server-side session continuity (sent as x-session-id header)
 	BearerToken   string // Optional JWT forwarded from the caller (user delegation)
 	UserSPIFFEID  string // User SPIFFE ID — sent as X-Delegation-User header
 	AgentSPIFFEID string // Agent SPIFFE ID — sent as X-Delegation-Agent header
@@ -39,9 +39,8 @@ type InvokeRequest struct {
 
 // InvokeResult holds the response from an A2A agent invocation.
 type InvokeResult struct {
-	Text   string `json:"text"`
-	State  string `json:"state"`
-	TaskID string `json:"task_id,omitempty"`
+	Text  string `json:"text"`
+	State string `json:"state"`
 }
 
 // Invoke sends a message/send request to an A2A agent.
@@ -60,10 +59,6 @@ func (c *A2AClient) Invoke(ctx context.Context, req *InvokeRequest) (*InvokeResu
 		msg = a2a.NewMessage(a2a.MessageRoleUser, a2a.NewDataPart(data))
 	}
 
-	if req.TaskID != "" {
-		msg.TaskID = a2a.TaskID(req.TaskID)
-	}
-
 	params := &a2a.SendMessageRequest{
 		Message: msg,
 	}
@@ -77,6 +72,9 @@ func (c *A2AClient) Invoke(ctx context.Context, req *InvokeRequest) (*InvokeResu
 	// Forward the bearer token and delegation context as HTTP headers
 	// via a CallInterceptor that injects ServiceParams.
 	sp := a2aclient.ServiceParams{}
+	if req.SessionID != "" {
+		sp.Append("x-session-id", req.SessionID)
+	}
 	if req.BearerToken != "" {
 		sp.Append("authorization", "Bearer "+req.BearerToken)
 	}
@@ -137,7 +135,6 @@ func (c *A2AClient) parseResult(result a2a.SendMessageResult) (*InvokeResult, er
 
 func (c *A2AClient) parseTask(task *a2a.Task) (*InvokeResult, error) {
 	state := string(task.Status.State)
-	taskID := string(task.ID)
 
 	// Check for failure or rejection
 	if task.Status.State == a2a.TaskStateFailed || task.Status.State == a2a.TaskStateRejected {
@@ -147,24 +144,24 @@ func (c *A2AClient) parseTask(task *a2a.Task) (*InvokeResult, error) {
 				reason = text
 			}
 		}
-		return &InvokeResult{Text: reason, State: state, TaskID: taskID}, nil
+		return &InvokeResult{Text: reason, State: state}, nil
 	}
 
 	// Extract text from artifacts
 	for _, artifact := range task.Artifacts {
 		if text := extractTextFromParts(artifact.Parts); text != "" {
-			return &InvokeResult{Text: text, State: state, TaskID: taskID}, nil
+			return &InvokeResult{Text: text, State: state}, nil
 		}
 	}
 
 	// Fall back to status message
 	if task.Status.Message != nil {
 		if text := extractTextFromParts(task.Status.Message.Parts); text != "" {
-			return &InvokeResult{Text: text, State: state, TaskID: taskID}, nil
+			return &InvokeResult{Text: text, State: state}, nil
 		}
 	}
 
-	return &InvokeResult{Text: "", State: state, TaskID: taskID}, nil
+	return &InvokeResult{Text: "", State: state}, nil
 }
 
 func (c *A2AClient) parseMessage(msg *a2a.Message) (*InvokeResult, error) {

--- a/internal/bridge/executor.go
+++ b/internal/bridge/executor.go
@@ -100,9 +100,9 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 
 			var messages []llm.Message
 			if e.Sessions != nil && sessionID != "" {
-				sess := e.Sessions.GetOrCreate(sessionID, e.SystemPrompt)
-				e.Sessions.Append(sessionID, llm.Message{Role: "user", Content: userText})
-				messages = sess.Messages
+				e.Sessions.GetOrCreate(sessionID, e.SystemPrompt)
+				messages = e.Sessions.AppendAndSnapshot(sessionID,
+					llm.Message{Role: "user", Content: userText})
 				e.Log.Info("Processing free-form message via agentic loop",
 					"session_id", sessionID,
 					"message_count", len(messages))

--- a/internal/bridge/executor.go
+++ b/internal/bridge/executor.go
@@ -94,6 +94,10 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 			e.Log.Info("A2A free-form request received",
 				"text_length", len(userText))
 
+			if len(sessionID) > 64 {
+				sessionID = sessionID[:64]
+			}
+
 			var messages []llm.Message
 			if e.Sessions != nil && sessionID != "" {
 				sess := e.Sessions.GetOrCreate(sessionID, e.SystemPrompt)

--- a/internal/bridge/executor.go
+++ b/internal/bridge/executor.go
@@ -9,6 +9,8 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 
 	"github.com/redhat-et/docsclaw/internal/logger"
+	"github.com/redhat-et/docsclaw/internal/session"
+	"github.com/redhat-et/docsclaw/pkg/llm"
 )
 
 // DocumentFetcher fetches a document by ID from the document-service.
@@ -21,9 +23,9 @@ type DocumentFetcher func(ctx context.Context, documentID, bearerToken string) (
 // LLMProcessor processes a document with an LLM and returns the result text.
 type LLMProcessor func(ctx context.Context, title, content string) (string, error)
 
-// MessageProcessor processes a free-form user message (no document).
+// MessageProcessor processes a conversation with an LLM.
 // Used in phase 2 (tool-use) mode for standalone operation.
-type MessageProcessor func(ctx context.Context, userMessage string) (string, error)
+type MessageProcessor func(ctx context.Context, messages []llm.Message) (string, error)
 
 // AgentExecutor implements a2asrv.AgentExecutor by bridging A2A messages
 // to document fetch and LLM processing.
@@ -31,7 +33,9 @@ type AgentExecutor struct {
 	Log            *logger.Logger
 	FetchDocument  DocumentFetcher
 	ProcessLLM     LLMProcessor
-	ProcessMessage MessageProcessor // optional: handles free-form messages
+	ProcessMessage MessageProcessor   // optional: handles free-form messages
+	Sessions       *session.Store     // optional: server-side conversation state
+	SystemPrompt   string             // system prompt for new sessions
 }
 
 // Execute handles an incoming A2A message: extracts the document ID,
@@ -80,18 +84,39 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 		var result string
 
 		if docErr != nil && e.ProcessMessage != nil {
-			// Free-form message mode: no document ID, pass raw text
-			// to the agentic loop
+			// Free-form message mode: no document ID, use session-based
+			// conversation or fall back to single-turn.
 			userText := extractTextContent(execCtx.Message)
 			e.Log.Info("A2A free-form request received",
 				"text_length", len(userText))
 
+			var messages []llm.Message
+			if e.Sessions != nil {
+				taskID := string(execCtx.TaskID)
+				sess := e.Sessions.GetOrCreate(taskID, e.SystemPrompt)
+				e.Sessions.Append(taskID, llm.Message{Role: "user", Content: userText})
+				messages = sess.Messages
+				e.Log.Info("Processing free-form message via agentic loop",
+					"session_id", taskID,
+					"message_count", len(messages))
+			} else {
+				messages = []llm.Message{
+					{Role: "system", Content: e.SystemPrompt},
+					{Role: "user", Content: userText},
+				}
+			}
+
 			var err error
-			result, err = e.ProcessMessage(ctx, userText)
+			result, err = e.ProcessMessage(ctx, messages)
 			if err != nil {
 				e.Log.Error("Message processing failed", "error", err)
 				yield(e.failedEvent(execCtx, "Processing failed: "+err.Error()), nil)
 				return
+			}
+
+			if e.Sessions != nil {
+				e.Sessions.Append(string(execCtx.TaskID),
+					llm.Message{Role: "assistant", Content: result})
 			}
 		} else if docErr != nil {
 			// No document ID and no free-form handler

--- a/internal/bridge/executor.go
+++ b/internal/bridge/executor.go
@@ -54,9 +54,10 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 			return
 		}
 
-		// Extract bearer token and delegation context from ServiceParams.
+		// Extract bearer token, delegation context, and session ID from ServiceParams.
 		var bearerToken string
 		var userSPIFFEID, agentSPIFFEID string
+		var sessionID string
 		if sp := execCtx.ServiceParams; sp != nil {
 			if vals, found := sp.Get("authorization"); found && len(vals) > 0 {
 				bearerToken = strings.TrimPrefix(vals[0], "Bearer ")
@@ -66,6 +67,9 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 			}
 			if vals, found := sp.Get("x-delegation-agent"); found && len(vals) > 0 {
 				agentSPIFFEID = vals[0]
+			}
+			if vals, found := sp.Get("x-session-id"); found && len(vals) > 0 {
+				sessionID = vals[0]
 			}
 		}
 
@@ -91,15 +95,15 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 				"text_length", len(userText))
 
 			var messages []llm.Message
-			if e.Sessions != nil {
-				taskID := string(execCtx.TaskID)
-				sess := e.Sessions.GetOrCreate(taskID, e.SystemPrompt)
-				e.Sessions.Append(taskID, llm.Message{Role: "user", Content: userText})
+			if e.Sessions != nil && sessionID != "" {
+				sess := e.Sessions.GetOrCreate(sessionID, e.SystemPrompt)
+				e.Sessions.Append(sessionID, llm.Message{Role: "user", Content: userText})
 				messages = sess.Messages
 				e.Log.Info("Processing free-form message via agentic loop",
-					"session_id", taskID,
+					"session_id", sessionID,
 					"message_count", len(messages))
 			} else {
+				e.Log.Info("Processing free-form message via agentic loop")
 				messages = []llm.Message{
 					{Role: "system", Content: e.SystemPrompt},
 					{Role: "user", Content: userText},
@@ -114,8 +118,8 @@ func (e *AgentExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 				return
 			}
 
-			if e.Sessions != nil {
-				e.Sessions.Append(string(execCtx.TaskID),
+			if e.Sessions != nil && sessionID != "" {
+				e.Sessions.Append(sessionID,
 					llm.Message{Role: "assistant", Content: result})
 			}
 		} else if docErr != nil {

--- a/internal/chat/messages.go
+++ b/internal/chat/messages.go
@@ -8,8 +8,7 @@ type ChatMessage struct {
 
 // responseMsg carries the agent's response text back to the model.
 type responseMsg struct {
-	text   string
-	taskID string
+	text string
 }
 
 // errMsg carries an error back to the model.

--- a/internal/chat/messages.go
+++ b/internal/chat/messages.go
@@ -8,7 +8,8 @@ type ChatMessage struct {
 
 // responseMsg carries the agent's response text back to the model.
 type responseMsg struct {
-	text string
+	text   string
+	taskID string
 }
 
 // errMsg carries an error back to the model.

--- a/internal/chat/model.go
+++ b/internal/chat/model.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"log/slog"
@@ -37,10 +38,10 @@ type Model struct {
 	input    textinput.Model
 	spinner  spinner.Model
 
-	messages []ChatMessage
-	taskID   string // server-side session ID (from A2A taskId)
-	waiting  bool
-	err      error
+	messages  []ChatMessage
+	sessionID string // stable ID for server-side session continuity
+	waiting   bool
+	err       error
 
 	width  int
 	height int
@@ -70,6 +71,7 @@ func NewModel(agentURL, agentName, agentDescription, userName string, skills []S
 		agentDescription: agentDescription,
 		userName:         userName,
 		skills:           skills,
+		sessionID:        generateSessionID(),
 		client:    bridge.NewA2AClient(
 			&http.Client{Timeout: 120 * time.Second},
 			slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -78,6 +80,12 @@ func NewModel(agentURL, agentName, agentDescription, userName string, skills []S
 		spinner:   sp,
 		renderer:  r,
 	}
+}
+
+func generateSessionID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
 // Init returns the initial command for the model.
@@ -143,9 +151,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case responseMsg:
 		m.waiting = false
-		if msg.taskID != "" {
-			m.taskID = msg.taskID
-		}
 		m.messages = append(m.messages, ChatMessage{Role: "agent", Text: msg.text})
 		m.updateViewport()
 		return m, textinput.Blink
@@ -268,19 +273,19 @@ func (m *Model) updateViewport() {
 func (m *Model) sendMessage(text string) tea.Cmd {
 	client := m.client
 	agentURL := m.agentURL
-	taskID := m.taskID
+	sessionID := m.sessionID
 	messageText := m.buildMessageWithHistory(text)
 
 	return func() tea.Msg {
 		result, err := client.Invoke(context.Background(), &bridge.InvokeRequest{
 			AgentURL:    agentURL,
 			MessageText: messageText,
-			TaskID:      taskID,
+			SessionID:   sessionID,
 		})
 		if err != nil {
 			return errMsg{err: err}
 		}
-		return responseMsg{text: result.Text, taskID: result.TaskID}
+		return responseMsg{text: result.Text}
 	}
 }
 
@@ -290,7 +295,7 @@ func (m *Model) sendMessage(text string) tea.Cmd {
 func (m *Model) buildMessageWithHistory(text string) string {
 	// When server-side sessions are active, the server maintains
 	// conversation history — don't prepend it client-side.
-	if m.taskID != "" {
+	if m.sessionID != "" {
 		return text
 	}
 

--- a/internal/chat/model.go
+++ b/internal/chat/model.go
@@ -38,6 +38,7 @@ type Model struct {
 	spinner  spinner.Model
 
 	messages []ChatMessage
+	taskID   string // server-side session ID (from A2A taskId)
 	waiting  bool
 	err      error
 
@@ -142,6 +143,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case responseMsg:
 		m.waiting = false
+		if msg.taskID != "" {
+			m.taskID = msg.taskID
+		}
 		m.messages = append(m.messages, ChatMessage{Role: "agent", Text: msg.text})
 		m.updateViewport()
 		return m, textinput.Blink
@@ -264,17 +268,19 @@ func (m *Model) updateViewport() {
 func (m *Model) sendMessage(text string) tea.Cmd {
 	client := m.client
 	agentURL := m.agentURL
+	taskID := m.taskID
 	messageText := m.buildMessageWithHistory(text)
 
 	return func() tea.Msg {
 		result, err := client.Invoke(context.Background(), &bridge.InvokeRequest{
 			AgentURL:    agentURL,
 			MessageText: messageText,
+			TaskID:      taskID,
 		})
 		if err != nil {
 			return errMsg{err: err}
 		}
-		return responseMsg{text: result.Text}
+		return responseMsg{text: result.Text, taskID: result.TaskID}
 	}
 }
 
@@ -282,6 +288,12 @@ func (m *Model) sendMessage(text string) tea.Cmd {
 // text so the agent sees prior turns. On the first message, returns the
 // raw text with no formatting.
 func (m *Model) buildMessageWithHistory(text string) string {
+	// When server-side sessions are active, the server maintains
+	// conversation history — don't prepend it client-side.
+	if m.taskID != "" {
+		return text
+	}
+
 	// Collect prior turns, excluding error messages and the current
 	// user message (which is already appended to m.messages).
 	var history []ChatMessage

--- a/internal/chat/model.go
+++ b/internal/chat/model.go
@@ -38,10 +38,11 @@ type Model struct {
 	input    textinput.Model
 	spinner  spinner.Model
 
-	messages  []ChatMessage
-	sessionID string // stable ID for server-side session continuity
-	waiting   bool
-	err       error
+	messages       []ChatMessage
+	sessionID      string // stable ID for server-side session continuity
+	sessionConfirmed bool // true after first successful response (server has session)
+	waiting        bool
+	err            error
 
 	width  int
 	height int
@@ -151,6 +152,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case responseMsg:
 		m.waiting = false
+		m.sessionConfirmed = true
 		m.messages = append(m.messages, ChatMessage{Role: "agent", Text: msg.text})
 		m.updateViewport()
 		return m, textinput.Blink
@@ -293,9 +295,9 @@ func (m *Model) sendMessage(text string) tea.Cmd {
 // text so the agent sees prior turns. On the first message, returns the
 // raw text with no formatting.
 func (m *Model) buildMessageWithHistory(text string) string {
-	// When server-side sessions are active, the server maintains
-	// conversation history — don't prepend it client-side.
-	if m.sessionID != "" {
+	// After the first successful response, the server has our session —
+	// stop prepending history client-side to avoid doubling context.
+	if m.sessionConfirmed {
 		return text
 	}
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/redhat-et/docsclaw/internal/bridge"
 	"github.com/redhat-et/docsclaw/internal/config"
+	"github.com/redhat-et/docsclaw/internal/session"
 	"github.com/redhat-et/docsclaw/internal/exec"
 	"github.com/redhat-et/docsclaw/internal/fetchdoc"
 	"github.com/redhat-et/docsclaw/internal/logger"
@@ -415,18 +416,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 		ProcessLLM:    processLLM,
 	}
 
-	// In phase 2 mode, enable free-form message handling
+	// In phase 2 mode, enable free-form message handling with sessions
 	if toolRegistry != nil {
-		executor.ProcessMessage = func(ctx context.Context, userMessage string) (string, error) {
+		sessions := session.NewStore(30 * time.Minute)
+		reaperCtx, reaperCancel := context.WithCancel(context.Background())
+		defer reaperCancel()
+		go sessions.StartReaper(reaperCtx)
+
+		executor.Sessions = sessions
+		executor.SystemPrompt = systemPrompt + skillsSummary
+		executor.ProcessMessage = func(ctx context.Context,
+			messages []llm.Message) (string, error) {
+
 			if llmProvider == nil {
 				return "", fmt.Errorf("LLM provider required for tool-use mode")
-			}
-
-			log.Info("Processing free-form message via agentic loop")
-
-			messages := []llm.Message{
-				{Role: "system", Content: systemPrompt + skillsSummary},
-				{Role: "user", Content: userMessage},
 			}
 
 			result, err := tools.RunToolLoop(ctx, llmProvider, messages,

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -76,6 +76,25 @@ func (s *Store) Append(id string, msg llm.Message) {
 	sess.LastActive = time.Now()
 }
 
+// AppendAndSnapshot adds a message and returns a copy of the session's
+// messages. All operations happen under the lock, preventing races
+// between concurrent reads and writes.
+func (s *Store) AppendAndSnapshot(id string, msg llm.Message) []llm.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil
+	}
+	sess.Messages = append(sess.Messages, msg)
+	sess.LastActive = time.Now()
+
+	snapshot := make([]llm.Message, len(sess.Messages))
+	copy(snapshot, sess.Messages)
+	return snapshot
+}
+
 // Len returns the number of active sessions.
 func (s *Store) Len() int {
 	s.mu.RLock()

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/redhat-et/docsclaw/pkg/llm"
+)
+
+// Session holds the conversation state for a single A2A task.
+type Session struct {
+	ID         string
+	Messages   []llm.Message
+	CreatedAt  time.Time
+	LastActive time.Time
+}
+
+// Store manages in-memory sessions with TTL-based expiry.
+type Store struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session
+	ttl      time.Duration
+}
+
+// NewStore creates a session store with the given idle TTL.
+func NewStore(ttl time.Duration) *Store {
+	return &Store{
+		sessions: make(map[string]*Session),
+		ttl:      ttl,
+	}
+}
+
+// GetOrCreate returns an existing session or creates one with the
+// system prompt as the first message.
+func (s *Store) GetOrCreate(id, systemPrompt string) *Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if sess, ok := s.sessions[id]; ok {
+		return sess
+	}
+
+	now := time.Now()
+	sess := &Session{
+		ID: id,
+		Messages: []llm.Message{
+			{Role: "system", Content: systemPrompt},
+		},
+		CreatedAt:  now,
+		LastActive: now,
+	}
+	s.sessions[id] = sess
+	slog.Info("session created", "session_id", id)
+	return sess
+}
+
+// Get returns the session or nil if not found.
+func (s *Store) Get(id string) *Session {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sessions[id]
+}
+
+// Append adds a message to the session and updates LastActive.
+func (s *Store) Append(id string, msg llm.Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[id]
+	if !ok {
+		return
+	}
+	sess.Messages = append(sess.Messages, msg)
+	sess.LastActive = time.Now()
+}
+
+// Len returns the number of active sessions.
+func (s *Store) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.sessions)
+}
+
+// StartReaper runs a background goroutine that removes sessions
+// idle beyond the TTL. It stops when ctx is cancelled.
+func (s *Store) StartReaper(ctx context.Context) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reap()
+		}
+	}
+}
+
+func (s *Store) reap() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for id, sess := range s.sessions {
+		if now.Sub(sess.LastActive) > s.ttl {
+			delete(s.sessions, id)
+			slog.Info("session expired",
+				"session_id", id,
+				"message_count", len(sess.Messages))
+		}
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -95,6 +97,61 @@ func TestStoreReaper(t *testing.T) {
 	}
 	if s.Get("keep-me") == nil {
 		t.Fatal("expected keep-me to survive")
+	}
+}
+
+func TestAppendAndSnapshot(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	s.GetOrCreate("task-1", "system")
+
+	msgs := s.AppendAndSnapshot("task-1", llm.Message{Role: "user", Content: "hello"})
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+
+	// Verify it's a copy — mutating the snapshot shouldn't affect the store
+	msgs[0].Content = "mutated"
+	sess := s.Get("task-1")
+	if sess.Messages[0].Content != "system" {
+		t.Fatal("snapshot mutation affected store")
+	}
+}
+
+func TestAppendAndSnapshotNonexistent(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	msgs := s.AppendAndSnapshot("nonexistent", llm.Message{Role: "user", Content: "hello"})
+	if msgs != nil {
+		t.Fatal("expected nil for nonexistent session")
+	}
+}
+
+func TestStoreConcurrentRace(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	s.GetOrCreate("shared", "system")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				s.GetOrCreate("shared", "system")
+				s.AppendAndSnapshot("shared",
+					llm.Message{Role: "user", Content: fmt.Sprintf("msg-%d", j)})
+				s.Get("shared")
+				s.Len()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if s.Len() != 1 {
+		t.Fatalf("expected 1 session, got %d", s.Len())
+	}
+	sess := s.Get("shared")
+	// 1 system + (50 goroutines * 100 messages)
+	if len(sess.Messages) != 5001 {
+		t.Fatalf("expected 5001 messages, got %d", len(sess.Messages))
 	}
 }
 

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redhat-et/docsclaw/pkg/llm"
+)
+
+func TestStoreGetOrCreate(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	sess := s.GetOrCreate("task-1", "You are a helpful assistant.")
+
+	if sess.ID != "task-1" {
+		t.Fatalf("expected ID task-1, got %q", sess.ID)
+	}
+	if len(sess.Messages) != 1 {
+		t.Fatalf("expected 1 message (system), got %d", len(sess.Messages))
+	}
+	if sess.Messages[0].Role != "system" {
+		t.Fatalf("expected system role, got %q", sess.Messages[0].Role)
+	}
+	if sess.Messages[0].Content != "You are a helpful assistant." {
+		t.Fatalf("unexpected system prompt: %q", sess.Messages[0].Content)
+	}
+}
+
+func TestStoreGetOrCreateExisting(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	sess1 := s.GetOrCreate("task-1", "prompt-1")
+	s.Append("task-1", llm.Message{Role: "user", Content: "hello"})
+
+	sess2 := s.GetOrCreate("task-1", "prompt-2")
+
+	if len(sess2.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(sess2.Messages))
+	}
+	if sess2.Messages[0].Content != "prompt-1" {
+		t.Fatal("existing session should keep original system prompt")
+	}
+	if sess1 != sess2 {
+		t.Fatal("expected same session pointer")
+	}
+}
+
+func TestStoreAppend(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	s.GetOrCreate("task-1", "system")
+
+	before := s.Get("task-1").LastActive
+	time.Sleep(time.Millisecond)
+
+	s.Append("task-1", llm.Message{Role: "user", Content: "hello"})
+	s.Append("task-1", llm.Message{Role: "assistant", Content: "hi"})
+
+	sess := s.Get("task-1")
+	if len(sess.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(sess.Messages))
+	}
+	if !sess.LastActive.After(before) {
+		t.Fatal("expected LastActive to be updated")
+	}
+}
+
+func TestStoreAppendNonexistent(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	s.Append("nonexistent", llm.Message{Role: "user", Content: "hello"})
+	if s.Len() != 0 {
+		t.Fatal("append to nonexistent session should not create it")
+	}
+}
+
+func TestStoreGetNonexistent(t *testing.T) {
+	s := NewStore(30 * time.Minute)
+	if s.Get("nonexistent") != nil {
+		t.Fatal("expected nil for nonexistent session")
+	}
+}
+
+func TestStoreReaper(t *testing.T) {
+	s := NewStore(10 * time.Millisecond)
+	s.GetOrCreate("expire-me", "system")
+	s.GetOrCreate("keep-me", "system")
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Touch keep-me so it survives
+	s.Append("keep-me", llm.Message{Role: "user", Content: "still here"})
+
+	s.reap()
+
+	if s.Get("expire-me") != nil {
+		t.Fatal("expected expire-me to be reaped")
+	}
+	if s.Get("keep-me") == nil {
+		t.Fatal("expected keep-me to survive")
+	}
+}
+
+func TestStoreStartReaperCancellation(t *testing.T) {
+	s := NewStore(time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		s.StartReaper(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StartReaper did not stop after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/session` package with in-memory `Store` (map + RWMutex, TTL-based reaper)
- Executor manages session lifecycle using client-sent `x-session-id` header as session key
- `MessageProcessor` signature changes from `func(ctx, string)` to `func(ctx, []llm.Message)` — server builds conversation history, not the client
- Chat TUI generates a stable session ID per instance and sends it via ServiceParams
- Client stops prepending conversation history as plaintext (server has it)

Each chat message creates an independent A2A task (respecting the protocol's terminal task states), but the server groups them into a conversation session via the `x-session-id` header. Two terminal sessions get independent conversations. Sessions expire after 30 minutes of idle time.

## Design

See `docs/superpowers/specs/2026-05-04-server-side-sessions-design.md`.

## Test plan

- [x] `make test` passes — session store tests cover GetOrCreate, Append, reaper, cancellation
- [x] `make lint` passes (0 issues)
- [x] `make build` passes
- [x] Manual: 5-turn conversation, agent remembers context, session_id stable, message_count grows correctly

Closes #5 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-turn conversation sessions with automatic inactivity-based cleanup
  * Server-side session management reduces redundant message transmission and improves context awareness

* **Documentation**
  * Added session management design specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->