### PR TITLE
docs: add NPS Explorer example

### DIFF
--- a/examples/nps-explorer/README.md
+++ b/examples/nps-explorer/README.md
@@ -1,0 +1,122 @@
+# NPS Explorer agent
+
+A DocsClaw agent that answers questions about U.S. national parks
+using the [National Park Service REST API][nps-api].
+This example demonstrates three common patterns:
+
+- **ConfigMap-driven personality** — system prompt, A2A agent card,
+  and tool configuration in a single ConfigMap
+- **Skill as a separate ConfigMap** — domain knowledge (API endpoints,
+  authentication, request patterns) mounted into the agent
+- **Secret management** — API keys for the LLM provider and the
+  external service injected via Kubernetes Secrets
+
+## Prerequisites
+
+- An OpenShift cluster (or Kubernetes with an Ingress controller)
+- `kubectl` or `oc` CLI
+- An LLM provider API key (Anthropic or OpenAI)
+- A free NPS API key — [register here][nps-register]
+
+## Files
+
+| File | Description |
+| ---- | ----------- |
+| `configmap.yaml` | Agent personality: system prompt, A2A card, tool config |
+| `skill-configmap.yaml` | NPS API skill with endpoint docs and examples |
+| `llm-secret.yaml` | LLM provider API key (placeholder) |
+| `nps-secret.yaml` | NPS API key (placeholder) |
+| `deployment.yaml` | Deployment, Service, and Route |
+
+## Deploy
+
+1. Edit the secrets with your actual API keys:
+
+   ```bash
+   # In llm-secret.yaml, replace REPLACE_WITH_YOUR_LLM_API_KEY
+   # In nps-secret.yaml, replace REPLACE_WITH_YOUR_NPS_API_KEY
+   ```
+
+1. Apply all resources:
+
+   ```bash
+   kubectl apply -f configmap.yaml \
+                 -f skill-configmap.yaml \
+                 -f llm-secret.yaml \
+                 -f nps-secret.yaml \
+                 -f deployment.yaml
+   ```
+
+1. Wait for the pod to become ready:
+
+   ```bash
+   kubectl wait --for=condition=ready pod -l app=nps-explorer --timeout=60s
+   ```
+
+1. Get the route URL (OpenShift):
+
+   ```bash
+   echo "https://$(oc get route nps-explorer -o jsonpath='{.spec.host}')"
+   ```
+
+## Test
+
+Send a request using curl or the [a2a CLI][a2a-cli]:
+
+```bash
+# Using curl
+AGENT_URL="https://$(oc get route nps-explorer -o jsonpath='{.spec.host}')"
+curl -s "$AGENT_URL/tasks/send" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tasks/send",
+    "id": "1",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"text": "What national parks are in Utah?"}]
+      }
+    }
+  }' | jq .
+```
+
+```bash
+# Using a2a CLI
+a2a send --url "$AGENT_URL" "What national parks are in Utah?"
+```
+
+## How it works
+
+The agent receives a user question and uses the `exec` tool to run
+`curl` commands against the NPS API. The skill ConfigMap teaches the
+agent which endpoints exist, what parameters they accept, and how to
+authenticate — so it can construct correct requests without hardcoded
+logic. The LLM typically pipes responses through `jq` for parsing.
+
+Both `curl` and `jq` are included in the DocsClaw container image.
+You can verify this locally:
+
+```bash
+podman run --rm --entrypoint curl ghcr.io/redhat-et/docsclaw:latest -V
+podman run --rm --entrypoint jq ghcr.io/redhat-et/docsclaw:latest --version
+```
+
+```text
+User question → DocsClaw → reads NPS skill → exec(curl) → NPS API
+                                                ↓
+                         formats response ← JSON response
+```
+
+## Customization
+
+- **Add more skills**: create another ConfigMap with a `SKILL.md` and
+  mount it at `/config/agent/skills/<skill-name>`
+- **Change the LLM**: set `LLM_PROVIDER` and `LLM_MODEL` environment
+  variables in the Deployment
+- **Adjust tool limits**: edit `agent-config.yaml` in the ConfigMap to
+  change timeouts, allowed tools, or max loop iterations
+
+[nps-api]: https://www.nps.gov/subjects/developer/api-documentation.htm
+[nps-register]: https://www.nps.gov/subjects/developer/get-started.htm
+[a2a-cli]: https://github.com/a2aserver/a2a-go

