### PR TITLE
feat: add Red Hat Hardened Image Containerfiles

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /docsclaw ./cmd/docsclaw
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+WORKDIR /app
+COPY --from=builder /docsclaw /app/docsclaw
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docsclaw"]
+CMD ["serve"]

--- a/demo/batch/Containerfile.finance
+++ b/demo/batch/Containerfile.finance
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o docsclaw ./cmd/docsclaw
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+COPY --from=builder /build/docsclaw /usr/local/bin/docsclaw
+
+EXPOSE 8000 8100
+
+ENTRYPOINT ["docsclaw"]
+CMD ["serve", "--config-dir", "/config/agent", "--listen-plain-http"]

--- a/demo/batch/Containerfile.hr
+++ b/demo/batch/Containerfile.hr
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o docsclaw ./cmd/docsclaw
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+COPY --from=builder /build/docsclaw /usr/local/bin/docsclaw
+
+EXPOSE 8000 8100
+
+ENTRYPOINT ["docsclaw"]
+CMD ["serve", "--config-dir", "/config/agent", "--listen-plain-http"]

--- a/demo/batch/Containerfile.security
+++ b/demo/batch/Containerfile.security
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o docsclaw ./cmd/docsclaw
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+COPY --from=builder /build/docsclaw /usr/local/bin/docsclaw
+
+EXPOSE 8000 8100
+
+ENTRYPOINT ["docsclaw"]
+CMD ["serve", "--config-dir", "/config/agent", "--listen-plain-http"]

--- a/demo/batch/dashboard/Containerfile
+++ b/demo/batch/dashboard/Containerfile
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o dashboard .
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+COPY --from=builder /build/dashboard /dashboard
+
+EXPOSE 8090
+
+ENTRYPOINT ["/dashboard"]

--- a/demo/batch/document-service/Containerfile
+++ b/demo/batch/document-service/Containerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /build
+COPY main.go .
+RUN CGO_ENABLED=0 go build -o document-service main.go
+
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+COPY --from=builder /build/document-service /document-service
+
+EXPOSE 8080
+
+ENTRYPOINT ["/document-service"]
+CMD ["-data-dir", "/data"]


### PR DESCRIPTION
## Summary

- Add Containerfiles using Red Hat Hardened Images as the primary
  build option for all components (docsclaw, demo agents,
  document-service, dashboard)
- Hardened images provide enterprise supply-chain trust with
  identical runtime memory footprint (~11 MiB per agent pod)
- Alpine Dockerfiles kept as fallback for non-Red Hat environments

## Tested

HR analyst running on hardened image alongside Alpine-based
finance analyst — identical memory consumption:

```
NAME                CPU(cores)   MEMORY(bytes)
finance-analyst     1m           12Mi
hr-analyst          1m           11Mi
```

## Test plan

- [x] Build docsclaw from `Containerfile` on RHEL
- [x] Deploy HR analyst with hardened image on OpenShift
- [x] Verify memory footprint matches Alpine-based agents
- [ ] Build and test document-service and dashboard Containerfiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added containerization support enabling streamlined deployment of the core service and related components.
  * Configured containerized environments for Finance, HR, and Security demonstration scenarios.
  * Enabled containerized deployment for dashboard and document management services, improving application portability and infrastructure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->