### PR TITLE
feat: support skills_dir in agent-config.yaml

### DIFF
--- a/docs/agent-config-guide.md
+++ b/docs/agent-config-guide.md
@@ -26,6 +26,8 @@ loop:
 ## Full example
 
 ```yaml
+skills_dir: /skills
+
 tools:
   allowed:
     - exec
@@ -67,10 +69,12 @@ rag:
 
 ## Structure
 
-The file has three top-level sections: `tools`, `loop`, and `rag`.
+The file has four top-level sections: `skills_dir`, `tools`, `loop`,
+and `rag`.
 
 ```text
 agent-config.yaml
+├── skills_dir           # where to find skill subdirectories
 ├── tools
 │   ├── allowed          # which tools the LLM can call
 │   ├── exec             # shell execution settings
@@ -83,6 +87,12 @@ agent-config.yaml
 ```
 
 ## Field reference
+
+### `skills_dir`
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `skills_dir` | `string` | `<config-dir>/skills` | Directory containing skill subdirectories. Each subdirectory must have a `SKILL.md` file. The CLI flag `--skills-dir` overrides this value. |
 
 ### `tools`
 

--- a/docs/demo/skill-discovery-test.yaml
+++ b/docs/demo/skill-discovery-test.yaml
@@ -61,6 +61,7 @@ data:
       "defaultOutputModes": ["text/plain"]
     }
   agent-config.yaml: |
+    skills_dir: /skills
     tools:
       allowed:
         - read_file
@@ -139,8 +140,6 @@ spec:
               type: RuntimeDefault
           args:
             - serve
-            - --skills-dir
-            - /skills
           ports:
             - containerPort: 8000
               name: http

--- a/docs/demo/skill-discovery-test.yaml
+++ b/docs/demo/skill-discovery-test.yaml
@@ -8,10 +8,10 @@
 #   1. OCI image volume (document-summarizer from quay.io)
 #   2. ConfigMap (code-review, inline)
 #
-# Skills are mounted at /skills (separate from /config/agent) using
-# the --skills-dir flag. This avoids a Kubernetes limitation where
-# image volumes mounted as subdirectories of a ConfigMap volume
-# appear empty.
+# Skills are mounted at /skills (separate from /config/agent).
+# The skills_dir setting in agent-config.yaml points to /skills.
+# This avoids a Kubernetes limitation where image volumes mounted
+# as subdirectories of a ConfigMap volume appear empty.
 #
 # Prerequisites:
 #   oc project panni-docsclaw

--- a/docs/oci-skills-guide.md
+++ b/docs/oci-skills-guide.md
@@ -243,9 +243,10 @@ volumeMounts:
     mountPath: /skills/x               # works
 ```
 
-For DocsClaw, use `--skills-dir /skills` to point to the separate
-mount path. Other agent frameworks may need an equivalent config
-option or environment variable (e.g., `SKILLS_DIR=/skills`).
+For DocsClaw, set `skills_dir: /skills` in `agent-config.yaml`
+(or use the `--skills-dir` CLI flag as an override). Other agent
+frameworks may need an equivalent config option or environment
+variable (e.g., `SKILLS_DIR=/skills`).
 
 This is a general Kubernetes limitation, not specific to any agent
 or OCI image format. It applies equally to ConfigMap-on-ConfigMap