--- a/examples/nps-explorer/configmap.yaml
+++ b/examples/nps-explorer/configmap.yaml
@@ -78,6 +78,6 @@ data:
       exec:
         timeout: 30
         max_output: 50000
-    workspace: /tmp/agent-workspace
+      workspace: /tmp/agent-workspace
     loop:
       max_iterations: 10

--- a/examples/nps-explorer/configmap.yaml
+++ b/examples/nps-explorer/configmap.yaml
@@ -1,0 +1,83 @@
+# NPS Explorer Agent — ConfigMap
+#
+# Defines the agent's personality, A2A protocol metadata, and tool
+# configuration. DocsClaw reads three files from --config-dir:
+#
+#   system-prompt.txt  — LLM system prompt (personality + instructions)
+#   agent-card.json    — A2A agent card served at /.well-known/agent.json
+#   agent-config.yaml  — tool allowlist, workspace path, loop limits
+#
+# Apply before the Deployment:
+#   kubectl apply -f configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nps-explorer
+  labels:
+    app: nps-explorer
+data:
+  # --- System prompt ---------------------------------------------------
+  # Tells the LLM what role to play and how to behave.
+  system-prompt.txt: |
+    You are a helpful National Park Service (NPS) information assistant
+    with access to the NPS REST API.
+
+    You can help users discover and learn about:
+      - National parks, monuments, and other NPS sites across the
+        United States
+      - Activities available at parks (hiking, camping, rock climbing)
+      - Current alerts, warnings, and park closures
+      - Campgrounds and camping facilities
+      - Park events and ranger programs
+      - Visitor centers and their hours
+
+    When given a task, use the exec tool to query the NPS API with
+    curl, parse the JSON response, and present park information in
+    clean markdown format. Always verify the NPS_API_KEY environment
+    variable is set before making requests.
+
+  # --- A2A agent card ---------------------------------------------------
+  # Protocol metadata — other agents and clients discover capabilities
+  # by fetching /.well-known/agent.json from this agent's URL.
+  agent-card.json: |
+    {
+      "name": "nps-explorer",
+      "description": "National Park Service information assistant",
+      "version": "1.0.0",
+      "protocolVersion": "0.3.0",
+      "url": "http://nps-explorer:8000",
+      "skills": [
+        {
+          "id": "nps-api",
+          "name": "NPS API",
+          "description": "Query the National Park Service REST API",
+          "tags": ["parks", "outdoors", "government-api"],
+          "examples": [
+            "What national parks are in California?",
+            "Are there any alerts for Yellowstone?",
+            "Find campgrounds in Colorado"
+          ]
+        }
+      ],
+      "capabilities": {},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/markdown"]
+    }
+
+  # --- Agent config -----------------------------------------------------
+  # Controls which tools the agent can use and how the agentic loop
+  # behaves. The "exec" tool lets the agent run shell commands (curl)
+  # to call the NPS API.
+  agent-config.yaml: |
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - write_file
+      exec:
+        timeout: 30
+        max_output: 50000
+    workspace: /tmp/agent-workspace
+    loop:
+      max_iterations: 10

--- a/examples/nps-explorer/deployment.yaml
+++ b/examples/nps-explorer/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: docsclaw
+          # Pin to a specific version for production (e.g., :v0.9.4)
           image: ghcr.io/redhat-et/docsclaw:latest
           # Container-level security: full hardened profile
           securityContext:

