### PR TITLE
docs: add LLM provider configuration to deploy examples

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,40 @@
 # Deployment
 
+## LLM provider configuration
+
+DocsClaw supports three LLM providers. All configuration is carried in
+a single Kubernetes Secret named `llm-secret`, injected via `envFrom`.
+
+| Provider | `LLM_PROVIDER` | `LLM_BASE_URL` required? | Example models |
+|----------|-----------------|--------------------------|----------------|
+| Anthropic | `anthropic` | No | `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5` |
+| OpenAI | `openai` | Yes (defaults to `https://api.openai.com/v1`) | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` |
+| MaaS / LiteLLM | `litellm` | Yes | `qwen3-14b`, `deepseek-r1-distill-qwen-14b` |
+
+Environment variables in the secret:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LLM_API_KEY` | Yes | API key for the provider |
+| `LLM_PROVIDER` | Yes | `anthropic`, `openai`, or `litellm` |
+| `LLM_MODEL` | No | Model name (each provider has a default) |
+| `LLM_BASE_URL` | OpenAI/LiteLLM only | API endpoint URL |
+
+To configure, copy the example for your provider and fill in the key:
+
+```bash
+# Pick one:
+cp secrets/anthropic_example.yaml secrets/anthropic.yaml
+cp secrets/openai_example.yaml    secrets/openai.yaml
+cp secrets/maas_example.yaml      secrets/maas.yaml
+
+# Edit to set LLM_API_KEY (and LLM_BASE_URL for MaaS), then:
+oc apply -f secrets/<provider>.yaml
+```
+
+All three examples create the same `llm-secret` name, so only apply
+one. To switch providers, delete the old secret and apply the new one.
+
 ## Local development
 
 Source an environment file to set LLM provider variables:
@@ -12,24 +47,21 @@ source environments/anthropic.env
 ./bin/docsclaw serve --config-dir testdata/standalone --listen-plain-http
 ```
 
-## OpenShift/Kubernetes
+## OpenShift / Kubernetes
 
-1. Create a secret from the example:
+1. Create a namespace and the LLM secret (see above):
 
 ```bash
-cp secrets/anthropic_example.yaml secrets/anthropic.yaml
-# Edit anthropic.yaml with your API key
-oc apply -f secrets/anthropic.yaml
+oc new-project docsclaw
+oc apply -f secrets/anthropic.yaml   # or openai.yaml / maas.yaml
 ```
 
 2. Deploy the agent:
 
 ```bash
-oc apply -f standalone-agent.yaml
+oc apply -f standalone-agent.yaml        # basic agent
+oc apply -f agent-with-skills.yaml       # agent with skills
 ```
-
-The deployment references `llm-secret` via `envFrom` — all three
-provider examples create the same secret name, so only apply one.
 
 ## Files
 
@@ -39,4 +71,5 @@ provider examples create the same secret name, so only apply one.
 | `environments/*.env` | No | Your local env files (gitignored) |
 | `secrets/*_example.yaml` | Yes | Template K8s secrets |
 | `secrets/*.yaml` | No | Your real secrets (gitignored) |
-| `standalone-agent.yaml` | Yes | Full deployment (ConfigMap + Deployment + Service + Route) |
+| `standalone-agent.yaml` | Yes | Basic agent (ConfigMap + Deployment + Service + Route) |
+| `agent-with-skills.yaml` | Yes | Agent with skills (adds skill ConfigMaps) |

--- a/deploy/agent-with-skills.yaml
+++ b/deploy/agent-with-skills.yaml
@@ -6,7 +6,26 @@
 #
 # Prerequisites:
 #   oc new-project docsclaw
-#   oc apply -f secrets/anthropic.yaml   (see secrets/*_example.yaml)
+#
+# Configure LLM provider (pick ONE):
+#
+#   Anthropic:
+#     cp secrets/anthropic_example.yaml secrets/anthropic.yaml
+#     # edit anthropic.yaml — set LLM_API_KEY
+#     oc apply -f secrets/anthropic.yaml
+#
+#   OpenAI:
+#     cp secrets/openai_example.yaml secrets/openai.yaml
+#     # edit openai.yaml — set LLM_API_KEY
+#     oc apply -f secrets/openai.yaml
+#
+#   MaaS (LiteLLM proxy for open-source models on OpenShift AI):
+#     cp secrets/maas_example.yaml secrets/maas.yaml
+#     # edit maas.yaml — set LLM_API_KEY and LLM_BASE_URL
+#     oc apply -f secrets/maas.yaml
+#
+# All three create the same "llm-secret" name, so only apply one.
+# See deploy/README.md for provider details.
 #
 # Deploy:
 #   oc apply -f agent-with-skills.yaml

--- a/deploy/standalone-agent.yaml
+++ b/deploy/standalone-agent.yaml
@@ -3,13 +3,33 @@
 #
 # Prerequisites:
 #   oc new-project docsclaw   (or use any namespace)
-#   oc create secret generic llm-secret --from-literal=LLM_API_KEY=sk-...
+#
+# Configure LLM provider (pick ONE):
+#
+#   Anthropic:
+#     cp secrets/anthropic_example.yaml secrets/anthropic.yaml
+#     # edit anthropic.yaml — set LLM_API_KEY
+#     oc apply -f secrets/anthropic.yaml
+#
+#   OpenAI:
+#     cp secrets/openai_example.yaml secrets/openai.yaml
+#     # edit openai.yaml — set LLM_API_KEY
+#     oc apply -f secrets/openai.yaml
+#
+#   MaaS (LiteLLM proxy for open-source models on OpenShift AI):
+#     cp secrets/maas_example.yaml secrets/maas.yaml
+#     # edit maas.yaml — set LLM_API_KEY and LLM_BASE_URL
+#     oc apply -f secrets/maas.yaml
+#
+# All three create the same "llm-secret" name, so only apply one.
+# The secret carries LLM_PROVIDER, LLM_MODEL, LLM_API_KEY, and
+# (for OpenAI/MaaS) LLM_BASE_URL. See deploy/README.md for details.
 #
 # Deploy:
-#   oc apply -f docsclaw.yaml
+#   oc apply -f standalone-agent.yaml
 #
 # Test:
-#   curl -X POST http://$(oc get route docsclaw -o jsonpath='{.spec.host}')/a2a \
+#   curl -X POST https://$(oc get route docsclaw -o jsonpath='{.spec.host}')/a2a \
 #     -H "Content-Type: application/json" \
 #     -d '{"jsonrpc":"2.0","method":"message/send","id":"1",
 #          "params":{"message":{"messageId":"m1","role":"user",


### PR DESCRIPTION
## Summary

- Expanded deploy YAML headers with per-provider secret setup instructions (Anthropic, OpenAI, MaaS/LiteLLM)
- Added provider reference table and env var table to `deploy/README.md`
- Fixed stale filename reference and `http` → `https` in standalone-agent.yaml test command

## Motivation

A coworker asked how to configure different LLM providers and models. The existing YAMLs only showed `oc create secret generic llm-secret --from-literal=LLM_API_KEY=sk-...`, with no mention of `LLM_PROVIDER`, `LLM_MODEL`, or `LLM_BASE_URL`. The secret example files already carried all the right vars — the deploy docs just didn't reference them.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm secret example files match the env vars documented in the table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide with comprehensive LLM provider configuration instructions for Anthropic, OpenAI, and MaaS/LiteLLM
  * Clarified deployment options: standalone agent vs agent with skills configurations
  * Enhanced setup procedures for Kubernetes and OpenShift deployments with explicit namespace and configuration steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->