### PR TITLE
feat: agent manifest with declarative tooling and build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 bin/
+build/
 tmp/
 *.exe
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 bin/
 build/
 tmp/
+Containerfile.agent
+tools.json
 *.exe
 *.test
 *.out

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ fmt:
 	gofmt -w .
 
 clean:
-	rm -rf $(BINDIR)
+	rm -rf $(BINDIR) build/
 
 image:
 	$(CONTAINER_ENGINE) build \
@@ -54,13 +54,14 @@ image-push: image
 #   make agent-push  MANIFEST=testdata/manifest/nps-agent.yaml TAG=ghcr.io/org/nps-agent:1.0.0
 
 MANIFEST ?=
-AGENT_BUILDDIR ?= $(shell mktemp -d)
+AGENT_BUILDDIR ?= build/agent
 TAG ?= $(REGISTRY):$(DEV_TAG)
 
 agent-build: build
 ifndef MANIFEST
 	$(error MANIFEST is required. Usage: make agent-build MANIFEST=path/to/agent-manifest.yaml)
 endif
+	@mkdir -p $(AGENT_BUILDDIR)
 	@echo "==> Generating build artifacts from $(MANIFEST)..."
 	$(BINDIR)/$(BINARY) build --manifest $(MANIFEST) --output $(AGENT_BUILDDIR)
 	@echo "==> Cross-compiling binary for linux/amd64..."

--- a/Makefile
+++ b/Makefile
@@ -64,16 +64,17 @@ endif
 	@mkdir -p $(AGENT_BUILDDIR)
 	@echo "==> Generating build artifacts from $(MANIFEST)..."
 	$(BINDIR)/$(BINARY) build --manifest $(MANIFEST) --output $(AGENT_BUILDDIR)
-	@echo "==> Cross-compiling binary for linux/amd64..."
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(AGENT_BUILDDIR)/docsclaw ./cmd/docsclaw
-	@echo "==> Build context ready at $(AGENT_BUILDDIR)"
+	@cp $(AGENT_BUILDDIR)/Containerfile Containerfile.agent
+	@cp $(AGENT_BUILDDIR)/tools.json tools.json
+	@echo "==> Build context ready (Containerfile.agent + tools.json)"
 
 agent-image: agent-build
 	@echo "==> Building container image $(TAG)..."
 	$(CONTAINER_ENGINE) build \
 		--platform linux/amd64 \
 		-t $(TAG) \
-		-f $(AGENT_BUILDDIR)/Containerfile $(AGENT_BUILDDIR)
+		-f Containerfile.agent .
+	@rm -f Containerfile.agent tools.json
 	@echo "==> Image built: $(TAG)"
 
 agent-push: agent-image

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OUTDIR ?= deploy/generated/$(NAME)
 NAMESPACE ?=
 KUBECTL ?= oc
 
-.PHONY: build test lint fmt clean image image-push configmap-gen configmap-apply
+.PHONY: build test lint fmt clean image image-push agent-build agent-image agent-push configmap-gen configmap-apply
 
 build:
 	go build -o $(BINDIR)/$(BINARY) ./cmd/docsclaw
@@ -43,6 +43,40 @@ image:
 
 image-push: image
 	$(CONTAINER_ENGINE) push $(REGISTRY):$(DEV_TAG)
+
+# --- Agent image from manifest ---
+# Build a custom agent image from an agent manifest.
+# The manifest declares which OS tools to install (curl, jq, git, etc.).
+#
+# Usage:
+#   make agent-build MANIFEST=testdata/manifest/nps-agent.yaml
+#   make agent-image MANIFEST=testdata/manifest/nps-agent.yaml TAG=ghcr.io/org/nps-agent:1.0.0
+#   make agent-push  MANIFEST=testdata/manifest/nps-agent.yaml TAG=ghcr.io/org/nps-agent:1.0.0
+
+MANIFEST ?=
+AGENT_BUILDDIR ?= $(shell mktemp -d)
+TAG ?= $(REGISTRY):$(DEV_TAG)
+
+agent-build: build
+ifndef MANIFEST
+	$(error MANIFEST is required. Usage: make agent-build MANIFEST=path/to/agent-manifest.yaml)
+endif
+	@echo "==> Generating build artifacts from $(MANIFEST)..."
+	$(BINDIR)/$(BINARY) build --manifest $(MANIFEST) --output $(AGENT_BUILDDIR)
+	@echo "==> Cross-compiling binary for linux/amd64..."
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(AGENT_BUILDDIR)/docsclaw ./cmd/docsclaw
+	@echo "==> Build context ready at $(AGENT_BUILDDIR)"
+
+agent-image: agent-build
+	@echo "==> Building container image $(TAG)..."
+	$(CONTAINER_ENGINE) build \
+		--platform linux/amd64 \
+		-t $(TAG) \
+		-f $(AGENT_BUILDDIR)/Containerfile $(AGENT_BUILDDIR)
+	@echo "==> Image built: $(TAG)"
+
+agent-push: agent-image
+	$(CONTAINER_ENGINE) push $(TAG)
 
 # --- ConfigMap generation ---
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,26 @@ Set via environment variables:
 └─────────────────────────────────────────────────┘
 ```
 
+## Custom agent images
+
+Build purpose-built agent images with a declarative manifest that
+specifies OS tools, system prompt, skills, and secrets:
+
+```bash
+# Validate
+docsclaw build --manifest agent-manifest.yaml --dry-run
+
+# Build and push
+make agent-push MANIFEST=agent-manifest.yaml TAG=ghcr.io/org/my-agent:1.0.0
+
+# Deploy
+export LLM_API_KEY=sk-...
+docsclaw deploy --manifest agent-manifest.yaml | oc apply -f -
+```
+
+See the [agent manifest guide](docs/agent-manifest-guide.md) for
+the full workflow, tool catalog, and security tiers.
+
 ## Build
 
 ```bash

--- a/docs/agent-manifest-guide.md
+++ b/docs/agent-manifest-guide.md
@@ -288,7 +288,7 @@ deployment methods.
 Skills that include a `skill.yaml` with tool requirements are
 checked at build time:
 
-```
+```text
 Checking skill compatibility...
 
   ✔ nps-api

--- a/docs/agent-manifest-guide.md
+++ b/docs/agent-manifest-guide.md
@@ -1,0 +1,309 @@
+# Agent manifest guide
+
+Build and deploy custom agent images from a declarative manifest.
+
+## Overview
+
+An agent manifest defines everything needed to build and deploy
+an agent: base image, OS tools, system prompt, skills, secrets,
+and deployment config. The formula:
+
+**agent = base image + installed tools + system prompt + skills**
+
+The workflow has three steps:
+
+1. **Write** the manifest (YAML)
+2. **Build** the container image (`make agent-push`)
+3. **Deploy** to OpenShift (`docsclaw deploy | oc apply -f -`)
+
+## Step 1: Write the manifest
+
+Create an `agent-manifest.yaml`:
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: nps-assistant
+  version: 1.0.0
+spec:
+  base:
+    image: registry.access.redhat.com/hi/core-runtime:latest
+    toolBuilder: registry.access.redhat.com/hi/core-runtime:latest-builder
+
+  tools:
+    - curl
+    - jq
+    - git
+
+  prompt:
+    text: |
+      You are a national parks assistant.
+      Use the NPS API skill to answer questions about parks.
+
+  skills:
+    - name: nps-api
+      image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+
+  runtime:
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - web_fetch
+        - load_skill
+      exec:
+        timeout: 30
+        maxOutput: 50000
+    loop:
+      maxIterations: 15
+
+  secrets:
+    - name: NPS_API_KEY
+      description: "API key for developer.nps.gov"
+      required: true
+    - name: LLM_API_KEY
+      description: "LLM provider API key"
+      required: true
+
+  deploy:
+    image: ghcr.io/redhat-et/nps-agent:1.0.0
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+### Key fields
+
+| Field | Purpose |
+|-------|---------|
+| `spec.base.image` | Hardened runtime base image |
+| `spec.base.toolBuilder` | Builder image with dnf (for installing tools) |
+| `spec.base.goBuilder` | Go compiler image (defaults to `hi/go:latest`) |
+| `spec.tools` | OS-level tools to install (from the tool catalog) |
+| `spec.prompt.text` | System prompt defining the agent's personality |
+| `spec.skills` | OCI image volumes mounted at `/config/agent/skills/` |
+| `spec.runtime` | Agent-config.yaml settings (tool allowlist, loop) |
+| `spec.secrets` | Required environment variables (values never stored) |
+| `spec.deploy.image` | The built agent image used in the K8s Deployment |
+
+### Tool catalog
+
+Tools are selected from a curated catalog organized by security
+tier. Core tools (curl, jq) are always included.
+
+| Tier | Tools | Risk | Auto-included |
+|------|-------|------|---------------|
+| core | curl, jq | 1-2 | Yes |
+| standard | git, openssh-client | 4 | No |
+| extended | pandoc, poppler-utils, imagemagick | 3-5 | No |
+| runtime | python3, nodejs | 8 | No |
+
+Each tool carries a risk score (1-10). The image-level score is
+the max of all installed tools. Use `--max-risk` to enforce a
+ceiling:
+
+```bash
+docsclaw build --manifest agent-manifest.yaml --max-risk 6
+```
+
+## Step 2: Build and push the image
+
+### Validate first (dry run)
+
+```bash
+docsclaw build --manifest agent-manifest.yaml --dry-run
+```
+
+This prints the tool inventory, tier, and risk score without
+building anything.
+
+### Build and push
+
+```bash
+make agent-push \
+  MANIFEST=agent-manifest.yaml \
+  TAG=ghcr.io/redhat-et/nps-agent:1.0.0
+```
+
+This runs three chained targets:
+
+1. `agent-build` — generates the Containerfile and tools.json,
+   copies them to the project root as the build context
+2. `agent-image` — runs `podman build` with the two-stage
+   Containerfile (Go compilation + hardened runtime)
+3. `agent-push` — pushes the image to the registry
+
+### Remote builds (RHEL host)
+
+If you develop on macOS and need x86_64 images, use a remote
+podman connection:
+
+```bash
+make agent-push \
+  MANIFEST=agent-manifest.yaml \
+  TAG=ghcr.io/redhat-et/nps-agent:1.0.0 \
+  PODMAN_CONNECTION=rhel
+```
+
+The two-stage Containerfile compiles the Go binary on the remote
+host natively — no cross-compilation needed.
+
+### Inspect the generated artifacts
+
+```bash
+docsclaw build --manifest agent-manifest.yaml --output build/agent
+
+ls build/agent/
+# Containerfile      — two-stage build
+# tools.json         — embedded runtime metadata
+# agent-config.yaml  — generated from spec.runtime
+# system-prompt.txt  — from spec.prompt.text
+# k8s/               — K8s manifests
+```
+
+## Step 3: Deploy to OpenShift
+
+### Create the namespace and secrets
+
+```bash
+oc new-project my-agents
+
+export NPS_API_KEY=your-key-here
+export LLM_API_KEY=your-llm-key
+```
+
+### Generate and apply manifests
+
+```bash
+docsclaw deploy --manifest agent-manifest.yaml | oc apply -f -
+```
+
+The deploy command:
+
+1. Reads the manifest
+2. Resolves secrets from environment variables (or `--secret`
+   flags)
+3. Generates ServiceAccount, ConfigMap, Secret, Service, and
+   Deployment YAML
+4. Prints to stdout for piping to `oc apply`
+
+Alternatively, write to files and apply separately:
+
+```bash
+docsclaw deploy --manifest agent-manifest.yaml \
+  --output deploy/nps-agent/
+
+oc apply -f deploy/nps-agent/k8s/
+```
+
+### Secret resolution
+
+Secrets are resolved at deploy time, never stored in the
+manifest. Resolution order:
+
+1. `--secret NAME=value` flag (highest priority)
+2. Environment variable with matching name
+3. Error if `required: true` and no value found
+
+```bash
+# From environment (recommended for CI/CD)
+export LLM_API_KEY=sk-...
+docsclaw deploy --manifest agent-manifest.yaml | oc apply -f -
+
+# From flags (quick local testing)
+docsclaw deploy --manifest agent-manifest.yaml \
+  --secret NPS_API_KEY=abc123 \
+  --secret LLM_API_KEY=sk-test \
+  | oc apply -f -
+```
+
+### Verify the deployment
+
+```bash
+# Check pod status
+oc get pods -l app=nps-assistant
+
+# Check logs
+oc logs -l app=nps-assistant
+
+# Verify tools are installed
+oc exec deploy/nps-assistant -- curl --version
+oc exec deploy/nps-assistant -- jq --version
+
+# Check embedded tool metadata
+oc exec deploy/nps-assistant -- cat /etc/docsclaw/tools.json
+
+# Test the agent
+a2a discover http://nps-assistant:8000
+a2a send http://nps-assistant:8000 "List parks in Montana"
+```
+
+## Image metadata
+
+Built images carry OCI annotations inspectable without pulling:
+
+```bash
+skopeo inspect docker://ghcr.io/redhat-et/nps-agent:1.0.0 \
+  | jq '.Labels | with_entries(select(.key | startswith("io.docsclaw")))'
+```
+
+| Annotation | Example |
+|------------|---------|
+| `io.docsclaw.tools/installed` | `curl,git,jq` |
+| `io.docsclaw.tools/tier` | `standard` |
+| `io.docsclaw.tools/risk-score` | `4` |
+| `io.docsclaw.tools/agent-name` | `nps-assistant` |
+
+At runtime, `/etc/docsclaw/tools.json` provides the full
+inventory with versions and risk scores. The agent reads this at
+startup and injects the tool list into the system prompt so the
+LLM knows exactly which OS tools are available.
+
+## Skill compatibility
+
+Skills that include a `skill.yaml` with tool requirements are
+checked at build time:
+
+```
+Checking skill compatibility...
+
+  ✔ nps-api
+      required: curl ✔, jq ✔
+
+  ✘ doc-converter
+      required: pandoc ✗
+      → Add 'pandoc' to spec.tools or remove this skill
+```
+
+Skills without `skill.yaml` are flagged as unknown — no build
+failure, but tool errors may occur at runtime.
+
+## Quick reference
+
+```bash
+# Validate manifest
+docsclaw build --manifest agent-manifest.yaml --dry-run
+
+# Generate artifacts without building
+docsclaw build --manifest agent-manifest.yaml --output ./build/
+
+# Build and push image
+make agent-push MANIFEST=agent-manifest.yaml TAG=registry/image:tag
+
+# Build on remote RHEL host
+make agent-push MANIFEST=... TAG=... PODMAN_CONNECTION=rhel
+
+# Deploy with env secrets
+export LLM_API_KEY=sk-...
+docsclaw deploy --manifest agent-manifest.yaml | oc apply -f -
+
+# Deploy with flag secrets
+docsclaw deploy --manifest agent-manifest.yaml \
+  --secret LLM_API_KEY=sk-... | oc apply -f -
+```

--- a/docs/agent-manifest-guide.md
+++ b/docs/agent-manifest-guide.md
@@ -265,6 +265,24 @@ inventory with versions and risk scores. The agent reads this at
 startup and injects the tool list into the system prompt so the
 LLM knows exactly which OS tools are available.
 
+## Cluster requirements
+
+### Skill image volumes
+
+Skills listed in `spec.skills` are mounted as OCI image volumes
+using the Kubernetes `image:` volume source (KEP-4639). This
+requires:
+
+- **OpenShift 4.20+** with the `ImageVolumeSource` feature gate
+  enabled, or
+- **Kubernetes 1.31+** with the `ImageVolume` feature gate
+  enabled (alpha)
+
+If your cluster does not support image volumes, deploy skills
+via ConfigMaps or init containers instead. See the
+[OCI skills guide](oci-skills-guide.md) for alternative
+deployment methods.
+
 ## Skill compatibility
 
 Skills that include a `skill.yaml` with tool requirements are