--- a/examples/nps-explorer/deployment.yaml
+++ b/examples/nps-explorer/deployment.yaml
@@ -1,0 +1,147 @@
+# NPS Explorer Agent — Deployment, Service, and Route
+#
+# Deploys the DocsClaw agent with:
+#   - Agent config from ConfigMap (system prompt, agent card, tool config)
+#   - NPS API skill from a separate ConfigMap
+#   - LLM and NPS API keys from Secrets
+#   - Hardened security context (non-root, read-only root, drop all caps)
+#   - Health and readiness probes
+#
+# Prerequisites — apply these first:
+#   kubectl apply -f configmap.yaml
+#   kubectl apply -f skill-configmap.yaml
+#   kubectl apply -f llm-secret.yaml
+#   kubectl apply -f nps-secret.yaml
+#
+# Then deploy:
+#   kubectl apply -f deployment.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nps-explorer
+  labels:
+    app: nps-explorer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nps-explorer
+  template:
+    metadata:
+      labels:
+        app: nps-explorer
+    spec:
+      # Pod-level security: no containers may run as root
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: docsclaw
+          image: ghcr.io/redhat-et/docsclaw:latest
+          # Container-level security: full hardened profile
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - serve
+            - --config-dir
+            - /config/agent
+            - --listen-plain-http
+            # In-memory session store — no writable filesystem needed
+            - --session-db
+            - memory
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8100
+              name: health
+          # Inject API keys from Secrets
+          envFrom:
+            - secretRef:
+                name: llm-secret
+            - secretRef:
+                name: nps-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            # Agent configuration (system prompt, agent card, tool config)
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            # NPS API skill — mounted into the skills subdirectory
+            - name: skill-nps-api
+              mountPath: /config/agent/skills/nps-api
+              readOnly: true
+            # Writable workspace for agent file operations
+            - name: workspace
+              mountPath: /tmp/agent-workspace
+      volumes:
+        - name: agent-config
+          configMap:
+            name: nps-explorer
+        - name: skill-nps-api
+          configMap:
+            name: nps-explorer-nps-api
+        - name: workspace
+          emptyDir: {}
+
+---
+# Service — exposes the agent inside the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: nps-explorer
+  labels:
+    app: nps-explorer
+spec:
+  selector:
+    app: nps-explorer
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+---
+# Route (OpenShift) — exposes the agent externally with TLS
+# On plain Kubernetes, replace with an Ingress resource.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: nps-explorer
+  annotations:
+    # LLM calls can take a while; allow up to 2 minutes
+    haproxy.router.openshift.io/timeout: 120s
+  labels:
+    app: nps-explorer
+spec:
+  to:
+    kind: Service
+    name: nps-explorer
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/examples/nps-explorer/llm-secret.yaml
+++ b/examples/nps-explorer/llm-secret.yaml
@@ -1,0 +1,40 @@
+# LLM Provider Secret
+#
+# DocsClaw needs an API key and provider configuration for the LLM
+# backend. Uncomment the section for your provider, fill in the API
+# key, and delete the other sections.
+#
+# Get your API key:
+#   - Anthropic: https://console.anthropic.com/settings/keys
+#   - OpenAI:    https://platform.openai.com/api-keys
+#
+# Apply before the Deployment:
+#   kubectl apply -f llm-secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-secret
+  labels:
+    app: nps-explorer
+stringData:
+
+  # --- Option 1: Anthropic (default) ---
+  LLM_API_KEY: ""              # your Anthropic API key
+  LLM_PROVIDER: "anthropic"
+  LLM_MODEL: "claude-sonnet-4-6"
+  # LLM_MODEL: "claude-opus-4-6"
+  # LLM_MODEL: "claude-haiku-4-5"
+
+  # --- Option 2: OpenAI ---
+  # LLM_API_KEY: ""            # your OpenAI API key
+  # LLM_PROVIDER: "openai"
+  # LLM_MODEL: "gpt-5.4"
+  # LLM_MODEL: "gpt-5.4-mini"
+  # LLM_BASE_URL: "https://api.openai.com/v1"
+
+  # --- Option 3: OpenAI-compatible (e.g. MaaS / LiteLLM) ---
+  # LLM_API_KEY: ""            # your provider API key
+  # LLM_PROVIDER: "litellm"
+  # LLM_MODEL: "qwen3-14b"
+  # LLM_BASE_URL: "https://your-litellm-proxy.example.com/v1"

