### PR TITLE
docs: add skill playground example

### DIFF
--- a/examples/skill-playground/README.md
+++ b/examples/skill-playground/README.md
@@ -1,0 +1,173 @@
+# Skill playground
+
+An interactive environment for developing and testing DocsClaw skills.
+Deploy a generic agent, edit a skill in a text editor, push the update,
+and test it in a chat — without redeploying the entire stack.
+
+This example is designed as a backend for a skill-editing frontend
+where users iterate on skill content through a browser-based workflow:
+edit skill text, click "Save and redeploy", test in chat, repeat.
+
+## Prerequisites
+
+- An OpenShift cluster (or Kubernetes with an Ingress controller)
+- `kubectl` or `oc` CLI
+- An LLM provider API key (Anthropic or OpenAI)
+
+## Files
+
+| File | Description |
+| ---- | ----------- |
+| `configmap.yaml` | Generic "skill tester" agent personality |
+| `skill-configmap.yaml` | Draft skill with placeholder content |
+| `llm-secret.yaml` | LLM provider API key (placeholder) |
+| `deployment.yaml` | Deployment, Service, and Route |
+| `redeploy.sh` | Update script: recreate ConfigMap, optionally restart |
+
+## Deploy
+
+1. Edit `llm-secret.yaml` with your LLM provider API key.
+
+1. Apply all resources:
+
+   ```bash
+   kubectl apply -f configmap.yaml \
+                 -f skill-configmap.yaml \
+                 -f llm-secret.yaml \
+                 -f deployment.yaml
+   ```
+
+1. Wait for the pod to become ready:
+
+   ```bash
+   kubectl wait --for=condition=ready pod -l app=skill-playground --timeout=60s
+   ```
+
+1. Get the route URL (OpenShift):
+
+   ```bash
+   echo "https://$(oc get route skill-playground -o jsonpath='{.spec.host}')"
+   ```
+
+## Edit and redeploy
+
+There are two update paths depending on what changed in the skill.
+
+### Content-only changes (auto-sync, no restart)
+
+When you only change the skill body (not the `name:` or `description:`
+in the YAML frontmatter), the update propagates automatically:
+
+1. Edit your SKILL.md file
+1. Update the ConfigMap:
+
+   ```bash
+   ./redeploy.sh my-skill.md
+   ```
+
+1. Wait ~30-60 seconds for the kubelet to sync the ConfigMap volume
+1. Send a test message — the agent reads skill content from disk on
+   each request, so it picks up the new version
+
+**How it works**: Kubernetes periodically syncs ConfigMap data to
+mounted volumes (default kubelet sync period is ~60 seconds). The
+DocsClaw `load_skill` tool reads the SKILL.md file from disk on
+every invocation, so once the kubelet syncs, the next request gets
+the updated content.
+
+### Full restart (for metadata changes)
+
+When you change the skill's `name:` or `description:` in the YAML
+frontmatter, the agent needs a restart because skill metadata is
+loaded once at startup:
+
+1. Edit your SKILL.md file (including frontmatter changes)
+1. Update the ConfigMap and restart:
+
+   ```bash
+   ./redeploy.sh my-skill.md --restart
+   ```
+
+1. Wait ~10-15 seconds for the new pod to become ready
+1. Send a test message
+
+## Expected timing
+
+| Operation | Delay |
+| --------- | ----- |
+| ConfigMap update (`kubectl apply`) | Instant |
+| Kubelet volume sync (auto-sync path) | ~30-60s |
+| Rollout restart + readiness (restart path) | ~10-15s |
+| Full restart cycle (update + restart + ready) | ~15-20s |
+
+The rollout restart is faster than waiting for the kubelet sync.
+For rapid iteration during development, use `--restart` even for
+content-only changes.
+
+## Frontend integration
+
+For a web frontend that wraps this workflow, the backend needs to
+make these Kubernetes API calls:
+
+1. **Update the skill ConfigMap**
+
+   ```text
+   PUT /api/v1/namespaces/{ns}/configmaps/skill-playground-draft-skill
+   ```
+
+   Set `data["SKILL.md"]` to the new skill text.
+
+1. **Trigger a rollout restart** (optional, for metadata changes)
+
+   ```text
+   PATCH /apis/apps/v1/namespaces/{ns}/deployments/skill-playground
+   ```
+
+   Set `spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]`
+   to the current timestamp.
+
+1. **Poll for readiness**
+
+   ```text
+   GET /apis/apps/v1/namespaces/{ns}/deployments/skill-playground
+   ```
+
+   Check `status.readyReplicas == spec.replicas`.
+
+1. **Send a test message** via the agent's A2A endpoint
+
+   ```text
+   POST https://{route-host}/tasks/send
+   ```
+
+## How it works
+
+```text
+                    ┌─────────────┐
+                    │ Edit skill  │
+                    └──────┬──────┘
+                           │
+                    ┌──────▼──────┐
+                    │  Update     │
+                    │  ConfigMap  │
+                    └──────┬──────┘
+                           │
+              ┌────────────┴────────────┐
+              │                         │
+     ┌────────▼────────┐     ┌──────────▼──────────┐
+     │  Auto-sync      │     │  Rollout restart     │
+     │  (~30-60s)      │     │  (~10-15s)           │
+     │                 │     │                      │
+     │  kubelet syncs  │     │  new pod reads       │
+     │  volume, agent  │     │  ConfigMap on        │
+     │  reads on next  │     │  startup             │
+     │  load_skill     │     │                      │
+     └────────┬────────┘     └──────────┬───────────┘
+              │                         │
+              └────────────┬────────────┘
+                           │
+                    ┌──────▼──────┐
+                    │ Test in     │
+                    │ chat        │
+                    └─────────────┘
+```