--- a/internal/cmd/agentconfig.go
+++ b/internal/cmd/agentconfig.go
@@ -14,9 +14,10 @@ import (
 
 // AgentConfig holds the agent-config.yaml configuration.
 type AgentConfig struct {
-	Tools ToolsConfig `yaml:"tools"`
-	Loop  LoopCfg     `yaml:"loop"`
-	RAG   *rag.Config `yaml:"rag"`
+	Tools     ToolsConfig `yaml:"tools"`
+	Loop      LoopCfg     `yaml:"loop"`
+	RAG       *rag.Config `yaml:"rag"`
+	SkillsDir string      `yaml:"skills_dir"`
 }
 
 // ToolsConfig configures tool availability and behavior.

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -367,7 +367,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	// Discover skills (runs in both phase 1 and phase 2)
+	// Priority: CLI flag → agent-config.yaml → default (<config-dir>/skills)
 	skillsDir := cfg.SkillsDir
+	if skillsDir == "" && agentCfg != nil {
+		skillsDir = agentCfg.SkillsDir
+	}
 	if skillsDir == "" {
 		skillsDir = filepath.Join(cfg.ConfigDir, "skills")
 	}

--- a/pkg/manifest/agentconfig.go
+++ b/pkg/manifest/agentconfig.go
@@ -8,6 +8,10 @@ import (
 func BuildAgentConfigYAML(m *AgentManifest) string {
 	var b strings.Builder
 
+	if m.Spec.Runtime.SkillsDir != "" {
+		fmt.Fprintf(&b, "skills_dir: %s\n", m.Spec.Runtime.SkillsDir)
+	}
+
 	b.WriteString("tools:\n")
 	if len(m.Spec.Runtime.Tools.Allowed) > 0 {
 		b.WriteString("  allowed:\n")
@@ -37,10 +41,6 @@ func BuildAgentConfigYAML(m *AgentManifest) string {
 	if m.Spec.Runtime.Loop.MaxIterations > 0 {
 		b.WriteString("loop:\n")
 		fmt.Fprintf(&b, "  maxIterations: %d\n", m.Spec.Runtime.Loop.MaxIterations)
-	}
-
-	if m.Spec.Runtime.SkillsDir != "" {
-		fmt.Fprintf(&b, "skills_dir: %s\n", m.Spec.Runtime.SkillsDir)
 	}
 
 	return b.String()

--- a/pkg/manifest/agentconfig.go
+++ b/pkg/manifest/agentconfig.go
@@ -39,6 +39,10 @@ func BuildAgentConfigYAML(m *AgentManifest) string {
 		fmt.Fprintf(&b, "  maxIterations: %d\n", m.Spec.Runtime.Loop.MaxIterations)
 	}
 
+	if m.Spec.Runtime.SkillsDir != "" {
+		fmt.Fprintf(&b, "skills_dir: %s\n", m.Spec.Runtime.SkillsDir)
+	}
+
 	return b.String()
 }
 
@@ -48,5 +52,6 @@ func HasRuntimeConfig(m *AgentManifest) bool {
 		r.Tools.Exec.Timeout > 0 ||
 		r.Tools.Exec.MaxOutput > 0 ||
 		len(r.Tools.WebFetch.AllowedHosts) > 0 ||
-		r.Loop.MaxIterations > 0
+		r.Loop.MaxIterations > 0 ||
+		r.SkillsDir != ""
 }

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -45,8 +45,9 @@ type SkillRef struct {
 }
 
 type RuntimeConfig struct {
-	Tools RuntimeToolsConfig `yaml:"tools"`
-	Loop  RuntimeLoopConfig  `yaml:"loop"`
+	Tools     RuntimeToolsConfig `yaml:"tools"`
+	Loop      RuntimeLoopConfig  `yaml:"loop"`
+	SkillsDir string             `yaml:"skillsDir,omitempty"`
 }
 
 type RuntimeToolsConfig struct {


### PR DESCRIPTION
## Summary

- Add `skills_dir` field to `agent-config.yaml` so platform teams can control skill discovery through ConfigMaps without editing the Deployment spec
- Resolution priority: CLI flag `--skills-dir` > `agent-config.yaml` `skills_dir` > default (`<config-dir>/skills`)
- CLI flag kept for backward compatibility
- Update manifest generation, docs, and demo manifests

**Before** (requires Deployment spec change):
```yaml
args:
  - serve
  - --skills-dir
  - /skills
```

**After** (ConfigMap only):
```yaml
# in agent-config.yaml
skills_dir: /skills
```

Fixes #78

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (5 pre-existing issues, no new ones)
- [ ] Deploy skill-discovery-test with `skills_dir` in ConfigMap, verify skills are discovered
- [ ] Verify CLI flag still overrides config file value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skills_dir` as an explicit top-level configuration field in agent configuration, allowing users to specify the skills directory path in `agent-config.yaml`.

* **Documentation**
  * Updated configuration guides to document the new `skills_dir` field, its default value (`<config-dir>/skills`), and how the `--skills-dir` CLI flag can override it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->