--- a/examples/nps-explorer/nps-secret.yaml
+++ b/examples/nps-explorer/nps-secret.yaml
@@ -1,0 +1,22 @@
+# NPS API Key Secret
+#
+# The National Park Service API requires a free API key for
+# authentication. The agent's NPS skill reads it from the
+# NPS_API_KEY environment variable.
+#
+# Get your free API key:
+#   1. Visit https://www.nps.gov/subjects/developer/get-started.htm
+#   2. Sign up and request an API key
+#   3. Replace the placeholder below with your key
+#
+# Apply before the Deployment:
+#   kubectl apply -f nps-secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nps-secret
+  labels:
+    app: nps-explorer
+stringData:
+  NPS_API_KEY: "REPLACE_WITH_YOUR_NPS_API_KEY"

--- a/examples/nps-explorer/skill-configmap.yaml
+++ b/examples/nps-explorer/skill-configmap.yaml
@@ -1,0 +1,148 @@
+# NPS API Skill — ConfigMap
+#
+# A skill teaches the agent *how* to use a specific API or tool.
+# This one describes the NPS REST API endpoints, authentication,
+# and request patterns so the LLM can construct correct curl commands.
+#
+# Mounted as a separate ConfigMap at /config/agent/skills/nps-api
+# so the agent discovers it via --config-dir skill scanning.
+#
+# Apply before the Deployment:
+#   kubectl apply -f skill-configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nps-explorer-nps-api
+  labels:
+    app: nps-explorer
+data:
+  SKILL.md: |
+    ---
+    name: nps-api
+    description: >-
+      Query the National Park Service REST API for information about
+      parks, activities, alerts, campgrounds, events, and visitor
+      centers. Use this skill whenever the user asks about national
+      parks, visiting parks, park activities, alerts, campgrounds,
+      or any NPS-related data.
+    ---
+
+    # NPS API Skill
+
+    Query the National Park Service REST API to retrieve information
+    about parks, activities, alerts, campgrounds, events, and other
+    NPS resources.
+
+    ## API Configuration
+
+    **Base URL**: `https://developer.nps.gov/api/v1/`
+
+    **Authentication**: All requests require an API key header:
+    ```
+    X-Api-Key: $NPS_API_KEY
+    ```
+
+    ## Available Endpoints
+
+    ### Parks (`/parks`)
+    National parks, monuments, and other NPS sites.
+
+    | Parameter   | Description                              |
+    | ----------- | ---------------------------------------- |
+    | `stateCode` | Two-letter state code (e.g., CA, WY, AZ) |
+    | `parkCode`  | Park code (e.g., yose, grca, yell)       |
+    | `q`         | Search query for names or keywords       |
+    | `limit`     | Number of results (default: 50)          |
+
+    ### Activities (`/activities`)
+    Recreational activities across NPS sites.
+
+    | Parameter | Description                |
+    | --------- | -------------------------- |
+    | `q`       | Search for activities      |
+    | `id`      | Activity ID                |
+
+    ### Alerts (`/alerts`)
+    Current alerts, warnings, and notices.
+
+    | Parameter   | Description            |
+    | ----------- | ---------------------- |
+    | `stateCode` | Filter by state        |
+    | `parkCode`  | Filter by park         |
+    | `limit`     | Number of alerts       |
+
+    ### Campgrounds (`/campgrounds`)
+    Campground and camping facility information.
+
+    | Parameter   | Description            |
+    | ----------- | ---------------------- |
+    | `stateCode` | Filter by state        |
+    | `parkCode`  | Filter by park         |
+    | `q`         | Search campground names|
+
+    ### Events (`/events`)
+    Park events, ranger programs, and activities.
+
+    | Parameter   | Description            |
+    | ----------- | ---------------------- |
+    | `parkCode`  | Filter by park         |
+    | `dateStart` | Filter by start date   |
+    | `dateEnd`   | Filter by end date     |
+    | `limit`     | Number of events       |
+
+    ### Visitor Centers (`/visitorcenters`)
+    Visitor centers and contact stations.
+
+    | Parameter   | Description            |
+    | ----------- | ---------------------- |
+    | `stateCode` | Filter by state        |
+    | `parkCode`  | Filter by park         |
+
+    ## Making Requests
+
+    Use curl with the API key header. Always verify the key is set:
+
+    ```bash
+    if [ -z "$NPS_API_KEY" ]; then
+      echo "Error: NPS_API_KEY not set"
+      exit 1
+    fi
+
+    curl -s "https://developer.nps.gov/api/v1/parks?stateCode=CA&limit=5" \
+      -H "X-Api-Key: $NPS_API_KEY"
+    ```
+
+    ## Response Format
+
+    All endpoints return JSON:
+    ```json
+    {
+      "total": "count",
+      "data": [ { "id": "...", "name": "...", ... } ],
+      "limit": "per page",
+      "start": "offset"
+    }
+    ```
+
+    ## Tips
+
+    - Use `-s` with curl for clean JSON output
+    - Use `jq` to format responses when available
+    - Park codes are typically 4 lowercase letters (yose, grca, yell)
+    - State codes are 2 uppercase letters (CA, WY, AZ)
+    - Add `&limit=5` for faster responses
+
+    ## Example Interactions
+
+    **User**: "What parks are in Wyoming?"
+    - Endpoint: `/parks?stateCode=WY`
+    - `curl -s "https://developer.nps.gov/api/v1/parks?stateCode=WY" -H "X-Api-Key: $NPS_API_KEY"`
+
+    **User**: "Are there any alerts for Yellowstone?"
+    - Endpoint: `/alerts?parkCode=yell`
+    - `curl -s "https://developer.nps.gov/api/v1/alerts?parkCode=yell" -H "X-Api-Key: $NPS_API_KEY"`
+
+    **User**: "What can I do at Yosemite?"
+    - Endpoint: `/parks?parkCode=yose`
+    - `curl -s "https://developer.nps.gov/api/v1/parks?parkCode=yose" -H "X-Api-Key: $NPS_API_KEY"`