--- a/docs/superpowers/plans/2026-05-20-agent-manifest.md
+++ b/docs/superpowers/plans/2026-05-20-agent-manifest.md
@@ -1,0 +1,1882 @@
+# Agent Manifest and Container Tooling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a declarative agent manifest (`agent-manifest.yaml`), a tiered tool catalog with risk scoring, and `docsclaw build`/`docsclaw deploy` commands that generate Containerfiles, K8s manifests, and OCI-annotated images from the manifest.
+
+**Architecture:** New `pkg/catalog` package defines the tool catalog with risk scores and tier metadata. New `pkg/manifest` package defines the AgentManifest type, parses/validates it, checks skill compatibility, and generates Containerfiles, `tools.json`, and K8s YAML. Two new Cobra subcommands (`build`, `deploy`) orchestrate the pipeline. At runtime, the agent reads `/etc/docsclaw/tools.json` and injects the available tool list into the system prompt.
+
+**Tech Stack:** Go stdlib (`text/template`, `embed`, `encoding/json`, `os`), Cobra/Viper (existing), `gopkg.in/yaml.v3` (existing dependency).
+
+**Design doc:** `docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md`
+
+---
+
+## Scope
+
+This plan covers the core infrastructure. The shopping cart web UI is a separate follow-up plan.
+
+| In scope | Out of scope (follow-up) |
+|----------|--------------------------|
+| Tool catalog types + embedded default | Shopping cart HTML UI |
+| Agent manifest parsing/validation | OCI registry skill.yaml fetching |
+| Containerfile generation | `--push` flag (build + push) |
+| K8s manifest generation | Build policy enforcement |
+| Compatibility checking (local skills) | Alpine/apk support |
+| `docsclaw build --output` | Image building (podman/docker exec) |
+| `docsclaw deploy` | |
+| Runtime tools.json loading | |
+| System prompt tool injection | |
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `pkg/catalog/types.go` | Create | ToolCatalog, ToolEntry, RiskScore types |
+| `pkg/catalog/catalog.go` | Create | Load, lookup, tier/risk helpers |
+| `pkg/catalog/catalog_test.go` | Create | Catalog loading and lookup tests |
+| `pkg/catalog/default.yaml` | Create | Embedded default tool catalog |
+| `pkg/manifest/types.go` | Create | AgentManifest, ManifestSpec types |
+| `pkg/manifest/parse.go` | Create | Parse + validate manifest YAML |
+| `pkg/manifest/parse_test.go` | Create | Parsing and validation tests |
+| `pkg/manifest/check.go` | Create | Skill compatibility checker |
+| `pkg/manifest/check_test.go` | Create | Compatibility checking tests |
+| `pkg/manifest/containerfile.go` | Create | Containerfile generator |
+| `pkg/manifest/containerfile_test.go` | Create | Containerfile generation tests |
+| `pkg/manifest/toolsjson.go` | Create | tools.json generator |
+| `pkg/manifest/toolsjson_test.go` | Create | tools.json tests |
+| `pkg/manifest/k8s.go` | Create | K8s manifest generator |
+| `pkg/manifest/k8s_test.go` | Create | K8s manifest generation tests |
+| `internal/cmd/build.go` | Create | `docsclaw build` Cobra command |
+| `internal/cmd/deploy.go` | Create | `docsclaw deploy` Cobra command |
+| `internal/cmd/serve.go` | Modify | Load tools.json, inject into prompt |
+| `testdata/manifest/nps-agent.yaml` | Create | Example agent manifest |
+| `testdata/manifest/bad-manifest.yaml` | Create | Invalid manifest for tests |
+
+---
+
+### Task 1: Tool catalog types and default catalog
+
+**Files:**
+- Create: `pkg/catalog/types.go`
+- Create: `pkg/catalog/catalog.go`
+- Create: `pkg/catalog/catalog_test.go`
+- Create: `pkg/catalog/default.yaml`
+
+- [ ] **Step 1: Write the catalog types**
+
+Create `pkg/catalog/types.go`:
+
+```go
+package catalog
+
+type ToolCatalog struct {
+	APIVersion string                `yaml:"apiVersion"`
+	Kind       string                `yaml:"kind"`
+	Metadata   CatalogMeta           `yaml:"metadata"`
+	Tiers      map[string]TierDef    `yaml:"tiers"`
+	Tools      map[string]ToolEntry  `yaml:"tools"`
+}
+
+type CatalogMeta struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type TierDef struct {
+	Description string `yaml:"description"`
+	AutoInclude bool   `yaml:"autoInclude,omitempty"`
+	Warning     string `yaml:"warning,omitempty"`
+}
+
+type ToolEntry struct {
+	Tier        string            `yaml:"tier"`
+	Package     map[string]string `yaml:"package"`
+	Size        string            `yaml:"size"`
+	Description string            `yaml:"description"`
+	Risk        RiskScore         `yaml:"risk"`
+}
+
+type RiskScore struct {
+	Score     int         `yaml:"score"`
+	Factors   RiskFactors `yaml:"factors"`
+	Rationale string      `yaml:"rationale"`
+}
+
+type RiskFactors struct {
+	CodeExecution  bool   `yaml:"codeExecution"`
+	NetworkCapable bool   `yaml:"networkCapable"`
+	Dependencies   int    `yaml:"dependencies"`
+	CVEHistory     string `yaml:"cveHistory"`
+}
+```
+
+- [ ] **Step 2: Write the catalog loader tests**
+
+Create `pkg/catalog/catalog_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func TestLoadDefault(t *testing.T) {
+	cat, err := LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
+	if cat.Metadata.Name != "docsclaw-default" {
+		t.Errorf("name = %q, want docsclaw-default", cat.Metadata.Name)
+	}
+	if _, ok := cat.Tools["curl"]; !ok {
+		t.Error("curl not in default catalog")
+	}
+	if _, ok := cat.Tools["jq"]; !ok {
+		t.Error("jq not in default catalog")
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	cat, err := LoadFromFile("testdata/custom-catalog.yaml")
+	if err != nil {
+		t.Fatalf("LoadFromFile() error: %v", err)
+	}
+	if cat.Metadata.Name != "test-catalog" {
+		t.Errorf("name = %q, want test-catalog", cat.Metadata.Name)
+	}
+}
+
+func TestLookupTool(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	entry, ok := cat.Lookup("curl")
+	if !ok {
+		t.Fatal("curl not found")
+	}
+	if entry.Tier != "core" {
+		t.Errorf("curl tier = %q, want core", entry.Tier)
+	}
+
+	_, ok = cat.Lookup("nonexistent")
+	if ok {
+		t.Error("nonexistent tool should not be found")
+	}
+}
+
+func TestCoreTierTools(t *testing.T) {
+	cat, _ := LoadDefault()
+	core := cat.CoreTools()
+	if len(core) == 0 {
+		t.Fatal("no core tools found")
+	}
+	for _, name := range core {
+		entry, _ := cat.Lookup(name)
+		if entry.Tier != "core" {
+			t.Errorf("%s tier = %q, want core", name, entry.Tier)
+		}
+	}
+}
+
+func TestHighestTier(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	tests := []struct {
+		tools []string
+		want  string
+	}{
+		{[]string{"curl", "jq"}, "core"},
+		{[]string{"curl", "git"}, "standard"},
+		{[]string{"curl", "pandoc"}, "extended"},
+		{[]string{"curl", "python3"}, "runtime"},
+	}
+	for _, tt := range tests {
+		got := cat.HighestTier(tt.tools)
+		if got != tt.want {
+			t.Errorf("HighestTier(%v) = %q, want %q", tt.tools, got, tt.want)
+		}
+	}
+}
+
+func TestMaxRiskScore(t *testing.T) {
+	cat, _ := LoadDefault()
+	score := cat.MaxRiskScore([]string{"curl", "jq"})
+	if score < 1 || score > 3 {
+		t.Errorf("core-only risk score = %d, expected 1-3", score)
+	}
+
+	score = cat.MaxRiskScore([]string{"curl", "python3"})
+	if score < 7 {
+		t.Errorf("python3 risk score = %d, expected >= 7", score)
+	}
+}
+
+func TestPackageName(t *testing.T) {
+	cat, _ := LoadDefault()
+	entry, _ := cat.Lookup("openssh-client")
+	if entry.Package["dnf"] != "openssh-clients" {
+		t.Errorf("openssh-client dnf package = %q, want openssh-clients", entry.Package["dnf"])
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/catalog/ -v`
+Expected: compilation errors — `LoadDefault`, `Lookup`, etc. not defined.
+
+- [ ] **Step 4: Create the default catalog YAML**
+
+Create `pkg/catalog/default.yaml` with the catalog from the design
+spec (all 9 tools: curl, jq, git, openssh-client, pandoc,
+poppler-utils, imagemagick, python3, nodejs).
+
+- [ ] **Step 5: Write the catalog loader**
+
+Create `pkg/catalog/catalog.go`:
+
+```go
+package catalog
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed default.yaml
+var defaultCatalog embed.FS
+
+var tierOrder = map[string]int{
+	"core":     0,
+	"standard": 1,
+	"extended": 2,
+	"runtime":  3,
+}
+
+func LoadDefault() (*ToolCatalog, error) {
+	data, err := defaultCatalog.ReadFile("default.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded catalog: %w", err)
+	}
+	return parse(data)
+}
+
+func LoadFromFile(path string) (*ToolCatalog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %s: %w", path, err)
+	}
+	return parse(data)
+}
+
+func parse(data []byte) (*ToolCatalog, error) {
+	var cat ToolCatalog
+	if err := yaml.Unmarshal(data, &cat); err != nil {
+		return nil, fmt.Errorf("parse catalog: %w", err)
+	}
+	return &cat, nil
+}
+
+func (c *ToolCatalog) Lookup(name string) (ToolEntry, bool) {
+	entry, ok := c.Tools[name]
+	return entry, ok
+}
+
+func (c *ToolCatalog) CoreTools() []string {
+	var names []string
+	for name, entry := range c.Tools {
+		if entry.Tier == "core" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (c *ToolCatalog) HighestTier(tools []string) string {
+	highest := "core"
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if tierOrder[entry.Tier] > tierOrder[highest] {
+			highest = entry.Tier
+		}
+	}
+	return highest
+}
+
+func (c *ToolCatalog) MaxRiskScore(tools []string) int {
+	max := 0
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if entry.Risk.Score > max {
+			max = entry.Risk.Score
+		}
+	}
+	return max
+}
+
+func (c *ToolCatalog) PackageNames(tools []string, distro string) []string {
+	var pkgs []string
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if pkg, ok := entry.Package[distro]; ok {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs
+}
+
+func (c *ToolCatalog) Validate(tools []string) error {
+	for _, name := range tools {
+		if _, ok := c.Tools[name]; !ok {
+			return fmt.Errorf("unknown tool %q not in catalog", name)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Create test fixture for custom catalog**
+
+Create `pkg/catalog/testdata/custom-catalog.yaml`:
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: ToolCatalog
+metadata:
+  name: test-catalog
+  version: 1.0.0
+tiers:
+  core:
+    description: "Always included"
+    autoInclude: true
+tools:
+  curl:
+    tier: core
+    package: { dnf: curl, apk: curl }
+    size: ~1MB
+    description: "HTTP client"
+    risk:
+      score: 2
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 2
+        cveHistory: low
+      rationale: "Network-capable but single-purpose"
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/catalog/ -v`
+Expected: all tests PASS.
+
+- [ ] **Step 8: Run linter**
+
+Run: `cd /Users/panni/work/docsclaw && golangci-lint run ./pkg/catalog/`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/catalog/
+git commit -s -m "feat: add tool catalog with risk scoring
+
+Tiered tool catalog (core/standard/extended/runtime) with per-tool
+risk scores, distro-specific package names, and embedded default
+catalog."
+```
+
+---
+
+### Task 2: Agent manifest types and parsing
+
+**Files:**
+- Create: `pkg/manifest/types.go`
+- Create: `pkg/manifest/parse.go`
+- Create: `pkg/manifest/parse_test.go`
+- Create: `testdata/manifest/nps-agent.yaml`
+- Create: `testdata/manifest/bad-manifest.yaml`
+
+- [ ] **Step 1: Write the manifest types**
+
+Create `pkg/manifest/types.go`:
+
+```go
+package manifest
+
+type AgentManifest struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Metadata   ManifestMeta `yaml:"metadata"`
+	Spec       ManifestSpec `yaml:"spec"`
+}
+
+type ManifestMeta struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type ManifestSpec struct {
+	Base    BaseImage      `yaml:"base"`
+	Tools   []string       `yaml:"tools"`
+	Prompt  PromptConfig   `yaml:"prompt"`
+	Skills  []SkillRef     `yaml:"skills"`
+	Runtime RuntimeConfig  `yaml:"runtime,omitempty"`
+	Secrets []SecretDecl   `yaml:"secrets,omitempty"`
+	Deploy  DeployConfig   `yaml:"deploy,omitempty"`
+}
+
+type BaseImage struct {
+	Image   string `yaml:"image"`
+	Builder string `yaml:"builder"`
+}
+
+type PromptConfig struct {
+	Text   string       `yaml:"text,omitempty"`
+	Source *PromptSource `yaml:"source,omitempty"`
+}
+
+type PromptSource struct {
+	Git  string `yaml:"git"`
+	Path string `yaml:"path"`
+	Ref  string `yaml:"ref"`
+}
+
+type SkillRef struct {
+	Name  string `yaml:"name"`
+	Image string `yaml:"image"`
+}
+
+type RuntimeConfig struct {
+	Tools RuntimeToolsConfig `yaml:"tools"`
+	Loop  RuntimeLoopConfig  `yaml:"loop"`
+}
+
+type RuntimeToolsConfig struct {
+	Allowed  []string        `yaml:"allowed"`
+	Exec     ExecConfig      `yaml:"exec,omitempty"`
+	WebFetch WebFetchConfig  `yaml:"webFetch,omitempty"`
+}
+
+type ExecConfig struct {
+	Timeout   int `yaml:"timeout,omitempty"`
+	MaxOutput int `yaml:"maxOutput,omitempty"`
+}
+
+type WebFetchConfig struct {
+	AllowedHosts []string `yaml:"allowedHosts,omitempty"`
+}
+
+type RuntimeLoopConfig struct {
+	MaxIterations int `yaml:"maxIterations,omitempty"`
+}
+
+type SecretDecl struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Required    bool   `yaml:"required"`
+}
+
+type DeployConfig struct {
+	Replicas  int             `yaml:"replicas,omitempty"`
+	Resources ResourceConfig  `yaml:"resources,omitempty"`
+}
+
+type ResourceConfig struct {
+	Requests ResourceValues `yaml:"requests,omitempty"`
+	Limits   ResourceValues `yaml:"limits,omitempty"`
+}
+
+type ResourceValues struct {
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
+}
+```
+
+- [ ] **Step 2: Create test fixtures**
+
+Create `testdata/manifest/nps-agent.yaml`:
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: nps-assistant
+  version: 1.0.0
+spec:
+  base:
+    image: registry.access.redhat.com/hi/core-runtime:latest
+    builder: registry.access.redhat.com/hi/core-runtime:latest-builder
+  tools:
+    - curl
+    - jq
+    - git
+  prompt:
+    text: |
+      You are a national parks assistant.
+  skills:
+    - name: nps-api
+      image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+  runtime:
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - web_fetch
+        - load_skill
+      exec:
+        timeout: 30
+        maxOutput: 50000
+    loop:
+      maxIterations: 15
+  secrets:
+    - name: NPS_API_KEY
+      description: "API key for developer.nps.gov"
+      required: true
+    - name: LLM_API_KEY
+      description: "LLM provider API key"
+      required: true
+  deploy:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+Create `testdata/manifest/bad-manifest.yaml`:
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: ""
+spec:
+  base:
+    image: ""
+  tools: []
+  prompt: {}
+```
+
+- [ ] **Step 3: Write parsing tests**
+
+Create `pkg/manifest/parse_test.go`:
+
+```go
+package manifest
+
+import "testing"
+
+func TestParseValid(t *testing.T) {
+	m, err := ParseFile("../../testdata/manifest/nps-agent.yaml")
+	if err != nil {
+		t.Fatalf("ParseFile() error: %v", err)
+	}
+	if m.Metadata.Name != "nps-assistant" {
+		t.Errorf("name = %q, want nps-assistant", m.Metadata.Name)
+	}
+	if m.Spec.Base.Image == "" {
+		t.Error("base image is empty")
+	}
+	if len(m.Spec.Tools) != 3 {
+		t.Errorf("tools count = %d, want 3", len(m.Spec.Tools))
+	}
+	if m.Spec.Prompt.Text == "" {
+		t.Error("prompt text is empty")
+	}
+	if len(m.Spec.Skills) != 1 {
+		t.Errorf("skills count = %d, want 1", len(m.Spec.Skills))
+	}
+	if len(m.Spec.Secrets) != 2 {
+		t.Errorf("secrets count = %d, want 2", len(m.Spec.Secrets))
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	_, err := ParseFile("../../testdata/manifest/bad-manifest.yaml")
+	if err == nil {
+		t.Fatal("expected validation error for bad manifest")
+	}
+}
+
+func TestValidate_MissingName(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Spec: ManifestSpec{
+			Base:  BaseImage{Image: "some-image"},
+			Tools: []string{"curl"},
+			Prompt: PromptConfig{Text: "hello"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestValidate_MissingBaseImage(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Metadata:   ManifestMeta{Name: "test"},
+		Spec: ManifestSpec{
+			Tools:  []string{"curl"},
+			Prompt: PromptConfig{Text: "hello"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing base image")
+	}
+}
+
+func TestValidate_MissingPrompt(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Metadata:   ManifestMeta{Name: "test"},
+		Spec: ManifestSpec{
+			Base:  BaseImage{Image: "some-image"},
+			Tools: []string{"curl"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing prompt")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestParse`
+Expected: compilation errors — `ParseFile`, `Validate` not defined.
+
+- [ ] **Step 5: Write the parser and validator**
+
+Create `pkg/manifest/parse.go`:
+
+```go
+package manifest
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ParseFile(path string) (*AgentManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	return Parse(data)
+}
+
+func Parse(data []byte) (*AgentManifest, error) {
+	var m AgentManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	if err := Validate(m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func Validate(m AgentManifest) error {
+	if m.Metadata.Name == "" {
+		return fmt.Errorf("metadata.name is required")
+	}
+	if m.Spec.Base.Image == "" {
+		return fmt.Errorf("spec.base.image is required")
+	}
+	if m.Spec.Prompt.Text == "" && m.Spec.Prompt.Source == nil {
+		return fmt.Errorf("spec.prompt.text or spec.prompt.source is required")
+	}
+	if m.Spec.Prompt.Text != "" && m.Spec.Prompt.Source != nil {
+		return fmt.Errorf("spec.prompt.text and spec.prompt.source are mutually exclusive")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestParse`
+Expected: all tests PASS.
+
+- [ ] **Step 7: Run linter**
+
+Run: `cd /Users/panni/work/docsclaw && golangci-lint run ./pkg/manifest/`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/manifest/types.go pkg/manifest/parse.go \
+  pkg/manifest/parse_test.go testdata/manifest/
+git commit -s -m "feat: add agent manifest types and parser
+
+AgentManifest declares base image, OS tools, system prompt, skills,
+secrets, and deployment config. Validation ensures required fields
+are present."
+```
+
+---
+
+### Task 3: Skill compatibility checker
+
+**Files:**
+- Create: `pkg/manifest/check.go`
+- Create: `pkg/manifest/check_test.go`
+
+- [ ] **Step 1: Write the compatibility check types and tests**
+
+Create `pkg/manifest/check_test.go`:
+
+```go
+package manifest
+
+import (
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+	skillcard "github.com/redhat-et/docsclaw/pkg/skills/card"
+)
+
+func TestCheckCompatibility_AllSatisfied(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{Name: "nps-api", Required: []string{"curl", "jq"}},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if len(results) != 1 {
+		t.Fatalf("results count = %d, want 1", len(results))
+	}
+	if !results[0].Satisfied {
+		t.Error("nps-api should be satisfied")
+	}
+	if len(results[0].MissingRequired) != 0 {
+		t.Errorf("missing required = %v, want none", results[0].MissingRequired)
+	}
+}
+
+func TestCheckCompatibility_MissingRequired(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{Name: "doc-converter", Required: []string{"curl", "pandoc"}},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if results[0].Satisfied {
+		t.Error("doc-converter should NOT be satisfied")
+	}
+	if len(results[0].MissingRequired) != 1 || results[0].MissingRequired[0] != "pandoc" {
+		t.Errorf("missing required = %v, want [pandoc]", results[0].MissingRequired)
+	}
+}
+
+func TestCheckCompatibility_OptionalMissing(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{
+			Name:     "nps-api",
+			Required: []string{"curl", "jq"},
+			Optional: []string{"python3"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if !results[0].Satisfied {
+		t.Error("should be satisfied (optional missing is OK)")
+	}
+	if len(results[0].MissingOptional) != 1 || results[0].MissingOptional[0] != "python3" {
+		t.Errorf("missing optional = %v, want [python3]", results[0].MissingOptional)
+	}
+}
+
+func TestCheckCompatibility_NoSkillYAML(t *testing.T) {
+	tools := []string{"curl"}
+	skills := []SkillCheck{
+		{Name: "unknown-skill", HasSkillYAML: false},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if !results[0].Satisfied {
+		t.Error("skill without skill.yaml should be marked satisfied")
+	}
+	if !results[0].Unknown {
+		t.Error("should be marked as unknown requirements")
+	}
+}
+
+func TestSkillCheckFromCard(t *testing.T) {
+	card := skillcard.SkillCard{
+		Metadata: skillcard.SkillCardMeta{Name: "test-skill"},
+		Spec: skillcard.SkillCardSpec{
+			Tools: skillcard.ToolDeps{
+				Required: []string{"curl"},
+				Optional: []string{"jq"},
+			},
+		},
+	}
+	sc := SkillCheckFromCard(card)
+	if sc.Name != "test-skill" {
+		t.Errorf("name = %q, want test-skill", sc.Name)
+	}
+	if !sc.HasSkillYAML {
+		t.Error("should have HasSkillYAML = true")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestCheck`
+Expected: compilation errors.
+
+- [ ] **Step 3: Write the compatibility checker**
+
+Create `pkg/manifest/check.go`:
+
+```go
+package manifest
+
+import (
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+	skillcard "github.com/redhat-et/docsclaw/pkg/skills/card"
+)
+
+type SkillCheck struct {
+	Name         string
+	Required     []string
+	Optional     []string
+	HasSkillYAML bool
+}
+
+type CheckResult struct {
+	SkillName       string
+	Satisfied       bool
+	Unknown         bool
+	MissingRequired []string
+	MissingOptional []string
+}
+
+func SkillCheckFromCard(card skillcard.SkillCard) SkillCheck {
+	return SkillCheck{
+		Name:         card.Metadata.Name,
+		Required:     card.Spec.Tools.Required,
+		Optional:     card.Spec.Tools.Optional,
+		HasSkillYAML: true,
+	}
+}
+
+func CheckCompatibility(manifestTools []string, skills []SkillCheck, cat *catalog.ToolCatalog) []CheckResult {
+	installed := make(map[string]bool, len(manifestTools))
+	for _, t := range manifestTools {
+		installed[t] = true
+	}
+	for _, name := range cat.CoreTools() {
+		installed[name] = true
+	}
+
+	var results []CheckResult
+	for _, skill := range skills {
+		r := CheckResult{SkillName: skill.Name}
+
+		if !skill.HasSkillYAML {
+			r.Satisfied = true
+			r.Unknown = true
+			results = append(results, r)
+			continue
+		}
+
+		r.Satisfied = true
+		for _, req := range skill.Required {
+			if !installed[req] {
+				r.MissingRequired = append(r.MissingRequired, req)
+				r.Satisfied = false
+			}
+		}
+		for _, opt := range skill.Optional {
+			if !installed[opt] {
+				r.MissingOptional = append(r.MissingOptional, opt)
+			}
+		}
+		results = append(results, r)
+	}
+	return results
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestCheck`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/manifest/check.go pkg/manifest/check_test.go
+git commit -s -m "feat: add skill compatibility checker
+
+Validates that manifest tools satisfy skill requirements from
+skill.yaml. Reports missing required and optional tools. Skills
+without skill.yaml are flagged as unknown."
+```
+
+---
+
+### Task 4: Containerfile generator
+
+**Files:**
+- Create: `pkg/manifest/containerfile.go`
+- Create: `pkg/manifest/containerfile_test.go`
+
+- [ ] **Step 1: Write Containerfile generation tests**
+
+Create `pkg/manifest/containerfile_test.go`:
+
+```go
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+func TestGenerateContainerfile_HardenedImage(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "test-agent"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
+				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+			},
+			Tools: []string{"curl", "jq", "git"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateContainerfile() error: %v", err)
+	}
+
+	checks := []string{
+		"FROM registry.access.redhat.com/hi/core-runtime:latest",
+		"io.docsclaw.tools/installed",
+		"curl,git,jq",
+		"--mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-builder",
+		"/builder/usr/bin/dnf install -y",
+		"curl git jq",
+		"USER 65532",
+		"COPY docsclaw /app/docsclaw",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestGenerateContainerfile_Labels(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "my-agent"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
+				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+			},
+			Tools: []string{"curl", "jq", "python3"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateContainerfile() error: %v", err)
+	}
+
+	if !strings.Contains(out, `io.docsclaw.tools/tier="runtime"`) {
+		t.Error("missing tier label for runtime")
+	}
+	if !strings.Contains(out, `io.docsclaw.tools/agent-name="my-agent"`) {
+		t.Error("missing agent-name label")
+	}
+}
+
+func TestGenerateContainerfile_CoreOnlyNoBuilder(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "minimal"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image: "registry.access.redhat.com/hi/core-runtime:latest",
+			},
+			Tools: []string{"curl", "jq"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(out, "FROM registry.access.redhat.com/hi/core-runtime:latest") {
+		t.Error("missing FROM line")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateContainerfile`
+Expected: compilation errors.
+
+- [ ] **Step 3: Write the Containerfile generator**
+
+Create `pkg/manifest/containerfile.go`:
+
+```go
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+var containerfileTmpl = template.Must(template.New("containerfile").Parse(`FROM {{ .BaseImage }}
+
+LABEL io.docsclaw.tools/installed="{{ .InstalledCSV }}"
+LABEL io.docsclaw.tools/tier="{{ .HighestTier }}"
+LABEL io.docsclaw.tools/risk-score="{{ .RiskScore }}"
+LABEL io.docsclaw.tools/agent-name="{{ .AgentName }}"
+{{ if .HasBuilder }}
+# Adding tools to the minimal hardened image expands its attack surface.
+# Only add what is strictly necessary for runtime operation.
+# Review each addition with your security team.
+USER root
+RUN --mount=type=bind,from={{ .BuilderImage }},target=/builder \
+    LD_LIBRARY_PATH=/builder/lib64:/builder/usr/lib64 \
+    RPM_CONFIGDIR=/builder/usr/lib/rpm \
+    /builder/usr/bin/dnf install -y \
+    --installroot=/ \
+    --setopt=reposdir=/builder/etc/yum.repos.d \
+    --setopt=install_weak_deps=False \
+    --setopt=tsflags=nodocs \
+    {{ .PackageList }}
+USER 65532
+{{ end }}
+WORKDIR /app
+COPY docsclaw /app/docsclaw
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docsclaw"]
+CMD ["serve"]
+`))
+
+type containerfileData struct {
+	BaseImage    string
+	BuilderImage string
+	HasBuilder   bool
+	AgentName    string
+	InstalledCSV string
+	HighestTier  string
+	RiskScore    int
+	PackageList  string
+}
+
+func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, error) {
+	allTools := mergeWithCore(m.Spec.Tools, cat)
+	sort.Strings(allTools)
+
+	pkgs := cat.PackageNames(allTools, "dnf")
+	sort.Strings(pkgs)
+
+	data := containerfileData{
+		BaseImage:    m.Spec.Base.Image,
+		BuilderImage: m.Spec.Base.Builder,
+		HasBuilder:   m.Spec.Base.Builder != "",
+		AgentName:    m.Metadata.Name,
+		InstalledCSV: strings.Join(allTools, ","),
+		HighestTier:  cat.HighestTier(allTools),
+		RiskScore:    cat.MaxRiskScore(allTools),
+		PackageList:  strings.Join(pkgs, " "),
+	}
+
+	var buf bytes.Buffer
+	if err := containerfileTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("render containerfile: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func mergeWithCore(tools []string, cat *catalog.ToolCatalog) []string {
+	seen := make(map[string]bool)
+	var merged []string
+	for _, name := range cat.CoreTools() {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	for _, name := range tools {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	return merged
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateContainerfile`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/manifest/containerfile.go pkg/manifest/containerfile_test.go
+git commit -s -m "feat: add Containerfile generator from agent manifest
+
+Generates Containerfile with dnf bind-mount pattern, OCI annotation
+labels (installed tools, tier, risk score, agent name), and hardened
+image security comment."
+```
+
+---
+
+### Task 5: tools.json generator
+
+**Files:**
+- Create: `pkg/manifest/toolsjson.go`
+- Create: `pkg/manifest/toolsjson_test.go`
+
+- [ ] **Step 1: Write tools.json generation tests**
+
+Create `pkg/manifest/toolsjson_test.go`:
+
+```go
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+func TestGenerateToolsJSON(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "test-agent", Version: "1.0.0"},
+		Spec: ManifestSpec{
+			Base: BaseImage{Image: "hi/core-runtime:latest"},
+			Tools: []string{"curl", "jq", "git"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	data, err := GenerateToolsJSON(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateToolsJSON() error: %v", err)
+	}
+
+	var tj ToolsJSON
+	if err := json.Unmarshal(data, &tj); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if tj.AgentName != "test-agent" {
+		t.Errorf("agentName = %q, want test-agent", tj.AgentName)
+	}
+	if tj.HighestTier != "standard" {
+		t.Errorf("highestTier = %q, want standard", tj.HighestTier)
+	}
+	if len(tj.Tools) != 3 {
+		t.Errorf("tools count = %d, want 3", len(tj.Tools))
+	}
+
+	found := false
+	for _, tool := range tj.Tools {
+		if tool.Name == "git" {
+			found = true
+			if tool.Tier != "standard" {
+				t.Errorf("git tier = %q, want standard", tool.Tier)
+			}
+		}
+	}
+	if !found {
+		t.Error("git not in tools list")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateToolsJSON`
+Expected: compilation errors.
+
+- [ ] **Step 3: Write the tools.json generator**
+
+Create `pkg/manifest/toolsjson.go`:
+
+```go
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+type ToolsJSON struct {
+	ManifestVersion string         `json:"manifestVersion"`
+	AgentName       string         `json:"agentName"`
+	Base            string         `json:"base"`
+	HighestTier     string         `json:"highestTier"`
+	RiskScore       int            `json:"riskScore"`
+	Tools           []ToolJSONEntry `json:"tools"`
+}
+
+type ToolJSONEntry struct {
+	Name           string `json:"name"`
+	Package        string `json:"package"`
+	Tier           string `json:"tier"`
+	Risk           ToolJSONRisk `json:"risk"`
+}
+
+type ToolJSONRisk struct {
+	Score          int  `json:"score"`
+	CodeExecution  bool `json:"codeExecution"`
+	NetworkCapable bool `json:"networkCapable"`
+}
+
+func GenerateToolsJSON(m *AgentManifest, cat *catalog.ToolCatalog) ([]byte, error) {
+	allTools := mergeWithCore(m.Spec.Tools, cat)
+	sort.Strings(allTools)
+
+	tj := ToolsJSON{
+		ManifestVersion: m.Metadata.Version,
+		AgentName:       m.Metadata.Name,
+		Base:            m.Spec.Base.Image,
+		HighestTier:     cat.HighestTier(allTools),
+		RiskScore:       cat.MaxRiskScore(allTools),
+	}
+
+	for _, name := range allTools {
+		entry, ok := cat.Lookup(name)
+		if !ok {
+			continue
+		}
+		tj.Tools = append(tj.Tools, ToolJSONEntry{
+			Name:    name,
+			Package: entry.Package["dnf"],
+			Tier:    entry.Tier,
+			Risk: ToolJSONRisk{
+				Score:          entry.Risk.Score,
+				CodeExecution:  entry.Risk.Factors.CodeExecution,
+				NetworkCapable: entry.Risk.Factors.NetworkCapable,
+			},
+		})
+	}
+
+	data, err := json.MarshalIndent(tj, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal tools.json: %w", err)
+	}
+	return data, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateToolsJSON`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/manifest/toolsjson.go pkg/manifest/toolsjson_test.go
+git commit -s -m "feat: add tools.json generator for runtime metadata
+
+Generates /etc/docsclaw/tools.json with installed tool inventory,
+tier, risk scores for runtime compatibility checking."
+```
+
+---
+
+### Task 6: K8s manifest generator
+
+**Files:**
+- Create: `pkg/manifest/k8s.go`
+- Create: `pkg/manifest/k8s_test.go`
+
+- [ ] **Step 1: Write K8s generation tests**
+
+Create `pkg/manifest/k8s_test.go`:
+
+```go
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateK8s_ConfigMap(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("GenerateK8s() error: %v", err)
+	}
+
+	if !strings.Contains(k8s.ConfigMap, "kind: ConfigMap") {
+		t.Error("missing ConfigMap kind")
+	}
+	if !strings.Contains(k8s.ConfigMap, "name: nps-assistant-config") {
+		t.Error("missing ConfigMap name")
+	}
+	if !strings.Contains(k8s.ConfigMap, "system-prompt.txt") {
+		t.Error("missing system-prompt.txt key")
+	}
+	if !strings.Contains(k8s.ConfigMap, "agent-config.yaml") {
+		t.Error("missing agent-config.yaml key")
+	}
+}
+
+func TestGenerateK8s_Deployment(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(k8s.Deployment, "kind: Deployment") {
+		t.Error("missing Deployment kind")
+	}
+	if !strings.Contains(k8s.Deployment, "runAsNonRoot: true") {
+		t.Error("missing security context")
+	}
+	if !strings.Contains(k8s.Deployment, "skill-nps-api") {
+		t.Error("missing skill volume")
+	}
+}
+
+func TestGenerateK8s_Secret(t *testing.T) {
+	m := testManifest()
+	secrets := map[string]string{
+		"NPS_API_KEY": "test-key",
+		"LLM_API_KEY": "test-llm",
+	}
+	k8s, err := GenerateK8s(m, secrets)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if k8s.Secret == "" {
+		t.Fatal("secret should be generated when values provided")
+	}
+	if !strings.Contains(k8s.Secret, "kind: Secret") {
+		t.Error("missing Secret kind")
+	}
+}
+
+func TestGenerateK8s_NoSecrets(t *testing.T) {
+	m := testManifest()
+	m.Spec.Secrets = nil
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if k8s.Secret != "" {
+		t.Error("should not generate secret when none declared")
+	}
+}
+
+func TestGenerateK8s_Service(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(k8s.Service, "kind: Service") {
+		t.Error("missing Service kind")
+	}
+	if !strings.Contains(k8s.Service, "port: 8000") {
+		t.Error("missing http port")
+	}
+}
+
+func testManifest() *AgentManifest {
+	return &AgentManifest{
+		Metadata: ManifestMeta{Name: "nps-assistant", Version: "1.0.0"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image: "ghcr.io/redhat-et/docsclaw:latest",
+			},
+			Tools: []string{"curl", "jq"},
+			Prompt: PromptConfig{
+				Text: "You are a national parks assistant.",
+			},
+			Skills: []SkillRef{
+				{Name: "nps-api", Image: "quay.io/docsclaw/skill-nps-api:1.0.0-image"},
+			},
+			Runtime: RuntimeConfig{
+				Tools: RuntimeToolsConfig{
+					Allowed: []string{"exec", "read_file", "load_skill"},
+					Exec:    ExecConfig{Timeout: 30, MaxOutput: 50000},
+				},
+				Loop: RuntimeLoopConfig{MaxIterations: 15},
+			},
+			Secrets: []SecretDecl{
+				{Name: "NPS_API_KEY", Required: true},
+				{Name: "LLM_API_KEY", Required: true},
+			},
+			Deploy: DeployConfig{
+				Replicas: 1,
+				Resources: ResourceConfig{
+					Requests: ResourceValues{CPU: "100m", Memory: "64Mi"},
+					Limits:   ResourceValues{CPU: "500m", Memory: "256Mi"},
+				},
+			},
+		},
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateK8s`
+Expected: compilation errors.
+
+- [ ] **Step 3: Write the K8s manifest generator**
+
+Create `pkg/manifest/k8s.go`. This file generates ConfigMap,
+Deployment, Service, ServiceAccount, and Secret YAML using
+`text/template`. The Deployment template includes security context
+(runAsNonRoot, drop ALL, readOnlyRootFilesystem), skill image
+volumes, health probes, and resource limits from the manifest.
+
+The `K8sOutput` struct holds each generated YAML as a string field:
+
+```go
+type K8sOutput struct {
+	ConfigMap      string
+	Deployment     string
+	Service        string
+	ServiceAccount string
+	Secret         string
+}
+
+func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error)
+```
+
+Key template logic:
+- ConfigMap data keys: `system-prompt.txt` (from `m.Spec.Prompt.Text`),
+  `agent-config.yaml` (generated from `m.Spec.Runtime`)
+- Deployment volumes: `agent-config` ConfigMap volume + one
+  `image:` volume per skill in `m.Spec.Skills`
+- Secret: only generated when `m.Spec.Secrets` is non-empty and
+  `secrets` map is provided. Uses `base64.StdEncoding` for values.
+  Deployment references it via `envFrom.secretRef`.
+
+Follow the pattern from the existing skillimage demo
+(`~/work/skillimage/site/demo/index.html` lines 1144-1315) for
+the YAML structure.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./pkg/manifest/ -v -run TestGenerateK8s`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/manifest/k8s.go pkg/manifest/k8s_test.go
+git commit -s -m "feat: add K8s manifest generator from agent manifest
+
+Generates ConfigMap, Deployment, Service, ServiceAccount, and Secret
+YAML with hardened security context and skill image volumes."
+```
+
+---
+
+### Task 7: `docsclaw build` command
+
+**Files:**
+- Create: `internal/cmd/build.go`
+
+- [ ] **Step 1: Write the build command**
+
+Create `internal/cmd/build.go`. Register it in `root.go` via
+`rootCmd.AddCommand(buildCmd)`.
+
+The command:
+- Flags: `--manifest` (required), `--output` (directory),
+  `--only` (containerfile|k8s), `--dry-run`, `--catalog` (optional
+  custom catalog path), `--max-risk` (int, 0 = no limit)
+- Validates manifest against schema
+- Loads tool catalog (default + optional custom)
+- Validates all tools exist in catalog
+- Runs compatibility check (for skills with local skill.yaml)
+- Prints compatibility report to stderr
+- If `--dry-run`: print report and exit
+- If `--max-risk N` and risk > N: fail with error
+- If `--output`: generate files to directory
+- Default (no `--output`): print generated Containerfile to stdout
+
+```go
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build agent image from manifest",
+	Long:  "Generate Containerfile and K8s manifests from an agent manifest.",
+	RunE:  runBuild,
+}
+
+func init() {
+	buildCmd.Flags().String("manifest", "", "path to agent-manifest.yaml (required)")
+	buildCmd.Flags().String("output", "", "directory to write generated files")
+	buildCmd.Flags().String("only", "", "generate only: containerfile, k8s")
+	buildCmd.Flags().Bool("dry-run", false, "print compatibility report only")
+	buildCmd.Flags().String("catalog", "", "path to custom tool catalog")
+	buildCmd.Flags().Int("max-risk", 0, "max allowed risk score (0 = no limit)")
+	_ = buildCmd.MarkFlagRequired("manifest")
+}
+```
+
+The `runBuild` function orchestrates the pipeline:
+
+1. `manifest.ParseFile(manifestPath)`
+2. `catalog.LoadDefault()` (or `LoadFromFile` if `--catalog`)
+3. `cat.Validate(m.Spec.Tools)` — fail on unknown tools
+4. Print risk score and tier to stderr
+5. If `--dry-run`: exit
+6. `manifest.GenerateContainerfile(m, cat)`
+7. `manifest.GenerateToolsJSON(m, cat)`
+8. `manifest.GenerateK8s(m, nil)` (if not `--only containerfile`)
+9. If `--output`: write files to directory; else print to stdout
+
+- [ ] **Step 2: Register the command in root.go**
+
+Add `rootCmd.AddCommand(buildCmd)` to `internal/cmd/root.go` in
+the `init()` function, alongside the existing `serveCmd` and
+`chatCmd` registrations.
+
+- [ ] **Step 3: Test the command manually**
+
+Run: `cd /Users/panni/work/docsclaw && go run ./cmd/docsclaw build --manifest testdata/manifest/nps-agent.yaml --dry-run`
+Expected: prints compatibility report with tool list and risk score.
+
+Run: `cd /Users/panni/work/docsclaw && go run ./cmd/docsclaw build --manifest testdata/manifest/nps-agent.yaml --output /tmp/docsclaw-build-test`
+Expected: generates files in `/tmp/docsclaw-build-test/`.
+
+- [ ] **Step 4: Run linter**
+
+Run: `cd /Users/panni/work/docsclaw && golangci-lint run ./internal/cmd/`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmd/build.go internal/cmd/root.go
+git commit -s -m "feat: add docsclaw build command
+
+Reads agent manifest, validates tools against catalog, checks skill
+compatibility, and generates Containerfile + K8s manifests to an
+output directory."
+```
+
+---
+
+### Task 8: `docsclaw deploy` command
+
+**Files:**
+- Create: `internal/cmd/deploy.go`
+
+- [ ] **Step 1: Write the deploy command**
+
+Create `internal/cmd/deploy.go`. Register it in `root.go`.
+
+The command:
+- Flags: `--manifest` (required), `--secret` (string slice,
+  `NAME=value`), `--output` (directory, optional)
+- Resolves secrets: `--secret` flag > environment variable >
+  fail if required
+- Calls `manifest.GenerateK8s(m, resolvedSecrets)`
+- If `--output`: write files to directory
+- Default: print all manifests joined by `---` to stdout
+  (pipeable to `oc apply -f -`)
+
+```go
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Generate K8s manifests from agent manifest",
+	Long:  "Resolve secrets and generate deployment manifests.",
+	RunE:  runDeploy,
+}
+
+func init() {
+	deployCmd.Flags().String("manifest", "", "path to agent-manifest.yaml (required)")
+	deployCmd.Flags().StringSlice("secret", nil, "secret values as NAME=value")
+	deployCmd.Flags().String("output", "", "directory to write generated files")
+	_ = deployCmd.MarkFlagRequired("manifest")
+}
+```
+
+Secret resolution in `runDeploy`:
+
+```go
+func resolveSecrets(decls []manifest.SecretDecl, flagSecrets []string) (map[string]string, error) {
+	overrides := make(map[string]string)
+	for _, s := range flagSecrets {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --secret format: %q (expected NAME=value)", s)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+
+	resolved := make(map[string]string)
+	for _, decl := range decls {
+		if v, ok := overrides[decl.Name]; ok {
+			resolved[decl.Name] = v
+		} else if v := os.Getenv(decl.Name); v != "" {
+			resolved[decl.Name] = v
+		} else if decl.Required {
+			return nil, fmt.Errorf("required secret %q not set (use --secret %s=value or export %s)", decl.Name, decl.Name, decl.Name)
+		}
+	}
+	return resolved, nil
+}
+```
+
+- [ ] **Step 2: Register the command in root.go**
+
+Add `rootCmd.AddCommand(deployCmd)` to `init()`.
+
+- [ ] **Step 3: Test the command manually**
+
+Run:
+```bash
+export NPS_API_KEY=test123
+export LLM_API_KEY=sk-test
+go run ./cmd/docsclaw deploy --manifest testdata/manifest/nps-agent.yaml
+```
+Expected: prints ConfigMap, Deployment, Service, ServiceAccount,
+Secret YAML separated by `---`.
+
+Run without secrets:
+```bash
+unset NPS_API_KEY
+go run ./cmd/docsclaw deploy --manifest testdata/manifest/nps-agent.yaml
+```
+Expected: fails with `required secret "NPS_API_KEY" not set`.
+
+- [ ] **Step 4: Run linter**
+
+Run: `cd /Users/panni/work/docsclaw && golangci-lint run ./internal/cmd/`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmd/deploy.go internal/cmd/root.go
+git commit -s -m "feat: add docsclaw deploy command
+
+Generates K8s manifests with secrets resolved from --secret flags
+or environment variables. Output is pipeable to oc apply -f -."
+```
+
+---
+
+### Task 9: Runtime tools.json loading and system prompt injection
+
+**Files:**
+- Modify: `internal/cmd/serve.go`
+
+- [ ] **Step 1: Add tools.json loader**
+
+Add a `loadToolsJSON` function to `internal/cmd/serve.go` that
+reads `/etc/docsclaw/tools.json` (or a configurable path). If the
+file doesn't exist, return nil (backward compatible — existing
+images without tools.json continue to work).
+
+```go
+func loadToolsJSON(path string) (*manifest.ToolsJSON, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read tools.json: %w", err)
+	}
+	var tj manifest.ToolsJSON
+	if err := json.Unmarshal(data, &tj); err != nil {
+		return nil, fmt.Errorf("parse tools.json: %w", err)
+	}
+	return &tj, nil
+}
+```
+
+- [ ] **Step 2: Inject available tools into system prompt**
+
+In the `runServe` function, after loading the system prompt and
+before passing it to the A2A handler, append the tool inventory
+if tools.json was found:
+
+```go
+const toolsJSONPath = "/etc/docsclaw/tools.json"
+
+tj, err := loadToolsJSON(toolsJSONPath)
+if err != nil {
+	slog.Warn("failed to load tools.json", "error", err)
+}
+if tj != nil {
+	var names []string
+	for _, t := range tj.Tools {
+		names = append(names, t.Name)
+	}
+	systemPrompt += fmt.Sprintf(
+		"\n\nAvailable OS tools: %s\nDo NOT attempt to use tools not in this list.",
+		strings.Join(names, ", "),
+	)
+	slog.Info("loaded OS tool inventory", "tools", names, "risk_score", tj.RiskScore)
+}
+```
+
+- [ ] **Step 3: Test manually with a local tools.json**
+
+Create a test tools.json and set the path via an env var or
+flag to test locally without building a container:
+
+```bash
+mkdir -p /tmp/docsclaw-test
+cat > /tmp/docsclaw-test/tools.json << 'EOF'
+{
+  "manifestVersion": "1.0.0",
+  "agentName": "test",
+  "base": "test",
+  "highestTier": "core",
+  "riskScore": 2,
+  "tools": [
+    {"name": "curl", "package": "curl", "tier": "core", "risk": {"score": 2, "codeExecution": false, "networkCapable": true}},
+    {"name": "jq", "package": "jq", "tier": "core", "risk": {"score": 1, "codeExecution": false, "networkCapable": false}}
+  ]
+}
+EOF
+```
+
+Verify the startup log shows:
+`INFO loaded OS tool inventory tools=[curl, jq] risk_score=2`
+
+- [ ] **Step 4: Run tests and linter**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./... && golangci-lint run ./...`
+Expected: all tests pass, no lint errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cmd/serve.go
+git commit -s -m "feat: inject OS tool inventory into system prompt
+
+At startup, reads /etc/docsclaw/tools.json and appends available
+tool names to the system prompt so the LLM knows exactly which
+OS tools exist. Prevents wasted agentic loop iterations on
+missing tools."
+```
+
+---
+
+### Task 10: Final integration test and cleanup
+
+**Files:**
+- All files from tasks 1-9
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /Users/panni/work/docsclaw && go test ./... -v`
+Expected: all tests pass including new catalog, manifest, and
+existing tests.
+
+- [ ] **Step 2: Run linter on entire project**
+
+Run: `cd /Users/panni/work/docsclaw && golangci-lint run ./...`
+Expected: no errors.
+
+- [ ] **Step 3: Test the full build pipeline end-to-end**
+
+```bash
+cd /Users/panni/work/docsclaw
+
+# Dry run
+go run ./cmd/docsclaw build \
+  --manifest testdata/manifest/nps-agent.yaml \
+  --dry-run
+
+# Generate all artifacts
+go run ./cmd/docsclaw build \
+  --manifest testdata/manifest/nps-agent.yaml \
+  --output /tmp/docsclaw-build-e2e
+
+# Verify generated files
+ls -la /tmp/docsclaw-build-e2e/
+cat /tmp/docsclaw-build-e2e/Containerfile
+cat /tmp/docsclaw-build-e2e/tools.json
+
+# Test deploy with secrets
+export NPS_API_KEY=test123 LLM_API_KEY=sk-test
+go run ./cmd/docsclaw deploy \
+  --manifest testdata/manifest/nps-agent.yaml
+
+# Test deploy with --secret flag
+unset NPS_API_KEY LLM_API_KEY
+go run ./cmd/docsclaw deploy \
+  --manifest testdata/manifest/nps-agent.yaml \
+  --secret NPS_API_KEY=test123 \
+  --secret LLM_API_KEY=sk-test
+```
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+If any issues found in integration testing, fix and commit.

--- a/docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md
+++ b/docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md
@@ -85,9 +85,9 @@ spec:
         - load_skill
       exec:
         timeout: 30
-        max_output: 50000
+        maxOutput: 50000
     loop:
-      max_iterations: 15
+      maxIterations: 15
 
   secrets:
     - name: NPS_API_KEY
@@ -462,9 +462,9 @@ docsclaw build --manifest agent-manifest.yaml --output ./build/ \
 # Dry run — compatibility report and risk score only
 docsclaw build --manifest agent-manifest.yaml --dry-run
 
-# Build and push
-docsclaw build --manifest agent-manifest.yaml --push \
-  --tag ghcr.io/org/nps-agent:1.0.0
+# Build and push (future work — use make agent-push for now)
+# docsclaw build --manifest agent-manifest.yaml --push \
+#   --tag ghcr.io/org/nps-agent:1.0.0
 
 # Enforce risk policy
 docsclaw build --manifest agent-manifest.yaml --max-risk 6

--- a/docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md
+++ b/docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md
@@ -1,0 +1,611 @@
+# Agent manifest and container tooling design
+
+## Overview
+
+DocsClaw agents run in minimal hardened container images. When
+skills need OS-level tools (curl, jq, pandoc, python3), those
+tools must be explicitly installed into the image. Today this is
+manual — editing Containerfiles by hand with no validation that
+skills will have what they need at runtime. This design introduces
+a declarative agent manifest, a curated tool catalog with
+risk scoring, and build/deploy tooling that generates container
+images and K8s manifests from that manifest.
+
+The core formula: **agent = base image + installed tools + system
+prompt + skills (mounted)**.
+
+## Goals
+
+- Declare a complete agent (image, tools, prompt, skills, secrets)
+  in a single versionable YAML file
+- Curate allowed tools in a tiered catalog with risk scoring so
+  admins can enforce security policy
+- Check skill/tool compatibility at both build time and runtime
+- Embed tool metadata in OCI annotations for inspection without
+  pulling the image
+- Generate Containerfiles, K8s manifests, and secrets from the
+  manifest
+- Provide a shopping cart UI for assembling agents visually
+
+## User model
+
+A layered model separates admin and developer concerns:
+
+| Role | Responsibilities |
+|------|-----------------|
+| Cluster admin | Maintains the tool catalog and build policy. Builds approved base images with tool tiers. Sets max risk thresholds. |
+| Developer | Picks a base image, adds skills, writes the system prompt. Gets compatibility warnings but cannot add OS-level tools beyond what the admin allows. |
+
+Admins provide approved base images with curated tool sets.
+Developers add skills on top and get compatibility warnings.
+
+## Agent manifest format
+
+The manifest is the single source of truth. Everything else
+(Containerfile, K8s YAML, OCI annotations) is generated from it.
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: nps-assistant
+  version: 1.0.0
+spec:
+  base:
+    image: registry.access.redhat.com/hi/core-runtime:latest
+    builder: registry.access.redhat.com/hi/core-runtime:latest-builder
+
+  tools:
+    - curl
+    - jq
+    - git
+
+  prompt:
+    # Option A: inline text
+    text: |
+      You are a national parks assistant...
+    # Option B: from a Git repo (mutually exclusive with text)
+    # source:
+    #   git: https://github.com/org/prompts.git
+    #   path: agents/nps-assistant/system-prompt.txt
+    #   ref: main
+
+  skills:
+    - name: nps-api
+      image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+    - name: document-summarizer
+      image: quay.io/docsclaw/skill-document-summarizer:1.0.0-image
+
+  runtime:
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - web_fetch
+        - load_skill
+      exec:
+        timeout: 30
+        max_output: 50000
+    loop:
+      max_iterations: 15
+
+  secrets:
+    - name: NPS_API_KEY
+      description: "API key for developer.nps.gov"
+      required: true
+    - name: LLM_API_KEY
+      description: "LLM provider API key"
+      required: true
+
+  deploy:
+    replicas: 1
+    resources:
+      requests: { cpu: 100m, memory: 64Mi }
+      limits: { cpu: 500m, memory: 256Mi }
+```
+
+Key distinctions:
+
+- `spec.tools` — OS-level packages installed in the container
+  (curl, jq, git)
+- `spec.runtime.tools.allowed` — DocsClaw internal tools the LLM
+  can call (exec, read_file, etc.)
+- `spec.secrets` — declares what the agent needs without storing
+  values; resolved from environment variables at deploy time
+
+### Secret resolution
+
+The manifest declares required secrets but never stores values.
+Resolution order at deploy time:
+
+1. `--secret NAME=value` CLI flag (highest priority)
+2. Environment variable with matching name
+3. Fail with error if `required: true` and no value found
+
+This keeps the manifest safe to commit while reducing friction
+for local development (`export NPS_API_KEY=xxx` before deploy).
+
+## Tool catalog
+
+A curated list of tools that DocsClaw knows how to install into
+hardened images. Each tool carries metadata for the UI,
+compatibility checking, and security warnings.
+
+### Tier system
+
+| Tier | Description | Auto-include | Warning |
+|------|-------------|-------------|---------|
+| core | Required for basic agent operation | Yes | None |
+| standard | Low risk, small footprint | No | None |
+| extended | Significant capabilities and attack surface | No | "Review with your security team" |
+| runtime | Full language runtimes, large footprint | No | "Adds full scripting runtime" |
+
+### Risk scoring
+
+Each tool carries a composite risk score (1-10) computed from
+four factors:
+
+| Factor | Condition | Points |
+|--------|-----------|--------|
+| Code execution | Can run arbitrary code | +3 |
+| Network capable | Can make outbound connections | +2 |
+| Dependencies | Per 5 transitive packages | +1 |
+| CVE history | low / medium / high | +1 / +2 / +3 |
+
+The image-level risk score is the max of all installed tool
+scores (not the sum). One python3 puts the image at 8/10;
+adding nodejs does not make it 16.
+
+### Catalog format
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: ToolCatalog
+metadata:
+  name: docsclaw-default
+  version: 1.0.0
+
+tiers:
+  core:
+    description: "Always included"
+    autoInclude: true
+  standard:
+    description: "Low risk, small footprint"
+  extended:
+    description: "Medium risk, larger footprint"
+    warning: "These tools expand the image attack surface."
+  runtime:
+    description: "High risk, full language runtimes"
+    warning: "Adds a full scripting runtime (~40-100 MB)."
+
+tools:
+  curl:
+    tier: core
+    package: { dnf: curl, apk: curl }
+    size: ~1MB
+    description: "HTTP client for API requests"
+    risk:
+      score: 2
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 2
+        cveHistory: low
+      rationale: "Network-capable but single-purpose"
+
+  jq:
+    tier: core
+    package: { dnf: jq, apk: jq }
+    size: ~1MB
+    description: "JSON processor for parsing API responses"
+    risk:
+      score: 1
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 1
+        cveHistory: low
+      rationale: "Single-purpose binary, minimal surface"
+
+  git:
+    tier: standard
+    package: { dnf: git, apk: git }
+    size: ~15MB
+    description: "Version control for code-related workflows"
+    risk:
+      score: 4
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 8
+        cveHistory: medium
+      rationale: "Network-capable, moderate dependency tree"
+
+  openssh-client:
+    tier: standard
+    package: { dnf: openssh-clients, apk: openssh-client }
+    size: ~5MB
+    description: "SSH client for remote operations"
+    risk:
+      score: 4
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 5
+        cveHistory: medium
+      rationale: "Network-capable, handles credentials"
+
+  pandoc:
+    tier: extended
+    package: { dnf: pandoc, apk: pandoc }
+    size: ~25MB
+    description: "Universal document converter"
+    risk:
+      score: 3
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 6
+        cveHistory: low
+      rationale: "Parses complex formats, moderate deps"
+
+  poppler-utils:
+    tier: extended
+    package: { dnf: poppler-utils, apk: poppler-utils }
+    size: ~10MB
+    description: "PDF text extraction"
+    risk:
+      score: 3
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 8
+        cveHistory: medium
+      rationale: "Parses untrusted PDF input"
+
+  imagemagick:
+    tier: extended
+    package: { dnf: ImageMagick, apk: imagemagick }
+    size: ~20MB
+    description: "Image conversion and manipulation"
+    risk:
+      score: 5
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 15
+        cveHistory: high
+      rationale: "Large dependency tree, extensive CVE history"
+
+  python3:
+    tier: runtime
+    package: { dnf: python3, apk: python3 }
+    size: ~45MB
+    description: "Python interpreter for scripting"
+    risk:
+      score: 8
+      factors:
+        codeExecution: true
+        networkCapable: false
+        dependencies: 12
+        cveHistory: high
+      rationale: "Full interpreter enables arbitrary code execution"
+
+  nodejs:
+    tier: runtime
+    package: { dnf: nodejs, apk: nodejs }
+    size: ~60MB
+    description: "Node.js runtime for JavaScript tools"
+    risk:
+      score: 8
+      factors:
+        codeExecution: true
+        networkCapable: false
+        dependencies: 10
+        cveHistory: high
+      rationale: "Full interpreter enables arbitrary code execution"
+```
+
+The `package` field has per-distro mappings so the Containerfile
+generator picks `dnf` for hardened images, `apk` for Alpine.
+
+Organizations can maintain their own catalog with custom tools or
+override tier assignments via `--catalog custom-catalog.yaml`.
+
+## Image metadata
+
+Two layers: OCI annotations for quick inspection without pulling,
+and an embedded manifest for full detail at runtime.
+
+### OCI annotations
+
+Set as LABELs in the generated Containerfile, visible via
+`skopeo inspect`:
+
+```
+io.docsclaw.tools/installed: "curl,jq,git"
+io.docsclaw.tools/tier: "standard"
+io.docsclaw.tools/risk-score: "4"
+io.docsclaw.tools/base: "hi/core-runtime:latest"
+io.docsclaw.tools/agent-name: "nps-assistant"
+```
+
+The tier label reflects the highest tier of any installed tool.
+
+### Embedded tools.json
+
+Generated during build at `/etc/docsclaw/tools.json`:
+
+```json
+{
+  "manifestVersion": "1.0.0",
+  "agentName": "nps-assistant",
+  "base": "registry.access.redhat.com/hi/core-runtime:latest",
+  "highestTier": "standard",
+  "riskScore": 4,
+  "tools": [
+    {
+      "name": "curl",
+      "package": "curl",
+      "version": "8.5.0",
+      "tier": "core",
+      "risk": { "score": 2, "codeExecution": false, "networkCapable": true }
+    },
+    {
+      "name": "jq",
+      "package": "jq",
+      "version": "1.7.1",
+      "tier": "core",
+      "risk": { "score": 1, "codeExecution": false, "networkCapable": false }
+    },
+    {
+      "name": "git",
+      "package": "git",
+      "version": "2.43.0",
+      "tier": "standard",
+      "risk": { "score": 4, "codeExecution": false, "networkCapable": true }
+    }
+  ]
+}
+```
+
+Version numbers are captured at build time by querying installed
+packages (`rpm -q` for hardened images, `apk info` for Alpine).
+
+### Usage by layer
+
+| Layer | When | By whom | Example |
+|-------|------|---------|---------|
+| OCI annotations | Before pulling | Registry UI, `skopeo`, admission webhooks | Block images with risk > 6 from production |
+| `/etc/docsclaw/tools.json` | At runtime | Agent startup, skill checker | Verify skills have required tools |
+
+OCI annotations enable OPA/Gatekeeper policies: a cluster admin
+can enforce "no runtime-tier images in production" at the
+admission controller level.
+
+## Skill compatibility checking
+
+Skills declare tool requirements in `skill.yaml` (the SkillCard
+format). The existing `spec.tools` field has `required` and
+`optional` lists.
+
+### Build-time checking
+
+When `docsclaw build` processes a manifest:
+
+1. Resolve all skills listed in `spec.skills`
+2. Fetch each skill's `skill.yaml` from OCI registry or local path
+3. Compare `spec.tools.required` against the manifest's
+   `spec.tools` list
+4. Required tool missing → build fails with actionable message
+5. Optional tool missing → warning with risk information
+
+```
+Checking skill compatibility...
+
+  ✔ nps-api
+      required: curl ✔, jq ✔
+      optional: python3 ✗ (tier: runtime, risk: 8)
+
+  ✘ doc-converter
+      required: curl ✔, pandoc ✗
+      ERROR: 'doc-converter' requires 'pandoc' (tier: extended)
+      → Add 'pandoc' to spec.tools or remove this skill
+
+Build failed: 1 unsatisfied skill requirement
+```
+
+### Runtime checking
+
+On agent startup, DocsClaw reads `/etc/docsclaw/tools.json` and
+validates each loaded skill:
+
+- Required tool missing → disable skill, log ERROR
+- Optional tool missing → log WARN, skill remains active
+- No `skill.yaml` → log INFO, skip validation
+
+### Known limitation
+
+Skills with only `SKILL.md` (no `skill.yaml`) have no
+machine-readable tool declarations. Build-time checking is
+skipped; runtime failures surface as `command not found` errors
+in the agentic loop. The build command emits a warning:
+
+```
+WARN  skill 'nps-api' has no skill.yaml — tool requirements
+      unknown. Runtime tool errors may occur.
+```
+
+This nudges skill authors toward declaring dependencies without
+blocking anyone.
+
+## Build pipeline
+
+### `docsclaw build`
+
+Reads the agent manifest and produces container images and/or
+generated files.
+
+```bash
+# Build image locally
+docsclaw build --manifest agent-manifest.yaml
+
+# Generate files to directory without building
+docsclaw build --manifest agent-manifest.yaml --output ./build/
+
+# Generate only specific artifacts
+docsclaw build --manifest agent-manifest.yaml --output ./build/ \
+  --only containerfile
+docsclaw build --manifest agent-manifest.yaml --output ./build/ \
+  --only k8s
+
+# Dry run — compatibility report and risk score only
+docsclaw build --manifest agent-manifest.yaml --dry-run
+
+# Build and push
+docsclaw build --manifest agent-manifest.yaml --push \
+  --tag ghcr.io/org/nps-agent:1.0.0
+
+# Enforce risk policy
+docsclaw build --manifest agent-manifest.yaml --max-risk 6
+```
+
+Output directory structure when using `--output`:
+
+```
+build/
+├── Containerfile
+├── tools.json
+├── agent-config.yaml
+├── system-prompt.txt
+└── k8s/
+    ├── configmap.yaml
+    ├── deployment.yaml
+    ├── service.yaml
+    ├── serviceaccount.yaml
+    └── secret.yaml
+```
+
+### Build steps
+
+1. Parse and validate manifest against schema
+2. Load tool catalog (built-in + optional org catalog)
+3. Validate all tools exist in catalog
+4. Fetch skill metadata from OCI registries
+5. Run compatibility check (skills vs tools)
+6. Compute risk score; enforce `--max-risk` threshold
+7. Generate Containerfile with dnf/apk install, LABELs, tools.json
+8. Build image via podman/docker (unless `--output` or `--dry-run`)
+9. Push to registry (if `--push`)
+
+### `docsclaw deploy`
+
+Generates K8s manifests with secrets resolved from environment:
+
+```bash
+export NPS_API_KEY=abc123
+export LLM_API_KEY=sk-xxx
+docsclaw deploy --manifest agent-manifest.yaml | oc apply -f -
+```
+
+### Admin build policy
+
+Organizations can enforce constraints via a policy file:
+
+```yaml
+apiVersion: docsclaw.io/v1alpha1
+kind: BuildPolicy
+metadata:
+  name: production
+spec:
+  maxRiskScore: 6
+  blockedTools:
+    - nodejs
+  blockedTiers:
+    - runtime
+  requiredBase: "registry.access.redhat.com/hi/"
+```
+
+## Runtime integration
+
+The agent startup sequence gains tool awareness without changing
+the core agentic loop.
+
+### Startup sequence
+
+1. Load `agent-config.yaml` (unchanged)
+2. **New:** read `/etc/docsclaw/tools.json` for OS tool inventory
+3. Discover skills in skills directory (unchanged)
+4. **New:** validate skill tool requirements against inventory
+5. Register internal tools based on `tools.allowed` (unchanged)
+6. **New:** inject tool list into system prompt context
+
+The injected context tells the LLM exactly what's available:
+
+```
+Available OS tools: curl, jq, git
+Do NOT attempt to use tools not in this list.
+```
+
+This directly prevents the wasted-iteration problem where LLMs
+try tools that don't exist (python3, pip, node) and burn through
+the agentic loop limit.
+
+## Shopping cart UI
+
+Extends the existing skillimage stepper wizard from 3 steps to 4.
+
+### Step 1: Base Image
+
+Pick the container runtime. Cards show image name, registry,
+whether it's hardened, and pre-installed core tools. Initially
+one option (DocsClaw on `hi/core-runtime`); extensible to other
+base images from the Red Hat image catalog
+(https://images.redhat.com/).
+
+### Step 2: Tools (new)
+
+Pick OS-level tools, grouped by tier. Core tools (curl, jq) are
+pre-selected and locked. Key UI elements:
+
+- **Risk gauge** in sidebar — green (1-3), yellow (4-6), red (7-10)
+- **Running size estimate** — "Estimated image size: +47 MB"
+- **Tier headers** with warning text for extended and runtime
+- **Confirmation banner** when selecting runtime-tier tools
+
+### Step 3: System Prompt
+
+Pick a persona or paste custom text. Same as existing UI.
+
+### Step 4: Skills
+
+Same as existing UI plus compatibility checking:
+
+- Skills with `skill.yaml`: check required tools against step 2
+  selections. Missing tool → inline banner with "Add tool" button
+- Skills without `skill.yaml`: info badge "Tool requirements
+  unknown"
+- Recommended skills pre-selected based on persona
+
+### Output tabs
+
+| Tab | Content |
+|-----|---------|
+| Agent Manifest | Primary output — copy or download YAML |
+| Containerfile | Generated from manifest + catalog |
+| K8s Manifests | ConfigMap, Deployment, Service, Secret |
+| CLI Commands | `docsclaw build` and `docsclaw deploy` one-liners |
+
+The manifest is the artifact users version-control. Generated
+files are ephemeral — regenerate anytime.
+
+## Summary
+
+| Component | Format | Purpose |
+|-----------|--------|---------|
+| Agent Manifest | `agent-manifest.yaml` | Single source of truth |
+| Tool Catalog | `tool-catalog.yaml` | Curated tools with risk scores |
+| Build Policy | `build-policy.yaml` | Org-level guardrails |
+| OCI annotations | Image labels | Pre-pull inspection |
+| tools.json | `/etc/docsclaw/tools.json` | Runtime compatibility |
+| Shopping cart UI | HTML | Visual agent assembly |

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+	"github.com/redhat-et/docsclaw/pkg/manifest"
+)
+
+var buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build agent container image from manifest",
+	Long: `Build agent container image from manifest.
+
+Reads an agent manifest, validates tools against the catalog, checks skill
+compatibility, and generates Containerfile + K8s manifests.
+
+Examples:
+  docsclaw build --manifest agent-manifest.yaml --output ./build
+  docsclaw build --manifest agent-manifest.yaml --dry-run
+  docsclaw build --manifest agent-manifest.yaml --only containerfile > Containerfile
+`,
+	RunE: runBuild,
+}
+
+func init() {
+	rootCmd.AddCommand(buildCmd)
+
+	buildCmd.Flags().String("manifest", "", "Path to agent-manifest.yaml (required)")
+	buildCmd.Flags().String("output", "", "Directory to write generated files (default: print to stdout)")
+	buildCmd.Flags().String("only", "", "Generate only 'containerfile' or 'k8s'")
+	buildCmd.Flags().Bool("dry-run", false, "Print compatibility report and risk score only")
+	buildCmd.Flags().String("catalog", "", "Path to custom tool catalog (default: embedded catalog)")
+	buildCmd.Flags().Int("max-risk", 0, "Max allowed risk score (0 = no limit)")
+
+	_ = buildCmd.MarkFlagRequired("manifest")
+}
+
+func runBuild(cmd *cobra.Command, args []string) error {
+	manifestPath, _ := cmd.Flags().GetString("manifest")
+	outputDir, _ := cmd.Flags().GetString("output")
+	onlyMode, _ := cmd.Flags().GetString("only")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	catalogPath, _ := cmd.Flags().GetString("catalog")
+	maxRisk, _ := cmd.Flags().GetInt("max-risk")
+
+	// Validate --only flag
+	if onlyMode != "" && onlyMode != "containerfile" && onlyMode != "k8s" {
+		return fmt.Errorf("--only must be 'containerfile' or 'k8s'")
+	}
+
+	// 1. Parse manifest
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	// 2. Load catalog
+	var cat *catalog.ToolCatalog
+	if catalogPath != "" {
+		cat, err = catalog.LoadFromFile(catalogPath)
+		if err != nil {
+			return fmt.Errorf("load catalog: %w", err)
+		}
+	} else {
+		cat, err = catalog.LoadDefault()
+		if err != nil {
+			return fmt.Errorf("load default catalog: %w", err)
+		}
+	}
+
+	// 3. Validate tools
+	if err := cat.Validate(m.Spec.Tools); err != nil {
+		return err
+	}
+
+	// 4. Merge core tools and compute risk score + tier
+	allTools := mergeToolsWithCore(m.Spec.Tools, cat)
+	sort.Strings(allTools)
+	tier := cat.HighestTier(allTools)
+	riskScore := cat.MaxRiskScore(allTools)
+
+	// 5. Print compatibility report
+	printReport(os.Stderr, m, allTools, tier, riskScore)
+
+	// 6. Check max-risk constraint
+	if maxRisk > 0 && riskScore > maxRisk {
+		return fmt.Errorf("risk score %d exceeds max allowed %d", riskScore, maxRisk)
+	}
+
+	// 7. If dry-run, exit after report
+	if dryRun {
+		return nil
+	}
+
+	// 8. Generate files based on --only flag
+	if onlyMode == "containerfile" || onlyMode == "" {
+		containerfile, err := manifest.GenerateContainerfile(m, cat)
+		if err != nil {
+			return fmt.Errorf("generate containerfile: %w", err)
+		}
+
+		toolsJSON, err := manifest.GenerateToolsJSON(m, cat)
+		if err != nil {
+			return fmt.Errorf("generate tools.json: %w", err)
+		}
+
+		if outputDir != "" {
+			if err := writeContainerfileOutputs(outputDir, containerfile, toolsJSON, m); err != nil {
+				return err
+			}
+		} else if onlyMode == "containerfile" {
+			// Print Containerfile to stdout only if --only containerfile
+			fmt.Print(containerfile)
+		}
+	}
+
+	if onlyMode == "k8s" || onlyMode == "" {
+		k8sOutput, err := manifest.GenerateK8s(m, nil)
+		if err != nil {
+			return fmt.Errorf("generate k8s manifests: %w", err)
+		}
+
+		if outputDir != "" {
+			if err := writeK8sOutputs(outputDir, k8sOutput); err != nil {
+				return err
+			}
+		}
+	}
+
+	// If outputDir specified and no --only, write everything
+	if outputDir != "" && onlyMode == "" {
+		fmt.Fprintf(os.Stderr, "\n✓ Build artifacts written to %s\n", outputDir)
+	}
+
+	return nil
+}
+
+func mergeToolsWithCore(tools []string, cat *catalog.ToolCatalog) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	// Add core tools first
+	for _, name := range cat.CoreTools() {
+		if !seen[name] {
+			seen[name] = true
+			result = append(result, name)
+		}
+	}
+
+	// Add manifest tools
+	for _, name := range tools {
+		if !seen[name] {
+			seen[name] = true
+			result = append(result, name)
+		}
+	}
+
+	return result
+}
+
+func printReport(w *os.File, m *manifest.AgentManifest, tools []string, tier string, riskScore int) {
+	fmt.Fprintf(w, "\n=== Agent Build Report ===\n\n")
+	fmt.Fprintf(w, "Agent:       %s\n", m.Metadata.Name)
+	fmt.Fprintf(w, "Version:     %s\n", m.Metadata.Version)
+	fmt.Fprintf(w, "Base:        %s\n", m.Spec.Base.Image)
+	fmt.Fprintf(w, "Tier:        %s\n", tier)
+	fmt.Fprintf(w, "Risk Score:  %d\n", riskScore)
+	fmt.Fprintf(w, "Tools:       %d total\n\n", len(tools))
+
+	// Group by tier
+	fmt.Fprintf(w, "Tool Inventory:\n")
+	for _, name := range tools {
+		fmt.Fprintf(w, "  - %s\n", name)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
+func writeContainerfileOutputs(dir, containerfile string, toolsJSON []byte, m *manifest.AgentManifest) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	// Write Containerfile
+	containerfilePath := filepath.Join(dir, "Containerfile")
+	if err := os.WriteFile(containerfilePath, []byte(containerfile), 0644); err != nil {
+		return fmt.Errorf("write Containerfile: %w", err)
+	}
+
+	// Write tools.json
+	toolsJSONPath := filepath.Join(dir, "tools.json")
+	if err := os.WriteFile(toolsJSONPath, toolsJSON, 0644); err != nil {
+		return fmt.Errorf("write tools.json: %w", err)
+	}
+
+	// Write system-prompt.txt
+	systemPromptPath := filepath.Join(dir, "system-prompt.txt")
+	if err := os.WriteFile(systemPromptPath, []byte(m.Spec.Prompt.Text), 0644); err != nil {
+		return fmt.Errorf("write system-prompt.txt: %w", err)
+	}
+
+	// Write agent-config.yaml if runtime config exists
+	if m.Spec.Runtime.Tools.Allowed != nil || m.Spec.Runtime.Loop.MaxIterations > 0 {
+		agentConfig := buildAgentConfigYAML(m)
+		agentConfigPath := filepath.Join(dir, "agent-config.yaml")
+		if err := os.WriteFile(agentConfigPath, []byte(agentConfig), 0644); err != nil {
+			return fmt.Errorf("write agent-config.yaml: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func writeK8sOutputs(dir string, k8s *manifest.K8sOutput) error {
+	k8sDir := filepath.Join(dir, "k8s")
+	if err := os.MkdirAll(k8sDir, 0755); err != nil {
+		return fmt.Errorf("create k8s directory: %w", err)
+	}
+
+	files := map[string]string{
+		"configmap.yaml":      k8s.ConfigMap,
+		"deployment.yaml":     k8s.Deployment,
+		"service.yaml":        k8s.Service,
+		"serviceaccount.yaml": k8s.ServiceAccount,
+	}
+
+	if k8s.Secret != "" {
+		files["secret.yaml"] = k8s.Secret
+	}
+
+	for name, content := range files {
+		path := filepath.Join(k8sDir, name)
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func buildAgentConfigYAML(m *manifest.AgentManifest) string {
+	var b strings.Builder
+
+	b.WriteString("tools:\n")
+	if len(m.Spec.Runtime.Tools.Allowed) > 0 {
+		b.WriteString("  allowed:\n")
+		for _, tool := range m.Spec.Runtime.Tools.Allowed {
+			fmt.Fprintf(&b, "    - %s\n", tool)
+		}
+	}
+
+	if m.Spec.Runtime.Tools.Exec.Timeout > 0 || m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
+		b.WriteString("  exec:\n")
+		if m.Spec.Runtime.Tools.Exec.Timeout > 0 {
+			fmt.Fprintf(&b, "    timeout: %d\n", m.Spec.Runtime.Tools.Exec.Timeout)
+		}
+		if m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
+			fmt.Fprintf(&b, "    maxOutput: %d\n", m.Spec.Runtime.Tools.Exec.MaxOutput)
+		}
+	}
+
+	if len(m.Spec.Runtime.Tools.WebFetch.AllowedHosts) > 0 {
+		b.WriteString("  webFetch:\n")
+		b.WriteString("    allowedHosts:\n")
+		for _, host := range m.Spec.Runtime.Tools.WebFetch.AllowedHosts {
+			fmt.Fprintf(&b, "      - %s\n", host)
+		}
+	}
+
+	if m.Spec.Runtime.Loop.MaxIterations > 0 {
+		b.WriteString("loop:\n")
+		fmt.Fprintf(&b, "  maxIterations: %d\n", m.Spec.Runtime.Loop.MaxIterations)
+	}
+
+	return b.String()
+}

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -81,7 +81,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Merge core tools and compute risk score + tier
-	allTools := mergeToolsWithCore(m.Spec.Tools, cat)
+	allTools := manifest.MergeWithCore(m.Spec.Tools, cat)
 	sort.Strings(allTools)
 	tier := cat.HighestTier(allTools)
 	riskScore := cat.MaxRiskScore(allTools)
@@ -131,6 +131,13 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			if err := writeK8sOutputs(outputDir, k8sOutput); err != nil {
 				return err
 			}
+		} else if onlyMode == "k8s" {
+			parts := []string{k8sOutput.ServiceAccount, k8sOutput.ConfigMap}
+			if k8sOutput.Secret != "" {
+				parts = append(parts, k8sOutput.Secret)
+			}
+			parts = append(parts, k8sOutput.Service, k8sOutput.Deployment)
+			fmt.Print(strings.Join(parts, "---\n"))
 		}
 	}
 
@@ -142,28 +149,6 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func mergeToolsWithCore(tools []string, cat *catalog.ToolCatalog) []string {
-	seen := make(map[string]bool)
-	var result []string
-
-	// Add core tools first
-	for _, name := range cat.CoreTools() {
-		if !seen[name] {
-			seen[name] = true
-			result = append(result, name)
-		}
-	}
-
-	// Add manifest tools
-	for _, name := range tools {
-		if !seen[name] {
-			seen[name] = true
-			result = append(result, name)
-		}
-	}
-
-	return result
-}
 
 func printReport(w *os.File, m *manifest.AgentManifest, tools []string, tier string, riskScore int) {
 	_, _ = fmt.Fprintf(w, "\n=== Agent Build Report ===\n\n")
@@ -204,9 +189,8 @@ func writeContainerfileOutputs(dir, containerfile string, toolsJSON []byte, m *m
 		return fmt.Errorf("write system-prompt.txt: %w", err)
 	}
 
-	// Write agent-config.yaml if runtime config exists
-	if m.Spec.Runtime.Tools.Allowed != nil || m.Spec.Runtime.Loop.MaxIterations > 0 {
-		agentConfig := buildAgentConfigYAML(m)
+	if manifest.HasRuntimeConfig(m) {
+		agentConfig := manifest.BuildAgentConfigYAML(m)
 		agentConfigPath := filepath.Join(dir, "agent-config.yaml")
 		if err := os.WriteFile(agentConfigPath, []byte(agentConfig), 0644); err != nil {
 			return fmt.Errorf("write agent-config.yaml: %w", err)
@@ -243,39 +227,3 @@ func writeK8sOutputs(dir string, k8s *manifest.K8sOutput) error {
 	return nil
 }
 
-func buildAgentConfigYAML(m *manifest.AgentManifest) string {
-	var b strings.Builder
-
-	b.WriteString("tools:\n")
-	if len(m.Spec.Runtime.Tools.Allowed) > 0 {
-		b.WriteString("  allowed:\n")
-		for _, tool := range m.Spec.Runtime.Tools.Allowed {
-			fmt.Fprintf(&b, "    - %s\n", tool)
-		}
-	}
-
-	if m.Spec.Runtime.Tools.Exec.Timeout > 0 || m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
-		b.WriteString("  exec:\n")
-		if m.Spec.Runtime.Tools.Exec.Timeout > 0 {
-			fmt.Fprintf(&b, "    timeout: %d\n", m.Spec.Runtime.Tools.Exec.Timeout)
-		}
-		if m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
-			fmt.Fprintf(&b, "    maxOutput: %d\n", m.Spec.Runtime.Tools.Exec.MaxOutput)
-		}
-	}
-
-	if len(m.Spec.Runtime.Tools.WebFetch.AllowedHosts) > 0 {
-		b.WriteString("  webFetch:\n")
-		b.WriteString("    allowedHosts:\n")
-		for _, host := range m.Spec.Runtime.Tools.WebFetch.AllowedHosts {
-			fmt.Fprintf(&b, "      - %s\n", host)
-		}
-	}
-
-	if m.Spec.Runtime.Loop.MaxIterations > 0 {
-		b.WriteString("loop:\n")
-		fmt.Fprintf(&b, "  maxIterations: %d\n", m.Spec.Runtime.Loop.MaxIterations)
-	}
-
-	return b.String()
-}

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -166,20 +166,19 @@ func mergeToolsWithCore(tools []string, cat *catalog.ToolCatalog) []string {
 }
 
 func printReport(w *os.File, m *manifest.AgentManifest, tools []string, tier string, riskScore int) {
-	fmt.Fprintf(w, "\n=== Agent Build Report ===\n\n")
-	fmt.Fprintf(w, "Agent:       %s\n", m.Metadata.Name)
-	fmt.Fprintf(w, "Version:     %s\n", m.Metadata.Version)
-	fmt.Fprintf(w, "Base:        %s\n", m.Spec.Base.Image)
-	fmt.Fprintf(w, "Tier:        %s\n", tier)
-	fmt.Fprintf(w, "Risk Score:  %d\n", riskScore)
-	fmt.Fprintf(w, "Tools:       %d total\n\n", len(tools))
+	_, _ = fmt.Fprintf(w, "\n=== Agent Build Report ===\n\n")
+	_, _ = fmt.Fprintf(w, "Agent:       %s\n", m.Metadata.Name)
+	_, _ = fmt.Fprintf(w, "Version:     %s\n", m.Metadata.Version)
+	_, _ = fmt.Fprintf(w, "Base:        %s\n", m.Spec.Base.Image)
+	_, _ = fmt.Fprintf(w, "Tier:        %s\n", tier)
+	_, _ = fmt.Fprintf(w, "Risk Score:  %d\n", riskScore)
+	_, _ = fmt.Fprintf(w, "Tools:       %d total\n\n", len(tools))
 
-	// Group by tier
-	fmt.Fprintf(w, "Tool Inventory:\n")
+	_, _ = fmt.Fprintf(w, "Tool Inventory:\n")
 	for _, name := range tools {
-		fmt.Fprintf(w, "  - %s\n", name)
+		_, _ = fmt.Fprintf(w, "  - %s\n", name)
 	}
-	fmt.Fprintf(w, "\n")
+	_, _ = fmt.Fprintf(w, "\n")
 }
 
 func writeContainerfileOutputs(dir, containerfile string, toolsJSON []byte, m *manifest.AgentManifest) error {

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/docsclaw/pkg/manifest"
+)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Generate K8s manifests with secrets resolved",
+	Long: `Generate K8s manifests with secrets resolved from flags or environment.
+
+Reads an agent manifest, resolves secrets from --secret flags or environment
+variables, and outputs K8s manifests ready for deployment.
+
+Examples:
+  docsclaw deploy --manifest agent-manifest.yaml --secret API_KEY=xyz | oc apply -f -
+  docsclaw deploy --manifest agent-manifest.yaml --output ./deploy
+  export API_KEY=xyz && docsclaw deploy --manifest agent-manifest.yaml
+`,
+	RunE: runDeploy,
+}
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+
+	deployCmd.Flags().String("manifest", "", "Path to agent-manifest.yaml (required)")
+	deployCmd.Flags().StringSlice("secret", nil, "Secret values as NAME=value pairs")
+	deployCmd.Flags().String("output", "", "Directory to write generated files (optional, default: stdout)")
+
+	_ = deployCmd.MarkFlagRequired("manifest")
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	manifestPath, _ := cmd.Flags().GetString("manifest")
+	secretFlags, _ := cmd.Flags().GetStringSlice("secret")
+	outputDir, _ := cmd.Flags().GetString("output")
+
+	// 1. Parse manifest
+	m, err := manifest.ParseFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	// 2. Resolve secrets
+	resolvedSecrets, err := resolveSecrets(m.Spec.Secrets, secretFlags)
+	if err != nil {
+		return err
+	}
+
+	// 3. Generate K8s manifests
+	k8sOutput, err := manifest.GenerateK8s(m, resolvedSecrets)
+	if err != nil {
+		return fmt.Errorf("generate k8s manifests: %w", err)
+	}
+
+	// 4. Output to directory or stdout
+	if outputDir != "" {
+		if err := writeK8sOutputs(outputDir, k8sOutput); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "✓ K8s manifests written to %s/k8s\n", outputDir)
+	} else {
+		printK8sManifests(k8sOutput)
+	}
+
+	return nil
+}
+
+func resolveSecrets(decls []manifest.SecretDecl, flagSecrets []string) (map[string]string, error) {
+	// Parse --secret flags into map
+	overrides := make(map[string]string)
+	for _, s := range flagSecrets {
+		parts := strings.SplitN(s, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --secret format: %q (expected NAME=value)", s)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+
+	// Resolve secrets: flag overrides, then env vars, then fail if required
+	resolved := make(map[string]string)
+	for _, decl := range decls {
+		if v, ok := overrides[decl.Name]; ok {
+			resolved[decl.Name] = v
+		} else if v := os.Getenv(decl.Name); v != "" {
+			resolved[decl.Name] = v
+		} else if decl.Required {
+			return nil, fmt.Errorf("required secret %q not set (use --secret %s=value or export %s)", decl.Name, decl.Name, decl.Name)
+		}
+	}
+	return resolved, nil
+}
+
+func printK8sManifests(k8s *manifest.K8sOutput) {
+	var manifests []string
+
+	// Order: ServiceAccount, ConfigMap, Secret (if present), Service, Deployment
+	if k8s.ServiceAccount != "" {
+		manifests = append(manifests, k8s.ServiceAccount)
+	}
+	if k8s.ConfigMap != "" {
+		manifests = append(manifests, k8s.ConfigMap)
+	}
+	if k8s.Secret != "" {
+		manifests = append(manifests, k8s.Secret)
+	}
+	if k8s.Service != "" {
+		manifests = append(manifests, k8s.Service)
+	}
+	if k8s.Deployment != "" {
+		manifests = append(manifests, k8s.Deployment)
+	}
+
+	fmt.Print(strings.Join(manifests, "---\n"))
+}

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/redhat-et/docsclaw/pkg/manifest"
@@ -13,9 +12,7 @@ func TestResolveSecrets_FlagOverride(t *testing.T) {
 	}
 	flagSecrets := []string{"API_KEY=flag-value"}
 
-	// Set env var that should be overridden
-	os.Setenv("API_KEY", "env-value")
-	defer os.Unsetenv("API_KEY")
+	t.Setenv("API_KEY", "env-value")
 
 	resolved, err := resolveSecrets(decls, flagSecrets)
 	if err != nil {
@@ -32,8 +29,7 @@ func TestResolveSecrets_EnvVarFallback(t *testing.T) {
 		{Name: "API_KEY", Required: true},
 	}
 
-	os.Setenv("API_KEY", "env-value")
-	defer os.Unsetenv("API_KEY")
+	t.Setenv("API_KEY", "env-value")
 
 	resolved, err := resolveSecrets(decls, nil)
 	if err != nil {
@@ -47,35 +43,26 @@ func TestResolveSecrets_EnvVarFallback(t *testing.T) {
 
 func TestResolveSecrets_RequiredMissing(t *testing.T) {
 	decls := []manifest.SecretDecl{
-		{Name: "API_KEY", Required: true},
+		{Name: "DOCSCLAW_TEST_MISSING_KEY", Required: true},
 	}
-
-	os.Unsetenv("API_KEY")
 
 	_, err := resolveSecrets(decls, nil)
 	if err == nil {
 		t.Fatal("expected error for missing required secret")
 	}
-
-	expectedMsg := "required secret \"API_KEY\" not set"
-	if err.Error()[:len(expectedMsg)] != expectedMsg {
-		t.Errorf("expected error message prefix %q, got %q", expectedMsg, err.Error())
-	}
 }
 
 func TestResolveSecrets_OptionalMissing(t *testing.T) {
 	decls := []manifest.SecretDecl{
-		{Name: "API_KEY", Required: false},
+		{Name: "DOCSCLAW_TEST_MISSING_KEY", Required: false},
 	}
-
-	os.Unsetenv("API_KEY")
 
 	resolved, err := resolveSecrets(decls, nil)
 	if err != nil {
 		t.Fatalf("resolveSecrets() error: %v", err)
 	}
 
-	if _, exists := resolved["API_KEY"]; exists {
+	if _, exists := resolved["DOCSCLAW_TEST_MISSING_KEY"]; exists {
 		t.Error("optional secret should not be in resolved map when missing")
 	}
 }
@@ -90,11 +77,6 @@ func TestResolveSecrets_InvalidFlagFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid flag format")
 	}
-
-	expectedMsg := "invalid --secret format"
-	if err.Error()[:len(expectedMsg)] != expectedMsg {
-		t.Errorf("expected error message prefix %q, got %q", expectedMsg, err.Error())
-	}
 }
 
 func TestResolveSecrets_MultipleSecrets(t *testing.T) {
@@ -105,8 +87,7 @@ func TestResolveSecrets_MultipleSecrets(t *testing.T) {
 	}
 	flagSecrets := []string{"API_KEY=flag-value"}
 
-	os.Setenv("DB_PASSWORD", "db-pass")
-	defer os.Unsetenv("DB_PASSWORD")
+	t.Setenv("DB_PASSWORD", "db-pass")
 
 	resolved, err := resolveSecrets(decls, flagSecrets)
 	if err != nil {

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/manifest"
+)
+
+func TestResolveSecrets_FlagOverride(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: true},
+	}
+	flagSecrets := []string{"API_KEY=flag-value"}
+
+	// Set env var that should be overridden
+	os.Setenv("API_KEY", "env-value")
+	defer os.Unsetenv("API_KEY")
+
+	resolved, err := resolveSecrets(decls, flagSecrets)
+	if err != nil {
+		t.Fatalf("resolveSecrets() error: %v", err)
+	}
+
+	if resolved["API_KEY"] != "flag-value" {
+		t.Errorf("expected flag value, got %q", resolved["API_KEY"])
+	}
+}
+
+func TestResolveSecrets_EnvVarFallback(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: true},
+	}
+
+	os.Setenv("API_KEY", "env-value")
+	defer os.Unsetenv("API_KEY")
+
+	resolved, err := resolveSecrets(decls, nil)
+	if err != nil {
+		t.Fatalf("resolveSecrets() error: %v", err)
+	}
+
+	if resolved["API_KEY"] != "env-value" {
+		t.Errorf("expected env value, got %q", resolved["API_KEY"])
+	}
+}
+
+func TestResolveSecrets_RequiredMissing(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: true},
+	}
+
+	os.Unsetenv("API_KEY")
+
+	_, err := resolveSecrets(decls, nil)
+	if err == nil {
+		t.Fatal("expected error for missing required secret")
+	}
+
+	expectedMsg := "required secret \"API_KEY\" not set"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("expected error message prefix %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestResolveSecrets_OptionalMissing(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: false},
+	}
+
+	os.Unsetenv("API_KEY")
+
+	resolved, err := resolveSecrets(decls, nil)
+	if err != nil {
+		t.Fatalf("resolveSecrets() error: %v", err)
+	}
+
+	if _, exists := resolved["API_KEY"]; exists {
+		t.Error("optional secret should not be in resolved map when missing")
+	}
+}
+
+func TestResolveSecrets_InvalidFlagFormat(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: true},
+	}
+	flagSecrets := []string{"INVALID_FORMAT"}
+
+	_, err := resolveSecrets(decls, flagSecrets)
+	if err == nil {
+		t.Fatal("expected error for invalid flag format")
+	}
+
+	expectedMsg := "invalid --secret format"
+	if err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("expected error message prefix %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestResolveSecrets_MultipleSecrets(t *testing.T) {
+	decls := []manifest.SecretDecl{
+		{Name: "API_KEY", Required: true},
+		{Name: "DB_PASSWORD", Required: true},
+		{Name: "OPTIONAL_KEY", Required: false},
+	}
+	flagSecrets := []string{"API_KEY=flag-value"}
+
+	os.Setenv("DB_PASSWORD", "db-pass")
+	defer os.Unsetenv("DB_PASSWORD")
+
+	resolved, err := resolveSecrets(decls, flagSecrets)
+	if err != nil {
+		t.Fatalf("resolveSecrets() error: %v", err)
+	}
+
+	if resolved["API_KEY"] != "flag-value" {
+		t.Errorf("API_KEY: expected flag-value, got %q", resolved["API_KEY"])
+	}
+	if resolved["DB_PASSWORD"] != "db-pass" {
+		t.Errorf("DB_PASSWORD: expected db-pass, got %q", resolved["DB_PASSWORD"])
+	}
+	if _, exists := resolved["OPTIONAL_KEY"]; exists {
+		t.Error("optional key should not be in resolved map when missing")
+	}
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redhat-et/docsclaw/internal/webfetch"
 	"github.com/redhat-et/docsclaw/internal/writefile"
 	"github.com/redhat-et/docsclaw/pkg/llm"
+	"github.com/redhat-et/docsclaw/pkg/manifest"
 	"github.com/redhat-et/docsclaw/pkg/rag"
 	"github.com/redhat-et/docsclaw/pkg/skills"
 	"github.com/redhat-et/docsclaw/pkg/tools"
@@ -108,6 +109,23 @@ func loadPromptVariants(configDir string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to parse prompt variants: %w", err)
 	}
 	return variants, nil
+}
+
+// loadToolsJSON reads the OS tool inventory from /etc/docsclaw/tools.json.
+// Returns nil if the file does not exist (backward compatible).
+func loadToolsJSON(path string) (*manifest.ToolsJSON, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read tools.json: %w", err)
+	}
+	var tj manifest.ToolsJSON
+	if err := json.Unmarshal(data, &tj); err != nil {
+		return nil, fmt.Errorf("parse tools.json: %w", err)
+	}
+	return &tj, nil
 }
 
 // selectPrompt picks the appropriate prompt based on message content.
@@ -277,6 +295,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	log := logger.New(logger.ComponentAgent)
+
+	// Load OS tool inventory and inject into system prompt
+	const toolsJSONPath = "/etc/docsclaw/tools.json"
+	tj, err := loadToolsJSON(toolsJSONPath)
+	if err != nil {
+		log.Warn("failed to load tools.json", "error", err)
+	}
+	if tj != nil {
+		var names []string
+		for _, t := range tj.Tools {
+			names = append(names, t.Name)
+		}
+		systemPrompt += fmt.Sprintf(
+			"\n\nAvailable OS tools: %s\nDo NOT attempt to use tools not in this list.",
+			strings.Join(names, ", "),
+		)
+		log.Info("loaded OS tool inventory", "tools", names, "risk_score", tj.RiskScore)
+	}
 
 	// HTTP client with delegation transport
 	httpClient := &http.Client{

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -126,6 +127,12 @@ func loadToolsJSON(path string) (*manifest.ToolsJSON, error) {
 		return nil, fmt.Errorf("parse tools.json: %w", err)
 	}
 	return &tj, nil
+}
+
+var toolNameAllowed = regexp.MustCompile(`[^a-zA-Z0-9 _-]`)
+
+func sanitizeToolName(name string) string {
+	return toolNameAllowed.ReplaceAllString(name, "")
 }
 
 // selectPrompt picks the appropriate prompt based on message content.
@@ -305,7 +312,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if tj != nil {
 		var names []string
 		for _, t := range tj.Tools {
-			names = append(names, t.Name)
+			clean := sanitizeToolName(t.Name)
+			if clean != "" {
+				names = append(names, clean)
+			}
 		}
 		systemPrompt += fmt.Sprintf(
 			"\n\nAvailable OS tools: %s\nDo NOT attempt to use tools not in this list.",

--- a/internal/cmd/serve_tools_test.go
+++ b/internal/cmd/serve_tools_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadToolsJSON(t *testing.T) {
+	t.Run("valid tools.json", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "tools.json")
+		content := `{
+  "manifestVersion": "1.0.0",
+  "agentName": "test-agent",
+  "base": "registry.access.redhat.com/ubi9-minimal",
+  "highestTier": "tier-3",
+  "riskScore": 30,
+  "tools": [
+    {
+      "name": "curl",
+      "package": "curl",
+      "tier": "tier-1",
+      "risk": {
+        "score": 10,
+        "codeExecution": false,
+        "networkCapable": true
+      }
+    },
+    {
+      "name": "jq",
+      "package": "jq",
+      "tier": "tier-1",
+      "risk": {
+        "score": 5,
+        "codeExecution": false,
+        "networkCapable": false
+      }
+    }
+  ]
+}`
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		tj, err := loadToolsJSON(path)
+		if err != nil {
+			t.Fatalf("loadToolsJSON failed: %v", err)
+		}
+		if tj == nil {
+			t.Fatal("expected ToolsJSON, got nil")
+		}
+		if tj.AgentName != "test-agent" {
+			t.Errorf("expected agent name 'test-agent', got %q", tj.AgentName)
+		}
+		if len(tj.Tools) != 2 {
+			t.Errorf("expected 2 tools, got %d", len(tj.Tools))
+		}
+		if tj.RiskScore != 30 {
+			t.Errorf("expected risk score 30, got %d", tj.RiskScore)
+		}
+		if tj.Tools[0].Name != "curl" {
+			t.Errorf("expected first tool 'curl', got %q", tj.Tools[0].Name)
+		}
+	})
+
+	t.Run("missing file returns nil", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "nonexistent.json")
+
+		tj, err := loadToolsJSON(path)
+		if err != nil {
+			t.Fatalf("expected nil error for missing file, got: %v", err)
+		}
+		if tj != nil {
+			t.Fatalf("expected nil ToolsJSON for missing file, got: %+v", tj)
+		}
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "invalid.json")
+		if err := os.WriteFile(path, []byte("{invalid json"), 0600); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		tj, err := loadToolsJSON(path)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON, got nil")
+		}
+		if tj != nil {
+			t.Fatalf("expected nil ToolsJSON for invalid JSON, got: %+v", tj)
+		}
+	})
+}

--- a/internal/cmd/serve_tools_test.go
+++ b/internal/cmd/serve_tools_test.go
@@ -49,6 +49,7 @@ func TestLoadToolsJSON(t *testing.T) {
 		}
 		if tj == nil {
 			t.Fatal("expected ToolsJSON, got nil")
+			return
 		}
 		if tj.AgentName != "test-agent" {
 			t.Errorf("expected agent name 'test-agent', got %q", tj.AgentName)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,0 +1,111 @@
+package catalog
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed default.yaml
+var defaultCatalog embed.FS
+
+var tierOrder = map[string]int{
+	"core":     0,
+	"standard": 1,
+	"extended": 2,
+	"runtime":  3,
+}
+
+func LoadDefault() (*ToolCatalog, error) {
+	data, err := defaultCatalog.ReadFile("default.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read embedded catalog: %w", err)
+	}
+	return parse(data)
+}
+
+func LoadFromFile(path string) (*ToolCatalog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %s: %w", path, err)
+	}
+	return parse(data)
+}
+
+func parse(data []byte) (*ToolCatalog, error) {
+	var cat ToolCatalog
+	if err := yaml.Unmarshal(data, &cat); err != nil {
+		return nil, fmt.Errorf("parse catalog: %w", err)
+	}
+	return &cat, nil
+}
+
+func (c *ToolCatalog) Lookup(name string) (ToolEntry, bool) {
+	entry, ok := c.Tools[name]
+	return entry, ok
+}
+
+func (c *ToolCatalog) CoreTools() []string {
+	var names []string
+	for name, entry := range c.Tools {
+		if entry.Tier == "core" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (c *ToolCatalog) HighestTier(tools []string) string {
+	highest := "core"
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if tierOrder[entry.Tier] > tierOrder[highest] {
+			highest = entry.Tier
+		}
+	}
+	return highest
+}
+
+func (c *ToolCatalog) MaxRiskScore(tools []string) int {
+	max := 0
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if entry.Risk.Score > max {
+			max = entry.Risk.Score
+		}
+	}
+	return max
+}
+
+func (c *ToolCatalog) PackageNames(tools []string, distro string) []string {
+	var pkgs []string
+	for _, name := range tools {
+		entry, ok := c.Tools[name]
+		if !ok {
+			continue
+		}
+		if pkg, ok := entry.Package[distro]; ok {
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs
+}
+
+func (c *ToolCatalog) Validate(tools []string) error {
+	for _, name := range tools {
+		if _, ok := c.Tools[name]; !ok {
+			return fmt.Errorf("unknown tool %q not in catalog", name)
+		}
+	}
+	return nil
+}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
 	"os"
@@ -37,7 +38,9 @@ func LoadFromFile(path string) (*ToolCatalog, error) {
 
 func parse(data []byte) (*ToolCatalog, error) {
 	var cat ToolCatalog
-	if err := yaml.Unmarshal(data, &cat); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cat); err != nil {
 		return nil, fmt.Errorf("parse catalog: %w", err)
 	}
 	return &cat, nil
@@ -66,7 +69,11 @@ func (c *ToolCatalog) HighestTier(tools []string) string {
 		if !ok {
 			continue
 		}
-		if tierOrder[entry.Tier] > tierOrder[highest] {
+		order, known := tierOrder[entry.Tier]
+		if !known {
+			continue
+		}
+		if order > tierOrder[highest] {
 			highest = entry.Tier
 		}
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,0 +1,137 @@
+package catalog
+
+import "testing"
+
+func TestLoadDefault(t *testing.T) {
+	cat, err := LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
+	if cat.Metadata.Name != "docsclaw-default" {
+		t.Errorf("name = %q, want docsclaw-default", cat.Metadata.Name)
+	}
+	if _, ok := cat.Tools["curl"]; !ok {
+		t.Error("curl not in default catalog")
+	}
+	if _, ok := cat.Tools["jq"]; !ok {
+		t.Error("jq not in default catalog")
+	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	cat, err := LoadFromFile("testdata/custom-catalog.yaml")
+	if err != nil {
+		t.Fatalf("LoadFromFile() error: %v", err)
+	}
+	if cat.Metadata.Name != "test-catalog" {
+		t.Errorf("name = %q, want test-catalog", cat.Metadata.Name)
+	}
+}
+
+func TestLookupTool(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	entry, ok := cat.Lookup("curl")
+	if !ok {
+		t.Fatal("curl not found")
+	}
+	if entry.Tier != "core" {
+		t.Errorf("curl tier = %q, want core", entry.Tier)
+	}
+
+	_, ok = cat.Lookup("nonexistent")
+	if ok {
+		t.Error("nonexistent tool should not be found")
+	}
+}
+
+func TestCoreTierTools(t *testing.T) {
+	cat, _ := LoadDefault()
+	core := cat.CoreTools()
+	if len(core) == 0 {
+		t.Fatal("no core tools found")
+	}
+	for _, name := range core {
+		entry, _ := cat.Lookup(name)
+		if entry.Tier != "core" {
+			t.Errorf("%s tier = %q, want core", name, entry.Tier)
+		}
+	}
+}
+
+func TestHighestTier(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	tests := []struct {
+		tools []string
+		want  string
+	}{
+		{[]string{"curl", "jq"}, "core"},
+		{[]string{"curl", "git"}, "standard"},
+		{[]string{"curl", "pandoc"}, "extended"},
+		{[]string{"curl", "python3"}, "runtime"},
+	}
+	for _, tt := range tests {
+		got := cat.HighestTier(tt.tools)
+		if got != tt.want {
+			t.Errorf("HighestTier(%v) = %q, want %q", tt.tools, got, tt.want)
+		}
+	}
+}
+
+func TestMaxRiskScore(t *testing.T) {
+	cat, _ := LoadDefault()
+	score := cat.MaxRiskScore([]string{"curl", "jq"})
+	if score < 1 || score > 3 {
+		t.Errorf("core-only risk score = %d, expected 1-3", score)
+	}
+
+	score = cat.MaxRiskScore([]string{"curl", "python3"})
+	if score < 7 {
+		t.Errorf("python3 risk score = %d, expected >= 7", score)
+	}
+}
+
+func TestPackageName(t *testing.T) {
+	cat, _ := LoadDefault()
+	entry, _ := cat.Lookup("openssh-client")
+	if entry.Package["dnf"] != "openssh-clients" {
+		t.Errorf("openssh-client dnf package = %q, want openssh-clients", entry.Package["dnf"])
+	}
+}
+
+func TestPackageNames(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	dnfPkgs := cat.PackageNames([]string{"curl", "jq", "openssh-client"}, "dnf")
+	if len(dnfPkgs) != 3 {
+		t.Errorf("dnf packages = %d, want 3", len(dnfPkgs))
+	}
+
+	apkPkgs := cat.PackageNames([]string{"curl", "jq"}, "apk")
+	if len(apkPkgs) != 2 {
+		t.Errorf("apk packages = %d, want 2", len(apkPkgs))
+	}
+
+	// Unknown tool should be skipped
+	pkgs := cat.PackageNames([]string{"curl", "unknown"}, "dnf")
+	if len(pkgs) != 1 {
+		t.Errorf("packages with unknown = %d, want 1", len(pkgs))
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cat, _ := LoadDefault()
+
+	// Valid tools
+	err := cat.Validate([]string{"curl", "jq", "git"})
+	if err != nil {
+		t.Errorf("Validate() with valid tools: %v", err)
+	}
+
+	// Invalid tool
+	err = cat.Validate([]string{"curl", "unknown"})
+	if err == nil {
+		t.Error("Validate() with unknown tool should error")
+	}
+}

--- a/pkg/catalog/default.yaml
+++ b/pkg/catalog/default.yaml
@@ -1,0 +1,153 @@
+apiVersion: docsclaw.io/v1alpha1
+kind: ToolCatalog
+metadata:
+  name: docsclaw-default
+  version: 1.0.0
+tiers:
+  core:
+    description: "Always included"
+    autoInclude: true
+  standard:
+    description: "Low risk, small footprint"
+  extended:
+    description: "Medium risk, larger footprint"
+    warning: "These tools expand the image attack surface."
+  runtime:
+    description: "High risk, full language runtimes"
+    warning: "Adds a full scripting runtime (~40-100 MB)."
+tools:
+  curl:
+    tier: core
+    package:
+      dnf: curl
+      apk: curl
+    size: ~1MB
+    description: "HTTP client for API requests"
+    risk:
+      score: 2
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 2
+        cveHistory: low
+      rationale: "Network-capable but single-purpose"
+  jq:
+    tier: core
+    package:
+      dnf: jq
+      apk: jq
+    size: ~1MB
+    description: "JSON processor for parsing API responses"
+    risk:
+      score: 1
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 1
+        cveHistory: low
+      rationale: "Single-purpose binary, minimal surface"
+  git:
+    tier: standard
+    package:
+      dnf: git
+      apk: git
+    size: ~15MB
+    description: "Version control for code-related workflows"
+    risk:
+      score: 4
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 8
+        cveHistory: medium
+      rationale: "Network-capable, moderate dependency tree"
+  openssh-client:
+    tier: standard
+    package:
+      dnf: openssh-clients
+      apk: openssh-client
+    size: ~5MB
+    description: "SSH client for remote operations"
+    risk:
+      score: 4
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 5
+        cveHistory: medium
+      rationale: "Network-capable, handles credentials"
+  pandoc:
+    tier: extended
+    package:
+      dnf: pandoc
+      apk: pandoc
+    size: ~25MB
+    description: "Universal document converter"
+    risk:
+      score: 3
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 6
+        cveHistory: low
+      rationale: "Parses complex formats, moderate deps"
+  poppler-utils:
+    tier: extended
+    package:
+      dnf: poppler-utils
+      apk: poppler-utils
+    size: ~10MB
+    description: "PDF text extraction"
+    risk:
+      score: 3
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 8
+        cveHistory: medium
+      rationale: "Parses untrusted PDF input"
+  imagemagick:
+    tier: extended
+    package:
+      dnf: ImageMagick
+      apk: imagemagick
+    size: ~20MB
+    description: "Image conversion and manipulation"
+    risk:
+      score: 5
+      factors:
+        codeExecution: false
+        networkCapable: false
+        dependencies: 15
+        cveHistory: high
+      rationale: "Large dependency tree, extensive CVE history"
+  python3:
+    tier: runtime
+    package:
+      dnf: python3
+      apk: python3
+    size: ~45MB
+    description: "Python interpreter for scripting"
+    risk:
+      score: 8
+      factors:
+        codeExecution: true
+        networkCapable: false
+        dependencies: 12
+        cveHistory: high
+      rationale: "Full interpreter enables arbitrary code execution"
+  nodejs:
+    tier: runtime
+    package:
+      dnf: nodejs
+      apk: nodejs
+    size: ~60MB
+    description: "Node.js runtime for JavaScript tools"
+    risk:
+      score: 8
+      factors:
+        codeExecution: true
+        networkCapable: false
+        dependencies: 10
+        cveHistory: high
+      rationale: "Full interpreter enables arbitrary code execution"

--- a/pkg/catalog/testdata/custom-catalog.yaml
+++ b/pkg/catalog/testdata/custom-catalog.yaml
@@ -1,0 +1,25 @@
+apiVersion: docsclaw.io/v1alpha1
+kind: ToolCatalog
+metadata:
+  name: test-catalog
+  version: 1.0.0
+tiers:
+  core:
+    description: "Always included"
+    autoInclude: true
+tools:
+  curl:
+    tier: core
+    package:
+      dnf: curl
+      apk: curl
+    size: ~1MB
+    description: "HTTP client"
+    risk:
+      score: 2
+      factors:
+        codeExecution: false
+        networkCapable: true
+        dependencies: 2
+        cveHistory: low
+      rationale: "Network-capable but single-purpose"

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -1,0 +1,41 @@
+package catalog
+
+type ToolCatalog struct {
+	APIVersion string                `yaml:"apiVersion"`
+	Kind       string                `yaml:"kind"`
+	Metadata   CatalogMeta           `yaml:"metadata"`
+	Tiers      map[string]TierDef    `yaml:"tiers"`
+	Tools      map[string]ToolEntry  `yaml:"tools"`
+}
+
+type CatalogMeta struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type TierDef struct {
+	Description string `yaml:"description"`
+	AutoInclude bool   `yaml:"autoInclude,omitempty"`
+	Warning     string `yaml:"warning,omitempty"`
+}
+
+type ToolEntry struct {
+	Tier        string            `yaml:"tier"`
+	Package     map[string]string `yaml:"package"`
+	Size        string            `yaml:"size"`
+	Description string            `yaml:"description"`
+	Risk        RiskScore         `yaml:"risk"`
+}
+
+type RiskScore struct {
+	Score     int         `yaml:"score"`
+	Factors   RiskFactors `yaml:"factors"`
+	Rationale string      `yaml:"rationale"`
+}
+
+type RiskFactors struct {
+	CodeExecution  bool   `yaml:"codeExecution"`
+	NetworkCapable bool   `yaml:"networkCapable"`
+	Dependencies   int    `yaml:"dependencies"`
+	CVEHistory     string `yaml:"cveHistory"`
+}

--- a/pkg/manifest/agentconfig.go
+++ b/pkg/manifest/agentconfig.go
@@ -1,0 +1,52 @@
+package manifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+func BuildAgentConfigYAML(m *AgentManifest) string {
+	var b strings.Builder
+
+	b.WriteString("tools:\n")
+	if len(m.Spec.Runtime.Tools.Allowed) > 0 {
+		b.WriteString("  allowed:\n")
+		for _, tool := range m.Spec.Runtime.Tools.Allowed {
+			fmt.Fprintf(&b, "    - %s\n", tool)
+		}
+	}
+
+	if m.Spec.Runtime.Tools.Exec.Timeout > 0 || m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
+		b.WriteString("  exec:\n")
+		if m.Spec.Runtime.Tools.Exec.Timeout > 0 {
+			fmt.Fprintf(&b, "    timeout: %d\n", m.Spec.Runtime.Tools.Exec.Timeout)
+		}
+		if m.Spec.Runtime.Tools.Exec.MaxOutput > 0 {
+			fmt.Fprintf(&b, "    maxOutput: %d\n", m.Spec.Runtime.Tools.Exec.MaxOutput)
+		}
+	}
+
+	if len(m.Spec.Runtime.Tools.WebFetch.AllowedHosts) > 0 {
+		b.WriteString("  webFetch:\n")
+		b.WriteString("    allowedHosts:\n")
+		for _, host := range m.Spec.Runtime.Tools.WebFetch.AllowedHosts {
+			fmt.Fprintf(&b, "      - %s\n", host)
+		}
+	}
+
+	if m.Spec.Runtime.Loop.MaxIterations > 0 {
+		b.WriteString("loop:\n")
+		fmt.Fprintf(&b, "  maxIterations: %d\n", m.Spec.Runtime.Loop.MaxIterations)
+	}
+
+	return b.String()
+}
+
+func HasRuntimeConfig(m *AgentManifest) bool {
+	r := m.Spec.Runtime
+	return len(r.Tools.Allowed) > 0 ||
+		r.Tools.Exec.Timeout > 0 ||
+		r.Tools.Exec.MaxOutput > 0 ||
+		len(r.Tools.WebFetch.AllowedHosts) > 0 ||
+		r.Loop.MaxIterations > 0
+}

--- a/pkg/manifest/check.go
+++ b/pkg/manifest/check.go
@@ -1,0 +1,67 @@
+package manifest
+
+import (
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+	skillcard "github.com/redhat-et/docsclaw/pkg/skills/card"
+)
+
+type SkillCheck struct {
+	Name         string
+	Required     []string
+	Optional     []string
+	HasSkillYAML bool
+}
+
+type CheckResult struct {
+	SkillName       string
+	Satisfied       bool
+	Unknown         bool
+	MissingRequired []string
+	MissingOptional []string
+}
+
+func SkillCheckFromCard(card skillcard.SkillCard) SkillCheck {
+	return SkillCheck{
+		Name:         card.Metadata.Name,
+		Required:     card.Spec.Tools.Required,
+		Optional:     card.Spec.Tools.Optional,
+		HasSkillYAML: true,
+	}
+}
+
+func CheckCompatibility(manifestTools []string, skills []SkillCheck, cat *catalog.ToolCatalog) []CheckResult {
+	installed := make(map[string]bool, len(manifestTools))
+	for _, t := range manifestTools {
+		installed[t] = true
+	}
+	for _, name := range cat.CoreTools() {
+		installed[name] = true
+	}
+
+	var results []CheckResult
+	for _, skill := range skills {
+		r := CheckResult{SkillName: skill.Name}
+
+		if !skill.HasSkillYAML {
+			r.Satisfied = true
+			r.Unknown = true
+			results = append(results, r)
+			continue
+		}
+
+		r.Satisfied = true
+		for _, req := range skill.Required {
+			if !installed[req] {
+				r.MissingRequired = append(r.MissingRequired, req)
+				r.Satisfied = false
+			}
+		}
+		for _, opt := range skill.Optional {
+			if !installed[opt] {
+				r.MissingOptional = append(r.MissingOptional, opt)
+			}
+		}
+		results = append(results, r)
+	}
+	return results
+}

--- a/pkg/manifest/check_test.go
+++ b/pkg/manifest/check_test.go
@@ -1,0 +1,99 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+	skillcard "github.com/redhat-et/docsclaw/pkg/skills/card"
+)
+
+func TestCheckCompatibility_AllSatisfied(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{Name: "nps-api", Required: []string{"curl", "jq"}, HasSkillYAML: true},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if len(results) != 1 {
+		t.Fatalf("results count = %d, want 1", len(results))
+	}
+	if !results[0].Satisfied {
+		t.Error("nps-api should be satisfied")
+	}
+	if len(results[0].MissingRequired) != 0 {
+		t.Errorf("missing required = %v, want none", results[0].MissingRequired)
+	}
+}
+
+func TestCheckCompatibility_MissingRequired(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{Name: "doc-converter", Required: []string{"curl", "pandoc"}, HasSkillYAML: true},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if results[0].Satisfied {
+		t.Error("doc-converter should NOT be satisfied")
+	}
+	if len(results[0].MissingRequired) != 1 || results[0].MissingRequired[0] != "pandoc" {
+		t.Errorf("missing required = %v, want [pandoc]", results[0].MissingRequired)
+	}
+}
+
+func TestCheckCompatibility_OptionalMissing(t *testing.T) {
+	tools := []string{"curl", "jq"}
+	skills := []SkillCheck{
+		{
+			Name:         "nps-api",
+			Required:     []string{"curl", "jq"},
+			Optional:     []string{"python3"},
+			HasSkillYAML: true,
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if !results[0].Satisfied {
+		t.Error("should be satisfied (optional missing is OK)")
+	}
+	if len(results[0].MissingOptional) != 1 || results[0].MissingOptional[0] != "python3" {
+		t.Errorf("missing optional = %v, want [python3]", results[0].MissingOptional)
+	}
+}
+
+func TestCheckCompatibility_NoSkillYAML(t *testing.T) {
+	tools := []string{"curl"}
+	skills := []SkillCheck{
+		{Name: "unknown-skill", HasSkillYAML: false},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	results := CheckCompatibility(tools, skills, cat)
+	if !results[0].Satisfied {
+		t.Error("skill without skill.yaml should be marked satisfied")
+	}
+	if !results[0].Unknown {
+		t.Error("should be marked as unknown requirements")
+	}
+}
+
+func TestSkillCheckFromCard(t *testing.T) {
+	card := skillcard.SkillCard{
+		Metadata: skillcard.SkillCardMeta{Name: "test-skill"},
+		Spec: skillcard.SkillCardSpec{
+			Tools: skillcard.ToolDeps{
+				Required: []string{"curl"},
+				Optional: []string{"jq"},
+			},
+		},
+	}
+	sc := SkillCheckFromCard(card)
+	if sc.Name != "test-skill" {
+		t.Errorf("name = %q, want test-skill", sc.Name)
+	}
+	if !sc.HasSkillYAML {
+		t.Error("should have HasSkillYAML = true")
+	}
+}

--- a/pkg/manifest/check_test.go
+++ b/pkg/manifest/check_test.go
@@ -12,7 +12,10 @@ func TestCheckCompatibility_AllSatisfied(t *testing.T) {
 	skills := []SkillCheck{
 		{Name: "nps-api", Required: []string{"curl", "jq"}, HasSkillYAML: true},
 	}
-	cat, _ := catalog.LoadDefault()
+	cat, err := catalog.LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
 
 	results := CheckCompatibility(tools, skills, cat)
 	if len(results) != 1 {
@@ -31,7 +34,10 @@ func TestCheckCompatibility_MissingRequired(t *testing.T) {
 	skills := []SkillCheck{
 		{Name: "doc-converter", Required: []string{"curl", "pandoc"}, HasSkillYAML: true},
 	}
-	cat, _ := catalog.LoadDefault()
+	cat, err := catalog.LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
 
 	results := CheckCompatibility(tools, skills, cat)
 	if results[0].Satisfied {
@@ -52,7 +58,10 @@ func TestCheckCompatibility_OptionalMissing(t *testing.T) {
 			HasSkillYAML: true,
 		},
 	}
-	cat, _ := catalog.LoadDefault()
+	cat, err := catalog.LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
 
 	results := CheckCompatibility(tools, skills, cat)
 	if !results[0].Satisfied {
@@ -68,7 +77,10 @@ func TestCheckCompatibility_NoSkillYAML(t *testing.T) {
 	skills := []SkillCheck{
 		{Name: "unknown-skill", HasSkillYAML: false},
 	}
-	cat, _ := catalog.LoadDefault()
+	cat, err := catalog.LoadDefault()
+	if err != nil {
+		t.Fatalf("LoadDefault() error: %v", err)
+	}
 
 	results := CheckCompatibility(tools, skills, cat)
 	if !results[0].Satisfied {

--- a/pkg/manifest/containerfile.go
+++ b/pkg/manifest/containerfile.go
@@ -10,7 +10,17 @@ import (
 	"github.com/redhat-et/docsclaw/pkg/catalog"
 )
 
-var containerfileTmpl = template.Must(template.New("containerfile").Parse(`FROM {{ .BaseImage }}
+var containerfileTmpl = template.Must(template.New("containerfile").Parse(`FROM {{ .GoBuilderImage }} AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /docsclaw ./cmd/docsclaw
+
+FROM {{ .BaseImage }}
 
 LABEL io.docsclaw.tools/installed="{{ .InstalledCSV }}"
 LABEL io.docsclaw.tools/tier="{{ .HighestTier }}"
@@ -18,11 +28,11 @@ LABEL io.docsclaw.tools/risk-score="{{ .RiskScore }}"
 LABEL io.docsclaw.tools/agent-name="{{ .AgentName }}"
 
 USER root
-{{ if .HasBuilder -}}
+{{ if .HasToolBuilder -}}
 # Adding tools to the minimal hardened image expands its attack surface.
 # Only add what is strictly necessary for runtime operation.
 # Review each addition with your security team.
-RUN --mount=type=bind,from={{ .BuilderImage }},target=/builder \
+RUN --mount=type=bind,from={{ .ToolBuilderImage }},target=/builder \
     LD_LIBRARY_PATH=/builder/lib64:/builder/usr/lib64 \
     RPM_CONFIGDIR=/builder/usr/lib/rpm \
     /builder/usr/bin/dnf install -y \
@@ -36,7 +46,7 @@ RUN mkdir -p /etc/docsclaw
 USER 65532
 
 WORKDIR /app
-COPY docsclaw /app/docsclaw
+COPY --from=builder /docsclaw /app/docsclaw
 COPY tools.json /etc/docsclaw/tools.json
 
 EXPOSE 8000
@@ -46,14 +56,15 @@ CMD ["serve"]
 `))
 
 type containerfileData struct {
-	BaseImage    string
-	BuilderImage string
-	HasBuilder   bool
-	AgentName    string
-	InstalledCSV string
-	HighestTier  string
-	RiskScore    int
-	PackageList  string
+	GoBuilderImage  string
+	BaseImage       string
+	ToolBuilderImage string
+	HasToolBuilder  bool
+	AgentName       string
+	InstalledCSV    string
+	HighestTier     string
+	RiskScore       int
+	PackageList     string
 }
 
 func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, error) {
@@ -63,15 +74,21 @@ func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, 
 	pkgs := cat.PackageNames(allTools, "dnf")
 	sort.Strings(pkgs)
 
+	goBuilder := m.Spec.Base.GoBuilder
+	if goBuilder == "" {
+		goBuilder = "registry.access.redhat.com/hi/go:latest"
+	}
+
 	data := containerfileData{
-		BaseImage:    m.Spec.Base.Image,
-		BuilderImage: m.Spec.Base.Builder,
-		HasBuilder:   m.Spec.Base.Builder != "",
-		AgentName:    m.Metadata.Name,
-		InstalledCSV: strings.Join(allTools, ","),
-		HighestTier:  cat.HighestTier(allTools),
-		RiskScore:    cat.MaxRiskScore(allTools),
-		PackageList:  strings.Join(pkgs, " "),
+		GoBuilderImage:  goBuilder,
+		BaseImage:       m.Spec.Base.Image,
+		ToolBuilderImage: m.Spec.Base.ToolBuilder,
+		HasToolBuilder:  m.Spec.Base.ToolBuilder != "",
+		AgentName:       m.Metadata.Name,
+		InstalledCSV:    strings.Join(allTools, ","),
+		HighestTier:     cat.HighestTier(allTools),
+		RiskScore:       cat.MaxRiskScore(allTools),
+		PackageList:     strings.Join(pkgs, " "),
 	}
 
 	var buf bytes.Buffer

--- a/pkg/manifest/containerfile.go
+++ b/pkg/manifest/containerfile.go
@@ -16,11 +16,12 @@ LABEL io.docsclaw.tools/installed="{{ .InstalledCSV }}"
 LABEL io.docsclaw.tools/tier="{{ .HighestTier }}"
 LABEL io.docsclaw.tools/risk-score="{{ .RiskScore }}"
 LABEL io.docsclaw.tools/agent-name="{{ .AgentName }}"
-{{ if .HasBuilder }}
+
+USER root
+{{ if .HasBuilder -}}
 # Adding tools to the minimal hardened image expands its attack surface.
 # Only add what is strictly necessary for runtime operation.
 # Review each addition with your security team.
-USER root
 RUN --mount=type=bind,from={{ .BuilderImage }},target=/builder \
     LD_LIBRARY_PATH=/builder/lib64:/builder/usr/lib64 \
     RPM_CONFIGDIR=/builder/usr/lib/rpm \
@@ -30,10 +31,13 @@ RUN --mount=type=bind,from={{ .BuilderImage }},target=/builder \
     --setopt=install_weak_deps=False \
     --setopt=tsflags=nodocs \
     {{ .PackageList }}
+{{ end -}}
+RUN mkdir -p /etc/docsclaw
 USER 65532
-{{ end }}
+
 WORKDIR /app
 COPY docsclaw /app/docsclaw
+COPY tools.json /etc/docsclaw/tools.json
 
 EXPOSE 8000
 

--- a/pkg/manifest/containerfile.go
+++ b/pkg/manifest/containerfile.go
@@ -1,0 +1,96 @@
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+var containerfileTmpl = template.Must(template.New("containerfile").Parse(`FROM {{ .BaseImage }}
+
+LABEL io.docsclaw.tools/installed="{{ .InstalledCSV }}"
+LABEL io.docsclaw.tools/tier="{{ .HighestTier }}"
+LABEL io.docsclaw.tools/risk-score="{{ .RiskScore }}"
+LABEL io.docsclaw.tools/agent-name="{{ .AgentName }}"
+{{ if .HasBuilder }}
+# Adding tools to the minimal hardened image expands its attack surface.
+# Only add what is strictly necessary for runtime operation.
+# Review each addition with your security team.
+USER root
+RUN --mount=type=bind,from={{ .BuilderImage }},target=/builder \
+    LD_LIBRARY_PATH=/builder/lib64:/builder/usr/lib64 \
+    RPM_CONFIGDIR=/builder/usr/lib/rpm \
+    /builder/usr/bin/dnf install -y \
+    --installroot=/ \
+    --setopt=reposdir=/builder/etc/yum.repos.d \
+    --setopt=install_weak_deps=False \
+    --setopt=tsflags=nodocs \
+    {{ .PackageList }}
+USER 65532
+{{ end }}
+WORKDIR /app
+COPY docsclaw /app/docsclaw
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docsclaw"]
+CMD ["serve"]
+`))
+
+type containerfileData struct {
+	BaseImage    string
+	BuilderImage string
+	HasBuilder   bool
+	AgentName    string
+	InstalledCSV string
+	HighestTier  string
+	RiskScore    int
+	PackageList  string
+}
+
+func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, error) {
+	allTools := mergeWithCore(m.Spec.Tools, cat)
+	sort.Strings(allTools)
+
+	pkgs := cat.PackageNames(allTools, "dnf")
+	sort.Strings(pkgs)
+
+	data := containerfileData{
+		BaseImage:    m.Spec.Base.Image,
+		BuilderImage: m.Spec.Base.Builder,
+		HasBuilder:   m.Spec.Base.Builder != "",
+		AgentName:    m.Metadata.Name,
+		InstalledCSV: strings.Join(allTools, ","),
+		HighestTier:  cat.HighestTier(allTools),
+		RiskScore:    cat.MaxRiskScore(allTools),
+		PackageList:  strings.Join(pkgs, " "),
+	}
+
+	var buf bytes.Buffer
+	if err := containerfileTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("render containerfile: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func mergeWithCore(tools []string, cat *catalog.ToolCatalog) []string {
+	seen := make(map[string]bool)
+	var merged []string
+	for _, name := range cat.CoreTools() {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	for _, name := range tools {
+		if !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	return merged
+}

--- a/pkg/manifest/containerfile.go
+++ b/pkg/manifest/containerfile.go
@@ -68,7 +68,7 @@ type containerfileData struct {
 }
 
 func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, error) {
-	allTools := mergeWithCore(m.Spec.Tools, cat)
+	allTools := MergeWithCore(m.Spec.Tools, cat)
 	sort.Strings(allTools)
 
 	pkgs := cat.PackageNames(allTools, "dnf")
@@ -98,7 +98,7 @@ func GenerateContainerfile(m *AgentManifest, cat *catalog.ToolCatalog) (string, 
 	return buf.String(), nil
 }
 
-func mergeWithCore(tools []string, cat *catalog.ToolCatalog) []string {
+func MergeWithCore(tools []string, cat *catalog.ToolCatalog) []string {
 	seen := make(map[string]bool)
 	var merged []string
 	for _, name := range cat.CoreTools() {

--- a/pkg/manifest/containerfile_test.go
+++ b/pkg/manifest/containerfile_test.go
@@ -34,6 +34,8 @@ func TestGenerateContainerfile_HardenedImage(t *testing.T) {
 		"curl git jq",
 		"USER 65532",
 		"COPY docsclaw /app/docsclaw",
+		"COPY tools.json /etc/docsclaw/tools.json",
+		"mkdir -p /etc/docsclaw",
 	}
 	for _, want := range checks {
 		if !strings.Contains(out, want) {
@@ -87,5 +89,11 @@ func TestGenerateContainerfile_CoreOnlyNoBuilder(t *testing.T) {
 
 	if !strings.Contains(out, "FROM registry.access.redhat.com/hi/core-runtime:latest") {
 		t.Error("missing FROM line")
+	}
+	if !strings.Contains(out, "COPY tools.json /etc/docsclaw/tools.json") {
+		t.Error("missing tools.json COPY even without builder")
+	}
+	if !strings.Contains(out, "mkdir -p /etc/docsclaw") {
+		t.Error("missing /etc/docsclaw mkdir even without builder")
 	}
 }

--- a/pkg/manifest/containerfile_test.go
+++ b/pkg/manifest/containerfile_test.go
@@ -13,7 +13,7 @@ func TestGenerateContainerfile_HardenedImage(t *testing.T) {
 		Spec: ManifestSpec{
 			Base: BaseImage{
 				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
-				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+				ToolBuilder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
 			},
 			Tools: []string{"curl", "jq", "git"},
 		},
@@ -26,6 +26,8 @@ func TestGenerateContainerfile_HardenedImage(t *testing.T) {
 	}
 
 	checks := []string{
+		"FROM registry.access.redhat.com/hi/go:latest AS builder",
+		"go build -o /docsclaw ./cmd/docsclaw",
 		"FROM registry.access.redhat.com/hi/core-runtime:latest",
 		"io.docsclaw.tools/installed",
 		"curl,git,jq",
@@ -33,7 +35,7 @@ func TestGenerateContainerfile_HardenedImage(t *testing.T) {
 		"/builder/usr/bin/dnf install -y",
 		"curl git jq",
 		"USER 65532",
-		"COPY docsclaw /app/docsclaw",
+		"COPY --from=builder /docsclaw /app/docsclaw",
 		"COPY tools.json /etc/docsclaw/tools.json",
 		"mkdir -p /etc/docsclaw",
 	}
@@ -50,7 +52,7 @@ func TestGenerateContainerfile_Labels(t *testing.T) {
 		Spec: ManifestSpec{
 			Base: BaseImage{
 				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
-				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+				ToolBuilder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
 			},
 			Tools: []string{"curl", "jq", "python3"},
 		},

--- a/pkg/manifest/containerfile_test.go
+++ b/pkg/manifest/containerfile_test.go
@@ -1,0 +1,91 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+func TestGenerateContainerfile_HardenedImage(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "test-agent"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
+				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+			},
+			Tools: []string{"curl", "jq", "git"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateContainerfile() error: %v", err)
+	}
+
+	checks := []string{
+		"FROM registry.access.redhat.com/hi/core-runtime:latest",
+		"io.docsclaw.tools/installed",
+		"curl,git,jq",
+		"--mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-builder",
+		"/builder/usr/bin/dnf install -y",
+		"curl git jq",
+		"USER 65532",
+		"COPY docsclaw /app/docsclaw",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestGenerateContainerfile_Labels(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "my-agent"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image:   "registry.access.redhat.com/hi/core-runtime:latest",
+				Builder: "registry.access.redhat.com/hi/core-runtime:latest-builder",
+			},
+			Tools: []string{"curl", "jq", "python3"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateContainerfile() error: %v", err)
+	}
+
+	if !strings.Contains(out, `io.docsclaw.tools/tier="runtime"`) {
+		t.Error("missing tier label for runtime")
+	}
+	if !strings.Contains(out, `io.docsclaw.tools/agent-name="my-agent"`) {
+		t.Error("missing agent-name label")
+	}
+}
+
+func TestGenerateContainerfile_CoreOnlyNoBuilder(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "minimal"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image: "registry.access.redhat.com/hi/core-runtime:latest",
+			},
+			Tools: []string{"curl", "jq"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	out, err := GenerateContainerfile(m, cat)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(out, "FROM registry.access.redhat.com/hi/core-runtime:latest") {
+		t.Error("missing FROM line")
+	}
+}

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -151,7 +151,7 @@ metadata:
     app: {{.Name}}
 data:
   system-prompt.txt: |
-    {{.SystemPrompt}}
+{{.SystemPrompt | nindent 4}}
   agent-config.yaml: |
 {{.AgentConfigYAML | nindent 4}}
 `))

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -43,19 +43,24 @@ func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error
 	output.ConfigMap = cmBuf.String()
 
 	// Deployment
+	agentImage := m.Spec.Deploy.Image
+	if agentImage == "" {
+		agentImage = m.Spec.Base.Image
+	}
+
 	deployData := struct {
-		Name      string
-		BaseImage string
-		Skills    []SkillRef
-		Replicas  int
-		Resources ResourceConfig
+		Name       string
+		AgentImage string
+		Skills     []SkillRef
+		Replicas   int
+		Resources  ResourceConfig
 		HasSecrets bool
 	}{
-		Name:      m.Metadata.Name,
-		BaseImage: m.Spec.Base.Image,
-		Skills:    m.Spec.Skills,
-		Replicas:  m.Spec.Deploy.Replicas,
-		Resources: m.Spec.Deploy.Resources,
+		Name:       m.Metadata.Name,
+		AgentImage: agentImage,
+		Skills:     m.Spec.Skills,
+		Replicas:   m.Spec.Deploy.Replicas,
+		Resources:  m.Spec.Deploy.Resources,
 		HasSecrets: len(secrets) > 0,
 	}
 	if deployData.Replicas == 0 {
@@ -206,7 +211,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: agent
-        image: {{.BaseImage}}
+        image: {{.AgentImage}}
         args:
         - serve
         - --config-dir

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -19,11 +19,7 @@ type K8sOutput struct {
 func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error) {
 	output := &K8sOutput{}
 
-	// Generate agent-config.yaml content
-	agentConfigYAML, err := buildAgentConfigYAML(m)
-	if err != nil {
-		return nil, fmt.Errorf("build agent-config.yaml: %w", err)
-	}
+	agentConfigYAML := BuildAgentConfigYAML(m)
 
 	// ConfigMap
 	cmData := struct {
@@ -119,34 +115,6 @@ func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error
 	return output, nil
 }
 
-func buildAgentConfigYAML(m *AgentManifest) (string, error) {
-	var buf strings.Builder
-
-	rt := m.Spec.Runtime
-
-	buf.WriteString("tools:\n")
-	buf.WriteString("  allowed:\n")
-	for _, t := range rt.Tools.Allowed {
-		fmt.Fprintf(&buf, "    - %s\n", t)
-	}
-
-	if rt.Tools.Exec.Timeout > 0 || rt.Tools.Exec.MaxOutput > 0 {
-		buf.WriteString("  exec:\n")
-		if rt.Tools.Exec.Timeout > 0 {
-			fmt.Fprintf(&buf, "    timeout: %d\n", rt.Tools.Exec.Timeout)
-		}
-		if rt.Tools.Exec.MaxOutput > 0 {
-			fmt.Fprintf(&buf, "    maxOutput: %d\n", rt.Tools.Exec.MaxOutput)
-		}
-	}
-
-	if rt.Loop.MaxIterations > 0 {
-		buf.WriteString("loop:\n")
-		fmt.Fprintf(&buf, "  maxIterations: %d\n", rt.Loop.MaxIterations)
-	}
-
-	return buf.String(), nil
-}
 
 func encodeSecrets(secrets map[string]string) map[string]string {
 	encoded := make(map[string]string, len(secrets))

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -272,15 +272,15 @@ spec:
 {{- end}}
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /health
             port: health
-          initialDelaySeconds: 10
+          initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: health
-          initialDelaySeconds: 5
+          initialDelaySeconds: 3
           periodSeconds: 5
       volumes:
       - name: agent-config

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -1,0 +1,333 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+type K8sOutput struct {
+	ConfigMap      string
+	Deployment     string
+	Service        string
+	ServiceAccount string
+	Secret         string
+}
+
+func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error) {
+	output := &K8sOutput{}
+
+	// Generate agent-config.yaml content
+	agentConfigYAML, err := buildAgentConfigYAML(m)
+	if err != nil {
+		return nil, fmt.Errorf("build agent-config.yaml: %w", err)
+	}
+
+	// ConfigMap
+	cmData := struct {
+		Name            string
+		SystemPrompt    string
+		AgentConfigYAML string
+	}{
+		Name:            m.Metadata.Name,
+		SystemPrompt:    m.Spec.Prompt.Text,
+		AgentConfigYAML: agentConfigYAML,
+	}
+
+	var cmBuf bytes.Buffer
+	if err := configMapTemplate.Execute(&cmBuf, cmData); err != nil {
+		return nil, fmt.Errorf("execute configmap template: %w", err)
+	}
+	output.ConfigMap = cmBuf.String()
+
+	// Deployment
+	deployData := struct {
+		Name      string
+		BaseImage string
+		Skills    []SkillRef
+		Replicas  int
+		Resources ResourceConfig
+		HasSecrets bool
+	}{
+		Name:      m.Metadata.Name,
+		BaseImage: m.Spec.Base.Image,
+		Skills:    m.Spec.Skills,
+		Replicas:  m.Spec.Deploy.Replicas,
+		Resources: m.Spec.Deploy.Resources,
+		HasSecrets: len(secrets) > 0,
+	}
+	if deployData.Replicas == 0 {
+		deployData.Replicas = 1
+	}
+
+	var deployBuf bytes.Buffer
+	if err := deploymentTemplate.Execute(&deployBuf, deployData); err != nil {
+		return nil, fmt.Errorf("execute deployment template: %w", err)
+	}
+	output.Deployment = deployBuf.String()
+
+	// Service
+	svcData := struct {
+		Name string
+	}{
+		Name: m.Metadata.Name,
+	}
+
+	var svcBuf bytes.Buffer
+	if err := serviceTemplate.Execute(&svcBuf, svcData); err != nil {
+		return nil, fmt.Errorf("execute service template: %w", err)
+	}
+	output.Service = svcBuf.String()
+
+	// ServiceAccount
+	saData := struct {
+		Name string
+	}{
+		Name: "docsclaw-agent",
+	}
+
+	var saBuf bytes.Buffer
+	if err := serviceAccountTemplate.Execute(&saBuf, saData); err != nil {
+		return nil, fmt.Errorf("execute serviceaccount template: %w", err)
+	}
+	output.ServiceAccount = saBuf.String()
+
+	// Secret (only if secrets map provided)
+	if len(secrets) > 0 {
+		secretData := struct {
+			Name    string
+			Secrets map[string]string
+		}{
+			Name:    m.Metadata.Name,
+			Secrets: encodeSecrets(secrets),
+		}
+
+		var secretBuf bytes.Buffer
+		if err := secretTemplate.Execute(&secretBuf, secretData); err != nil {
+			return nil, fmt.Errorf("execute secret template: %w", err)
+		}
+		output.Secret = secretBuf.String()
+	}
+
+	return output, nil
+}
+
+func buildAgentConfigYAML(m *AgentManifest) (string, error) {
+	var buf strings.Builder
+
+	rt := m.Spec.Runtime
+
+	buf.WriteString("tools:\n")
+	buf.WriteString("  allowed:\n")
+	for _, t := range rt.Tools.Allowed {
+		fmt.Fprintf(&buf, "    - %s\n", t)
+	}
+
+	if rt.Tools.Exec.Timeout > 0 || rt.Tools.Exec.MaxOutput > 0 {
+		buf.WriteString("  exec:\n")
+		if rt.Tools.Exec.Timeout > 0 {
+			fmt.Fprintf(&buf, "    timeout: %d\n", rt.Tools.Exec.Timeout)
+		}
+		if rt.Tools.Exec.MaxOutput > 0 {
+			fmt.Fprintf(&buf, "    maxOutput: %d\n", rt.Tools.Exec.MaxOutput)
+		}
+	}
+
+	if rt.Loop.MaxIterations > 0 {
+		buf.WriteString("loop:\n")
+		fmt.Fprintf(&buf, "  maxIterations: %d\n", rt.Loop.MaxIterations)
+	}
+
+	return buf.String(), nil
+}
+
+func encodeSecrets(secrets map[string]string) map[string]string {
+	encoded := make(map[string]string, len(secrets))
+	for k, v := range secrets {
+		encoded[k] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	return encoded
+}
+
+// nindent indents each line of text by n spaces
+func nindent(n int, text string) string {
+	indent := strings.Repeat(" ", n)
+	lines := strings.Split(text, "\n")
+	var result strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			result.WriteString("\n")
+		}
+		if line != "" {
+			result.WriteString(indent)
+			result.WriteString(line)
+		}
+	}
+	return result.String()
+}
+
+var configMapTemplate = template.Must(template.New("configmap").Funcs(template.FuncMap{
+	"nindent": nindent,
+}).Parse(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.Name}}-config
+  labels:
+    app: {{.Name}}
+data:
+  system-prompt.txt: |
+    {{.SystemPrompt}}
+  agent-config.yaml: |
+{{.AgentConfigYAML | nindent 4}}
+`))
+
+var deploymentTemplate = template.Must(template.New("deployment").Funcs(template.FuncMap{
+	"nindent": nindent,
+}).Parse(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    app: {{.Name}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      app: {{.Name}}
+  template:
+    metadata:
+      labels:
+        app: {{.Name}}
+    spec:
+      serviceAccountName: docsclaw-agent
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: agent
+        image: {{.BaseImage}}
+        args:
+        - serve
+        - --config-dir
+        - /config/agent
+        - --listen-plain-http
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
+        - name: health
+          containerPort: 8100
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+{{- if .HasSecrets}}
+        envFrom:
+        - secretRef:
+            name: {{.Name}}-secrets
+{{- end}}
+        volumeMounts:
+        - name: agent-config
+          mountPath: /config/agent
+          readOnly: true
+{{- range .Skills}}
+        - name: skill-{{.Name}}
+          mountPath: /config/agent/skills/{{.Name}}
+          readOnly: true
+{{- end}}
+        - name: tmp
+          mountPath: /tmp
+{{- if or .Resources.Requests.CPU .Resources.Requests.Memory .Resources.Limits.CPU .Resources.Limits.Memory}}
+        resources:
+{{- if or .Resources.Requests.CPU .Resources.Requests.Memory}}
+          requests:
+{{- if .Resources.Requests.CPU}}
+            cpu: {{.Resources.Requests.CPU}}
+{{- end}}
+{{- if .Resources.Requests.Memory}}
+            memory: {{.Resources.Requests.Memory}}
+{{- end}}
+{{- end}}
+{{- if or .Resources.Limits.CPU .Resources.Limits.Memory}}
+          limits:
+{{- if .Resources.Limits.CPU}}
+            cpu: {{.Resources.Limits.CPU}}
+{{- end}}
+{{- if .Resources.Limits.Memory}}
+            memory: {{.Resources.Limits.Memory}}
+{{- end}}
+{{- end}}
+{{- end}}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: agent-config
+        configMap:
+          name: {{.Name}}-config
+{{- range .Skills}}
+      - name: skill-{{.Name}}
+        image:
+          reference: {{.Image}}
+{{- end}}
+      - name: tmp
+        emptyDir: {}
+`))
+
+var serviceTemplate = template.Must(template.New("service").Parse(`apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Name}}
+  labels:
+    app: {{.Name}}
+spec:
+  selector:
+    app: {{.Name}}
+  ports:
+  - name: http
+    port: 8000
+    targetPort: http
+    protocol: TCP
+  - name: health
+    port: 8100
+    targetPort: health
+    protocol: TCP
+`))
+
+var serviceAccountTemplate = template.Must(template.New("serviceaccount").Parse(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Name}}
+  labels:
+    app: docsclaw
+`))
+
+var secretTemplate = template.Must(template.New("secret").Parse(`apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.Name}}-secrets
+  labels:
+    app: {{.Name}}
+type: Opaque
+data:
+{{- range $key, $value := .Secrets}}
+  {{$key}}: {{$value}}
+{{- end}}
+`))
+

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -44,20 +44,27 @@ func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error
 		agentImage = m.Spec.Base.Image
 	}
 
+	saName := m.Spec.Deploy.ServiceAccount
+	if saName == "" {
+		saName = "docsclaw-agent"
+	}
+
 	deployData := struct {
-		Name       string
-		AgentImage string
-		Skills     []SkillRef
-		Replicas   int
-		Resources  ResourceConfig
-		HasSecrets bool
+		Name           string
+		AgentImage     string
+		ServiceAccount string
+		Skills         []SkillRef
+		Replicas       int
+		Resources      ResourceConfig
+		HasSecrets     bool
 	}{
-		Name:       m.Metadata.Name,
-		AgentImage: agentImage,
-		Skills:     m.Spec.Skills,
-		Replicas:   m.Spec.Deploy.Replicas,
-		Resources:  m.Spec.Deploy.Resources,
-		HasSecrets: len(secrets) > 0,
+		Name:           m.Metadata.Name,
+		AgentImage:     agentImage,
+		ServiceAccount: saName,
+		Skills:         m.Spec.Skills,
+		Replicas:       m.Spec.Deploy.Replicas,
+		Resources:      m.Spec.Deploy.Resources,
+		HasSecrets:     len(secrets) > 0,
 	}
 	if deployData.Replicas == 0 {
 		deployData.Replicas = 1
@@ -86,7 +93,7 @@ func GenerateK8s(m *AgentManifest, secrets map[string]string) (*K8sOutput, error
 	saData := struct {
 		Name string
 	}{
-		Name: "docsclaw-agent",
+		Name: saName,
 	}
 
 	var saBuf bytes.Buffer
@@ -174,7 +181,7 @@ spec:
       labels:
         app: {{.Name}}
     spec:
-      serviceAccountName: docsclaw-agent
+      serviceAccountName: {{.ServiceAccount}}
       securityContext:
         runAsNonRoot: true
       containers:

--- a/pkg/manifest/k8s_test.go
+++ b/pkg/manifest/k8s_test.go
@@ -42,6 +42,9 @@ func TestGenerateK8s_Deployment(t *testing.T) {
 	if !strings.Contains(k8s.Deployment, "skill-nps-api") {
 		t.Error("missing skill volume")
 	}
+	if !strings.Contains(k8s.Deployment, "ghcr.io/redhat-et/nps-agent:1.0.0") {
+		t.Error("missing deploy image in Deployment")
+	}
 }
 
 func TestGenerateK8s_Secret(t *testing.T) {
@@ -116,6 +119,7 @@ func testManifest() *AgentManifest {
 				{Name: "LLM_API_KEY", Required: true},
 			},
 			Deploy: DeployConfig{
+				Image:    "ghcr.io/redhat-et/nps-agent:1.0.0",
 				Replicas: 1,
 				Resources: ResourceConfig{
 					Requests: ResourceValues{CPU: "100m", Memory: "64Mi"},

--- a/pkg/manifest/k8s_test.go
+++ b/pkg/manifest/k8s_test.go
@@ -1,0 +1,127 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateK8s_ConfigMap(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("GenerateK8s() error: %v", err)
+	}
+
+	if !strings.Contains(k8s.ConfigMap, "kind: ConfigMap") {
+		t.Error("missing ConfigMap kind")
+	}
+	if !strings.Contains(k8s.ConfigMap, "name: nps-assistant-config") {
+		t.Error("missing ConfigMap name")
+	}
+	if !strings.Contains(k8s.ConfigMap, "system-prompt.txt") {
+		t.Error("missing system-prompt.txt key")
+	}
+	if !strings.Contains(k8s.ConfigMap, "agent-config.yaml") {
+		t.Error("missing agent-config.yaml key")
+	}
+}
+
+func TestGenerateK8s_Deployment(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(k8s.Deployment, "kind: Deployment") {
+		t.Error("missing Deployment kind")
+	}
+	if !strings.Contains(k8s.Deployment, "runAsNonRoot: true") {
+		t.Error("missing security context")
+	}
+	if !strings.Contains(k8s.Deployment, "skill-nps-api") {
+		t.Error("missing skill volume")
+	}
+}
+
+func TestGenerateK8s_Secret(t *testing.T) {
+	m := testManifest()
+	secrets := map[string]string{
+		"NPS_API_KEY": "test-key",
+		"LLM_API_KEY": "test-llm",
+	}
+	k8s, err := GenerateK8s(m, secrets)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if k8s.Secret == "" {
+		t.Fatal("secret should be generated when values provided")
+	}
+	if !strings.Contains(k8s.Secret, "kind: Secret") {
+		t.Error("missing Secret kind")
+	}
+}
+
+func TestGenerateK8s_NoSecrets(t *testing.T) {
+	m := testManifest()
+	m.Spec.Secrets = nil
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if k8s.Secret != "" {
+		t.Error("should not generate secret when none declared")
+	}
+}
+
+func TestGenerateK8s_Service(t *testing.T) {
+	m := testManifest()
+	k8s, err := GenerateK8s(m, nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !strings.Contains(k8s.Service, "kind: Service") {
+		t.Error("missing Service kind")
+	}
+	if !strings.Contains(k8s.Service, "port: 8000") {
+		t.Error("missing http port")
+	}
+}
+
+func testManifest() *AgentManifest {
+	return &AgentManifest{
+		Metadata: ManifestMeta{Name: "nps-assistant", Version: "1.0.0"},
+		Spec: ManifestSpec{
+			Base: BaseImage{
+				Image: "ghcr.io/redhat-et/docsclaw:latest",
+			},
+			Tools: []string{"curl", "jq"},
+			Prompt: PromptConfig{
+				Text: "You are a national parks assistant.",
+			},
+			Skills: []SkillRef{
+				{Name: "nps-api", Image: "quay.io/docsclaw/skill-nps-api:1.0.0-image"},
+			},
+			Runtime: RuntimeConfig{
+				Tools: RuntimeToolsConfig{
+					Allowed: []string{"exec", "read_file", "load_skill"},
+					Exec:    ExecConfig{Timeout: 30, MaxOutput: 50000},
+				},
+				Loop: RuntimeLoopConfig{MaxIterations: 15},
+			},
+			Secrets: []SecretDecl{
+				{Name: "NPS_API_KEY", Required: true},
+				{Name: "LLM_API_KEY", Required: true},
+			},
+			Deploy: DeployConfig{
+				Replicas: 1,
+				Resources: ResourceConfig{
+					Requests: ResourceValues{CPU: "100m", Memory: "64Mi"},
+					Limits:   ResourceValues{CPU: "500m", Memory: "256Mi"},
+				},
+			},
+		},
+	}
+}

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -1,0 +1,43 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ParseFile(path string) (*AgentManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	return Parse(data)
+}
+
+func Parse(data []byte) (*AgentManifest, error) {
+	var m AgentManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	if err := Validate(m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func Validate(m AgentManifest) error {
+	if m.Metadata.Name == "" {
+		return fmt.Errorf("metadata.name is required")
+	}
+	if m.Spec.Base.Image == "" {
+		return fmt.Errorf("spec.base.image is required")
+	}
+	if m.Spec.Prompt.Text == "" && m.Spec.Prompt.Source == nil {
+		return fmt.Errorf("spec.prompt.text or spec.prompt.source is required")
+	}
+	if m.Spec.Prompt.Text != "" && m.Spec.Prompt.Source != nil {
+		return fmt.Errorf("spec.prompt.text and spec.prompt.source are mutually exclusive")
+	}
+	return nil
+}

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -17,7 +18,9 @@ func ParseFile(path string) (*AgentManifest, error) {
 
 func Parse(data []byte) (*AgentManifest, error) {
 	var m AgentManifest
-	if err := yaml.Unmarshal(data, &m); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&m); err != nil {
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
 	if err := Validate(m); err != nil {

--- a/pkg/manifest/parse_test.go
+++ b/pkg/manifest/parse_test.go
@@ -1,0 +1,83 @@
+package manifest
+
+import "testing"
+
+func TestParseValid(t *testing.T) {
+	m, err := ParseFile("../../testdata/manifest/nps-agent.yaml")
+	if err != nil {
+		t.Fatalf("ParseFile() error: %v", err)
+	}
+	if m.Metadata.Name != "nps-assistant" {
+		t.Errorf("name = %q, want nps-assistant", m.Metadata.Name)
+	}
+	if m.Spec.Base.Image == "" {
+		t.Error("base image is empty")
+	}
+	if len(m.Spec.Tools) != 3 {
+		t.Errorf("tools count = %d, want 3", len(m.Spec.Tools))
+	}
+	if m.Spec.Prompt.Text == "" {
+		t.Error("prompt text is empty")
+	}
+	if len(m.Spec.Skills) != 1 {
+		t.Errorf("skills count = %d, want 1", len(m.Spec.Skills))
+	}
+	if len(m.Spec.Secrets) != 2 {
+		t.Errorf("secrets count = %d, want 2", len(m.Spec.Secrets))
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	_, err := ParseFile("../../testdata/manifest/bad-manifest.yaml")
+	if err == nil {
+		t.Fatal("expected validation error for bad manifest")
+	}
+}
+
+func TestValidate_MissingName(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Spec: ManifestSpec{
+			Base:   BaseImage{Image: "some-image"},
+			Tools:  []string{"curl"},
+			Prompt: PromptConfig{Text: "hello"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestValidate_MissingBaseImage(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Metadata:   ManifestMeta{Name: "test"},
+		Spec: ManifestSpec{
+			Tools:  []string{"curl"},
+			Prompt: PromptConfig{Text: "hello"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing base image")
+	}
+}
+
+func TestValidate_MissingPrompt(t *testing.T) {
+	m := AgentManifest{
+		APIVersion: "docsclaw.io/v1alpha1",
+		Kind:       "AgentManifest",
+		Metadata:   ManifestMeta{Name: "test"},
+		Spec: ManifestSpec{
+			Base:  BaseImage{Image: "some-image"},
+			Tools: []string{"curl"},
+		},
+	}
+	err := Validate(m)
+	if err == nil {
+		t.Fatal("expected error for missing prompt")
+	}
+}

--- a/pkg/manifest/toolsjson.go
+++ b/pkg/manifest/toolsjson.go
@@ -1,0 +1,67 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+type ToolsJSON struct {
+	ManifestVersion string          `json:"manifestVersion"`
+	AgentName       string          `json:"agentName"`
+	Base            string          `json:"base"`
+	HighestTier     string          `json:"highestTier"`
+	RiskScore       int             `json:"riskScore"`
+	Tools           []ToolJSONEntry `json:"tools"`
+}
+
+type ToolJSONEntry struct {
+	Name    string       `json:"name"`
+	Package string       `json:"package"`
+	Tier    string       `json:"tier"`
+	Risk    ToolJSONRisk `json:"risk"`
+}
+
+type ToolJSONRisk struct {
+	Score          int  `json:"score"`
+	CodeExecution  bool `json:"codeExecution"`
+	NetworkCapable bool `json:"networkCapable"`
+}
+
+func GenerateToolsJSON(m *AgentManifest, cat *catalog.ToolCatalog) ([]byte, error) {
+	allTools := mergeWithCore(m.Spec.Tools, cat)
+	sort.Strings(allTools)
+
+	tj := ToolsJSON{
+		ManifestVersion: m.Metadata.Version,
+		AgentName:       m.Metadata.Name,
+		Base:            m.Spec.Base.Image,
+		HighestTier:     cat.HighestTier(allTools),
+		RiskScore:       cat.MaxRiskScore(allTools),
+	}
+
+	for _, name := range allTools {
+		entry, ok := cat.Lookup(name)
+		if !ok {
+			continue
+		}
+		tj.Tools = append(tj.Tools, ToolJSONEntry{
+			Name:    name,
+			Package: entry.Package["dnf"],
+			Tier:    entry.Tier,
+			Risk: ToolJSONRisk{
+				Score:          entry.Risk.Score,
+				CodeExecution:  entry.Risk.Factors.CodeExecution,
+				NetworkCapable: entry.Risk.Factors.NetworkCapable,
+			},
+		})
+	}
+
+	data, err := json.MarshalIndent(tj, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal tools.json: %w", err)
+	}
+	return data, nil
+}

--- a/pkg/manifest/toolsjson.go
+++ b/pkg/manifest/toolsjson.go
@@ -31,7 +31,7 @@ type ToolJSONRisk struct {
 }
 
 func GenerateToolsJSON(m *AgentManifest, cat *catalog.ToolCatalog) ([]byte, error) {
-	allTools := mergeWithCore(m.Spec.Tools, cat)
+	allTools := MergeWithCore(m.Spec.Tools, cat)
 	sort.Strings(allTools)
 
 	tj := ToolsJSON{
@@ -63,5 +63,5 @@ func GenerateToolsJSON(m *AgentManifest, cat *catalog.ToolCatalog) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("marshal tools.json: %w", err)
 	}
-	return data, nil
+	return append(data, '\n'), nil
 }

--- a/pkg/manifest/toolsjson_test.go
+++ b/pkg/manifest/toolsjson_test.go
@@ -1,0 +1,52 @@
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/redhat-et/docsclaw/pkg/catalog"
+)
+
+func TestGenerateToolsJSON(t *testing.T) {
+	m := &AgentManifest{
+		Metadata: ManifestMeta{Name: "test-agent", Version: "1.0.0"},
+		Spec: ManifestSpec{
+			Base: BaseImage{Image: "hi/core-runtime:latest"},
+			Tools: []string{"curl", "jq", "git"},
+		},
+	}
+	cat, _ := catalog.LoadDefault()
+
+	data, err := GenerateToolsJSON(m, cat)
+	if err != nil {
+		t.Fatalf("GenerateToolsJSON() error: %v", err)
+	}
+
+	var tj ToolsJSON
+	if err := json.Unmarshal(data, &tj); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if tj.AgentName != "test-agent" {
+		t.Errorf("agentName = %q, want test-agent", tj.AgentName)
+	}
+	if tj.HighestTier != "standard" {
+		t.Errorf("highestTier = %q, want standard", tj.HighestTier)
+	}
+	if len(tj.Tools) != 3 {
+		t.Errorf("tools count = %d, want 3", len(tj.Tools))
+	}
+
+	found := false
+	for _, tool := range tj.Tools {
+		if tool.Name == "git" {
+			found = true
+			if tool.Tier != "standard" {
+				t.Errorf("git tier = %q, want standard", tool.Tier)
+			}
+		}
+	}
+	if !found {
+		t.Error("git not in tools list")
+	}
+}

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -75,9 +75,10 @@ type SecretDecl struct {
 }
 
 type DeployConfig struct {
-	Image     string         `yaml:"image,omitempty"`
-	Replicas  int            `yaml:"replicas,omitempty"`
-	Resources ResourceConfig `yaml:"resources,omitempty"`
+	Image          string         `yaml:"image,omitempty"`
+	ServiceAccount string         `yaml:"serviceAccount,omitempty"`
+	Replicas       int            `yaml:"replicas,omitempty"`
+	Resources      ResourceConfig `yaml:"resources,omitempty"`
 }
 
 type ResourceConfig struct {

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -1,0 +1,89 @@
+package manifest
+
+type AgentManifest struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Metadata   ManifestMeta `yaml:"metadata"`
+	Spec       ManifestSpec `yaml:"spec"`
+}
+
+type ManifestMeta struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+type ManifestSpec struct {
+	Base    BaseImage     `yaml:"base"`
+	Tools   []string      `yaml:"tools"`
+	Prompt  PromptConfig  `yaml:"prompt"`
+	Skills  []SkillRef    `yaml:"skills"`
+	Runtime RuntimeConfig `yaml:"runtime,omitempty"`
+	Secrets []SecretDecl  `yaml:"secrets,omitempty"`
+	Deploy  DeployConfig  `yaml:"deploy,omitempty"`
+}
+
+type BaseImage struct {
+	Image   string `yaml:"image"`
+	Builder string `yaml:"builder"`
+}
+
+type PromptConfig struct {
+	Text   string        `yaml:"text,omitempty"`
+	Source *PromptSource `yaml:"source,omitempty"`
+}
+
+type PromptSource struct {
+	Git  string `yaml:"git"`
+	Path string `yaml:"path"`
+	Ref  string `yaml:"ref"`
+}
+
+type SkillRef struct {
+	Name  string `yaml:"name"`
+	Image string `yaml:"image"`
+}
+
+type RuntimeConfig struct {
+	Tools RuntimeToolsConfig `yaml:"tools"`
+	Loop  RuntimeLoopConfig  `yaml:"loop"`
+}
+
+type RuntimeToolsConfig struct {
+	Allowed  []string       `yaml:"allowed"`
+	Exec     ExecConfig     `yaml:"exec,omitempty"`
+	WebFetch WebFetchConfig `yaml:"webFetch,omitempty"`
+}
+
+type ExecConfig struct {
+	Timeout   int `yaml:"timeout,omitempty"`
+	MaxOutput int `yaml:"maxOutput,omitempty"`
+}
+
+type WebFetchConfig struct {
+	AllowedHosts []string `yaml:"allowedHosts,omitempty"`
+}
+
+type RuntimeLoopConfig struct {
+	MaxIterations int `yaml:"maxIterations,omitempty"`
+}
+
+type SecretDecl struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Required    bool   `yaml:"required"`
+}
+
+type DeployConfig struct {
+	Replicas  int            `yaml:"replicas,omitempty"`
+	Resources ResourceConfig `yaml:"resources,omitempty"`
+}
+
+type ResourceConfig struct {
+	Requests ResourceValues `yaml:"requests,omitempty"`
+	Limits   ResourceValues `yaml:"limits,omitempty"`
+}
+
+type ResourceValues struct {
+	CPU    string `yaml:"cpu,omitempty"`
+	Memory string `yaml:"memory,omitempty"`
+}

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -23,8 +23,9 @@ type ManifestSpec struct {
 }
 
 type BaseImage struct {
-	Image   string `yaml:"image"`
-	Builder string `yaml:"builder"`
+	Image       string `yaml:"image"`
+	GoBuilder   string `yaml:"goBuilder,omitempty"`
+	ToolBuilder string `yaml:"toolBuilder"`
 }
 
 type PromptConfig struct {

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -75,6 +75,7 @@ type SecretDecl struct {
 }
 
 type DeployConfig struct {
+	Image     string         `yaml:"image,omitempty"`
 	Replicas  int            `yaml:"replicas,omitempty"`
 	Resources ResourceConfig `yaml:"resources,omitempty"`
 }

--- a/testdata/manifest/bad-manifest.yaml
+++ b/testdata/manifest/bad-manifest.yaml
@@ -1,0 +1,9 @@
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: ""
+spec:
+  base:
+    image: ""
+  tools: []
+  prompt: {}

--- a/testdata/manifest/nps-agent.yaml
+++ b/testdata/manifest/nps-agent.yaml
@@ -1,0 +1,47 @@
+apiVersion: docsclaw.io/v1alpha1
+kind: AgentManifest
+metadata:
+  name: nps-assistant
+  version: 1.0.0
+spec:
+  base:
+    image: registry.access.redhat.com/hi/core-runtime:latest
+    builder: registry.access.redhat.com/hi/core-runtime:latest-builder
+  tools:
+    - curl
+    - jq
+    - git
+  prompt:
+    text: |
+      You are a national parks assistant.
+  skills:
+    - name: nps-api
+      image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+  runtime:
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - web_fetch
+        - load_skill
+      exec:
+        timeout: 30
+        maxOutput: 50000
+    loop:
+      maxIterations: 15
+  secrets:
+    - name: NPS_API_KEY
+      description: "API key for developer.nps.gov"
+      required: true
+    - name: LLM_API_KEY
+      description: "LLM provider API key"
+      required: true
+  deploy:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi

--- a/testdata/manifest/nps-agent.yaml
+++ b/testdata/manifest/nps-agent.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   base:
     image: registry.access.redhat.com/hi/core-runtime:latest
-    builder: registry.access.redhat.com/hi/core-runtime:latest-builder
+    toolBuilder: registry.access.redhat.com/hi/core-runtime:latest-builder
   tools:
     - curl
     - jq
@@ -16,7 +16,8 @@ spec:
       You are a national parks assistant.
   skills:
     - name: nps-api
-      image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+      #image: quay.io/docsclaw/skill-nps-api:1.0.0-image
+      image: quay.io/skillimage/business/document-summarizer:1.2.0
   runtime:
     tools:
       allowed:

--- a/testdata/manifest/nps-agent.yaml
+++ b/testdata/manifest/nps-agent.yaml
@@ -38,6 +38,7 @@ spec:
       description: "LLM provider API key"
       required: true
   deploy:
+    image: ghcr.io/redhat-et/nps-agent:1.0.0
     replicas: 1
     resources:
       requests:


### PR DESCRIPTION
## Summary

- Adds a declarative **agent manifest** (`agent-manifest.yaml`) that defines an agent as: base image + installed tools + system prompt + skills
- Introduces a **tiered tool catalog** with risk scoring (core/standard/extended/runtime) to govern which OS tools can be installed in hardened images
- New `docsclaw build` and `docsclaw deploy` commands generate Containerfiles, K8s manifests, and tools.json from the manifest
- At runtime, the agent reads `/etc/docsclaw/tools.json` and injects the available tool list into the system prompt, preventing wasted agentic loop iterations on missing tools
- New Makefile targets (`agent-build`, `agent-image`, `agent-push`) for building custom agent images with two-stage Containerfile and remote podman support

## Motivation

We hit a problem where LLMs waste agentic loop iterations trying tools that aren't installed (jq, python3, node). The agent manifest + tool catalog + runtime injection solves this by declaring tools upfront and telling the LLM exactly what's available.

## New packages

| Package | Purpose |
|---------|---------|
| `pkg/catalog` | Tool catalog with tiers, risk scores, package mappings |
| `pkg/manifest` | Manifest parser, compatibility checker, Containerfile/K8s/tools.json generators |

## New commands

| Command | Purpose |
|---------|---------|
| `docsclaw build --manifest` | Validate tools, check skill compat, generate artifacts |
| `docsclaw deploy --manifest` | Generate K8s YAML with secret resolution from env vars |

## Test plan

- [x] Unit tests for catalog, manifest, compatibility, generators (30+ tests)
- [x] `make agent-build` generates Containerfile + tools.json
- [x] `make agent-image PODMAN_CONNECTION=rhel` builds on remote host
- [x] `docsclaw deploy` resolves secrets from env vars and `--secret` flags
- [x] Deployed on OpenShift — agent runs with tools installed, tools.json loaded, probes passing
- [x] Verified: `oc exec -- cat /etc/docsclaw/tools.json` shows correct inventory

## Design doc

`docs/superpowers/specs/2026-05-20-agent-manifest-tooling-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative agent manifest for building custom agent container images
  * New CLI commands to build and deploy agents, including manifest-driven dry-run, build/push, and secret resolution
  * Tool catalog with tiering and risk scoring; generated tools.json and agent metadata embedded in images
  * Kubernetes manifest generation for agent deployments; Makefile targets to build/push agent images
  * Runtime prompt now lists available OS tools when provided

* **Documentation**
  * Added guides for agent-manifest workflow, build/push, and deployment

* **Tests**
  * Added extensive unit tests covering build, deploy, manifest parsing, catalog, and compatibility checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->