--- a/examples/skill-playground/README.md
+++ b/examples/skill-playground/README.md
@@ -65,12 +65,14 @@ in the YAML frontmatter), the update propagates automatically:
    ./redeploy.sh my-skill.md
    ```
 
-1. Wait ~30-60 seconds for the kubelet to sync the ConfigMap volume
+1. Wait for the kubelet to sync the ConfigMap volume (typically a few
+   seconds on modern clusters using the Watch strategy)
 1. Send a test message — the agent reads skill content from disk on
    each request, so it picks up the new version
 
-**How it works**: Kubernetes periodically syncs ConfigMap data to
-mounted volumes (default kubelet sync period is ~60 seconds). The
+**How it works**: Kubernetes propagates ConfigMap changes to mounted
+volumes automatically. With the default Watch-based change detection
+(Kubernetes 1.18+), updates typically arrive within seconds. The
 DocsClaw `load_skill` tool reads the SKILL.md file from disk on
 every invocation, so once the kubelet syncs, the next request gets
 the updated content.
@@ -96,18 +98,24 @@ loaded once at startup:
 | Operation | Delay |
 | --------- | ----- |
 | ConfigMap update (`kubectl apply`) | Instant |
-| Kubelet volume sync (auto-sync path) | ~30-60s |
+| Kubelet volume sync (auto-sync path) | Typically a few seconds |
 | Rollout restart + readiness (restart path) | ~10-15s |
-| Full restart cycle (update + restart + ready) | ~15-20s |
 
-The rollout restart is faster than waiting for the kubelet sync.
-For rapid iteration during development, use `--restart` even for
-content-only changes.
+Use the auto-sync path (no `--restart`) for content-only changes —
+it is the fastest option. Use `--restart` when you change the skill's
+`name:` or `description:` in the YAML frontmatter, since skill
+metadata is loaded once at startup.
 
 ## Frontend integration
 
-For a web frontend that wraps this workflow, the backend needs to
-make these Kubernetes API calls:
+For a web frontend that wraps this workflow, the backend needs a
+ServiceAccount with RBAC permissions to:
+
+- `get`, `update` on ConfigMaps (to push skill content)
+- `get`, `patch` on Deployments (to trigger rollout restart and
+  poll readiness)
+
+The backend makes these Kubernetes API calls:
 
 1. **Update the skill ConfigMap**
 
@@ -156,7 +164,7 @@ make these Kubernetes API calls:
               │                         │
      ┌────────▼────────┐     ┌──────────▼──────────┐
      │  Auto-sync      │     │  Rollout restart     │
-     │  (~30-60s)      │     │  (~10-15s)           │
+     │  (seconds)      │     │  (~10-15s)           │
      │                 │     │                      │
      │  kubelet syncs  │     │  new pod reads       │
      │  volume, agent  │     │  ConfigMap on        │

--- a/examples/skill-playground/configmap.yaml
+++ b/examples/skill-playground/configmap.yaml
@@ -1,0 +1,65 @@
+# Skill Playground Agent — ConfigMap
+#
+# A generic agent personality for testing skills. The agent has no
+# built-in domain knowledge — it relies entirely on mounted skills
+# for its capabilities.
+#
+# Apply before the Deployment:
+#   kubectl apply -f configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skill-playground
+  labels:
+    app: skill-playground
+data:
+  # --- System prompt ---------------------------------------------------
+  # Generic personality that defers to skills for domain knowledge.
+  system-prompt.txt: |
+    You are a helpful assistant for testing skills. You have access to
+    tools and skills that give you domain-specific capabilities.
+
+    When a skill is available, always try to apply it to answer the
+    user's question. Use the exec tool to run commands when the skill
+    instructs you to. Use read_file and write_file for file operations.
+
+    If no skill matches the user's question, say so and suggest what
+    kind of skill would help.
+
+  # --- A2A agent card ---------------------------------------------------
+  agent-card.json: |
+    {
+      "name": "skill-playground",
+      "description": "Skill testing agent — capabilities come from mounted skills",
+      "version": "1.0.0",
+      "protocolVersion": "0.3.0",
+      "url": "http://skill-playground:8000",
+      "skills": [
+        {
+          "id": "draft-skill",
+          "name": "Draft Skill",
+          "description": "A user-defined skill under development",
+          "tags": ["draft", "testing"],
+          "examples": ["Test my skill"]
+        }
+      ],
+      "capabilities": {},
+      "defaultInputModes": ["text/plain"],
+      "defaultOutputModes": ["text/markdown"]
+    }
+
+  # --- Agent config -----------------------------------------------------
+  # Enables the agentic loop with exec, read_file, and write_file tools.
+  agent-config.yaml: |
+    tools:
+      allowed:
+        - exec
+        - read_file
+        - write_file
+      exec:
+        timeout: 30
+        max_output: 50000
+      workspace: /tmp/agent-workspace
+    loop:
+      max_iterations: 10

--- a/examples/skill-playground/deployment.yaml
+++ b/examples/skill-playground/deployment.yaml
@@ -1,0 +1,133 @@
+# Skill Playground — Deployment, Service, and Route
+#
+# Deploys a generic DocsClaw agent with a single draft skill that
+# can be updated without redeploying the entire stack. See README.md
+# for the two update paths (auto-sync vs rollout restart).
+#
+# Prerequisites — apply these first:
+#   kubectl apply -f configmap.yaml
+#   kubectl apply -f skill-configmap.yaml
+#   kubectl apply -f llm-secret.yaml
+#
+# Then deploy:
+#   kubectl apply -f deployment.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skill-playground
+  labels:
+    app: skill-playground
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: skill-playground
+  template:
+    metadata:
+      labels:
+        app: skill-playground
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: docsclaw
+          # Pin to a specific version for production (e.g., :v0.9.4)
+          image: ghcr.io/redhat-et/docsclaw:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - serve
+            - --config-dir
+            - /config/agent
+            - --listen-plain-http
+            - --session-db
+            - memory
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8100
+              name: health
+          envFrom:
+            - secretRef:
+                name: llm-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            - name: skill-draft
+              mountPath: /config/agent/skills/draft-skill
+              readOnly: true
+            - name: workspace
+              mountPath: /tmp/agent-workspace
+      volumes:
+        - name: agent-config
+          configMap:
+            name: skill-playground
+        - name: skill-draft
+          configMap:
+            name: skill-playground-draft-skill
+        - name: workspace
+          emptyDir: {}
+
+---
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: skill-playground
+  labels:
+    app: skill-playground
+spec:
+  selector:
+    app: skill-playground
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+---
+# Route (OpenShift) — on plain Kubernetes, replace with an Ingress.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: skill-playground
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
+  labels:
+    app: skill-playground
+spec:
+  to:
+    kind: Service
+    name: skill-playground
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/examples/skill-playground/llm-secret.yaml
+++ b/examples/skill-playground/llm-secret.yaml
@@ -1,0 +1,38 @@
+# LLM Provider Secret
+#
+# Same format as examples/nps-explorer/llm-secret.yaml.
+# Uncomment the section for your provider and fill in the API key.
+#
+# Get your API key:
+#   - Anthropic: https://console.anthropic.com/settings/keys
+#   - OpenAI:    https://platform.openai.com/api-keys
+#
+# Apply before the Deployment:
+#   kubectl apply -f llm-secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-secret
+  labels:
+    app: skill-playground
+stringData:
+
+  # --- Option 1: Anthropic (default) ---
+  LLM_API_KEY: ""              # your Anthropic API key
+  LLM_PROVIDER: "anthropic"
+  LLM_MODEL: "claude-sonnet-4-6"
+  # LLM_MODEL: "claude-opus-4-6"
+  # LLM_MODEL: "claude-haiku-4-5"
+
+  # --- Option 2: OpenAI ---
+  # LLM_API_KEY: ""            # your OpenAI API key
+  # LLM_PROVIDER: "openai"
+  # LLM_MODEL: "gpt-5.4"
+  # LLM_BASE_URL: "https://api.openai.com/v1"
+
+  # --- Option 3: OpenAI-compatible (e.g. MaaS / LiteLLM) ---
+  # LLM_API_KEY: ""            # your provider API key
+  # LLM_PROVIDER: "litellm"
+  # LLM_MODEL: "qwen3-14b"
+  # LLM_BASE_URL: "https://your-litellm-proxy.example.com/v1"

--- a/examples/skill-playground/llm-secret.yaml
+++ b/examples/skill-playground/llm-secret.yaml
@@ -29,6 +29,7 @@ stringData:
   # LLM_API_KEY: ""            # your OpenAI API key
   # LLM_PROVIDER: "openai"
   # LLM_MODEL: "gpt-5.4"
+  # LLM_MODEL: "gpt-5.4-mini"
   # LLM_BASE_URL: "https://api.openai.com/v1"
 
   # --- Option 3: OpenAI-compatible (e.g. MaaS / LiteLLM) ---

--- a/examples/skill-playground/redeploy.sh
+++ b/examples/skill-playground/redeploy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# redeploy.sh — Update the draft skill ConfigMap and optionally restart
+#
+# Usage:
+#   ./redeploy.sh <skill-file>              # content-only (auto-sync)
+#   ./redeploy.sh <skill-file> --restart    # full restart
+#
+# The auto-sync path updates the ConfigMap and lets the kubelet
+# propagate the change to the mounted volume (~30-60s). The agent's
+# load_skill tool reads from disk on each call, so new content is
+# picked up on the next request after sync completes.
+#
+# The --restart path additionally triggers a rollout restart, which
+# creates a new pod that reads the updated ConfigMap immediately
+# (~10-15s). Use this when you change the skill's name or description
+# in the YAML frontmatter.
+
+set -euo pipefail
+
+CONFIGMAP_NAME="skill-playground-draft-skill"
+DEPLOYMENT_NAME="skill-playground"
+
+usage() {
+    echo "Usage: $0 <skill-file> [--restart]"
+    echo ""
+    echo "  <skill-file>   Path to the SKILL.md file"
+    echo "  --restart       Trigger a rollout restart (for metadata changes)"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+SKILL_FILE="$1"
+RESTART=false
+
+if [[ $# -ge 2 && "$2" == "--restart" ]]; then
+    RESTART=true
+fi
+
+if [[ ! -f "$SKILL_FILE" ]]; then
+    echo "Error: file not found: $SKILL_FILE"
+    exit 1
+fi
+
+START=$(date +%s)
+
+echo "Updating ConfigMap ${CONFIGMAP_NAME}..."
+kubectl create configmap "$CONFIGMAP_NAME" \
+    --from-file="SKILL.md=${SKILL_FILE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+if [[ "$RESTART" == "true" ]]; then
+    echo "Triggering rollout restart..."
+    kubectl rollout restart deployment/"$DEPLOYMENT_NAME"
+    echo "Waiting for rollout to complete..."
+    kubectl rollout status deployment/"$DEPLOYMENT_NAME" --timeout=60s
+else
+    echo "ConfigMap updated. Kubelet will sync the volume in ~30-60s."
+    echo "The agent will pick up new content on the next request after sync."
+fi
+
+END=$(date +%s)
+ELAPSED=$((END - START))
+echo "Done in ${ELAPSED}s."

--- a/examples/skill-playground/redeploy.sh
+++ b/examples/skill-playground/redeploy.sh
@@ -6,9 +6,9 @@
 #   ./redeploy.sh <skill-file> --restart    # full restart
 #
 # The auto-sync path updates the ConfigMap and lets the kubelet
-# propagate the change to the mounted volume (~30-60s). The agent's
-# load_skill tool reads from disk on each call, so new content is
-# picked up on the next request after sync completes.
+# propagate the change to the mounted volume (typically seconds).
+# The agent's load_skill tool reads from disk on each call, so new
+# content is picked up on the next request after sync completes.
 #
 # The --restart path additionally triggers a rollout restart, which
 # creates a new pod that reads the updated ConfigMap immediately
@@ -19,12 +19,15 @@ set -euo pipefail
 
 CONFIGMAP_NAME="skill-playground-draft-skill"
 DEPLOYMENT_NAME="skill-playground"
+NAMESPACE=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)
+NAMESPACE="${NAMESPACE:-default}"
 
 usage() {
-    echo "Usage: $0 <skill-file> [--restart]"
+    echo "Usage: $0 <skill-file> [--restart] [-n NAMESPACE]"
     echo ""
     echo "  <skill-file>   Path to the SKILL.md file"
     echo "  --restart       Trigger a rollout restart (for metadata changes)"
+    echo "  -n NAMESPACE    Kubernetes namespace (default: current context)"
     exit 1
 }
 
@@ -33,31 +36,45 @@ if [[ $# -lt 1 ]]; then
 fi
 
 SKILL_FILE="$1"
+shift
 RESTART=false
 
-if [[ $# -ge 2 && "$2" == "--restart" ]]; then
-    RESTART=true
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --restart)
+            RESTART=true
+            shift
+            ;;
+        -n)
+            NAMESPACE="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
 
 if [[ ! -f "$SKILL_FILE" ]]; then
     echo "Error: file not found: $SKILL_FILE"
     exit 1
 fi
 
+echo "Namespace: ${NAMESPACE}"
 START=$(date +%s)
 
 echo "Updating ConfigMap ${CONFIGMAP_NAME}..."
-kubectl create configmap "$CONFIGMAP_NAME" \
+kubectl -n "$NAMESPACE" create configmap "$CONFIGMAP_NAME" \
     --from-file="SKILL.md=${SKILL_FILE}" \
-    --dry-run=client -o yaml | kubectl apply -f -
+    --dry-run=client -o yaml | kubectl -n "$NAMESPACE" apply -f -
 
 if [[ "$RESTART" == "true" ]]; then
     echo "Triggering rollout restart..."
-    kubectl rollout restart deployment/"$DEPLOYMENT_NAME"
+    kubectl -n "$NAMESPACE" rollout restart deployment/"$DEPLOYMENT_NAME"
     echo "Waiting for rollout to complete..."
-    kubectl rollout status deployment/"$DEPLOYMENT_NAME" --timeout=60s
+    kubectl -n "$NAMESPACE" rollout status deployment/"$DEPLOYMENT_NAME" --timeout=60s
 else
-    echo "ConfigMap updated. Kubelet will sync the volume in ~30-60s."
+    echo "ConfigMap updated. The kubelet will sync the volume shortly."
     echo "The agent will pick up new content on the next request after sync."
 fi
 

--- a/examples/skill-playground/skill-configmap.yaml
+++ b/examples/skill-playground/skill-configmap.yaml
@@ -1,0 +1,52 @@
+# Draft Skill — ConfigMap
+#
+# A placeholder skill for the playground. Replace the SKILL.md content
+# with your own skill instructions, then use redeploy.sh to push the
+# update to the running agent.
+#
+# The skill name and description in the YAML frontmatter stay fixed
+# so that content-only changes can propagate via ConfigMap auto-sync
+# without a pod restart. See README.md for details.
+#
+# Apply before the Deployment:
+#   kubectl apply -f skill-configmap.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skill-playground-draft-skill
+  labels:
+    app: skill-playground
+data:
+  SKILL.md: |
+    ---
+    name: draft-skill
+    description: A draft skill for testing — edit the content below
+    ---
+
+    # Draft skill
+
+    Replace this content with your skill instructions.
+
+    A good skill tells the agent:
+    - What domain or API it covers
+    - How to authenticate (API keys, tokens)
+    - What endpoints or commands are available
+    - What parameters each endpoint accepts
+    - How to format responses for the user
+
+    ## Example structure
+
+    ```
+    ## API Configuration
+    Base URL: https://api.example.com/v1
+    Authentication: Bearer token from $MY_API_KEY
+
+    ## Endpoints
+    ### GET /items
+    Returns a list of items.
+    Parameters: limit (int), offset (int), q (string)
+
+    ### GET /items/{id}
+    Returns a single item by ID.
+    ```


### PR DESCRIPTION
## Summary

- Adds `examples/skill-playground/` — backend manifests for a skill-editing frontend workflow
- Generic agent personality with a draft skill that users iterate on via ConfigMap updates
- Documents two update paths with timing: auto-sync (~60s, no restart) and rollout restart (~15s)
- Includes `redeploy.sh` script and Kubernetes API reference for frontend integration

## Files

| File | Purpose |
| ---- | ------- |
| `README.md` | Workflow docs, timing expectations, frontend integration API calls |
| `configmap.yaml` | Generic "skill tester" agent personality |
| `skill-configmap.yaml` | Draft skill with placeholder content and scaffolding |
| `llm-secret.yaml` | Multi-provider LLM secret (Anthropic/OpenAI/LiteLLM) |
| `deployment.yaml` | Deployment, Service, Route with hardened security |
| `redeploy.sh` | Update script: recreate ConfigMap, optionally rollout restart |

## Test plan

- [ ] `yamllint` passes on all YAML files
- [ ] `bash -n redeploy.sh` passes (script syntax)
- [ ] `kubectl apply --dry-run=client -f examples/skill-playground/` succeeds
- [ ] Deploy to OpenShift, run `redeploy.sh` with a custom skill, verify agent picks it up
- [ ] Measure actual timing for both update paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)