### PR DESCRIPTION
## Summary

- Adds a self-contained example under `examples/nps-explorer/` showing how to deploy a DocsClaw agent that queries the National Park Service REST API
- Demonstrates three common patterns: ConfigMap-driven personality, skills as separate ConfigMaps, and API key management via Kubernetes Secrets
- Includes multi-provider LLM secret (Anthropic, OpenAI, LiteLLM) with placeholder keys

## Files

| File | Purpose |
| ---- | ------- |
| `README.md` | Overview, prerequisites, deploy/test steps |
| `configmap.yaml` | System prompt, A2A agent card, tool config |
| `skill-configmap.yaml` | NPS API skill (endpoints, auth, examples) |
| `llm-secret.yaml` | LLM provider secret with three provider options |
| `nps-secret.yaml` | NPS API key secret with registration link |
| `deployment.yaml` | Deployment, Service, Route with hardened security |

## Test plan

- [ ] Verify no real API keys in any file
- [ ] `yamllint` passes on all YAML files (line-length warnings in literal blocks are expected)
- [ ] README renders correctly on GitHub
- [ ] `kubectl apply --dry-run=client -f examples/nps-explorer/` succeeds
- [ ] Deploy to OpenShift with real API keys and test with a2a CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive example documentation with deployment instructions and testing guidance.

* **Chores**
  * Added Kubernetes manifests (ConfigMaps, Secrets, Deployment) and configuration files for a new example agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->