### PR TITLE
feat: add skill-puller sidecar for dynamic skill loading

### DIFF
--- a/Dockerfile.skill-puller
+++ b/Dockerfile.skill-puller
@@ -1,0 +1,23 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /skill-puller ./cmd/skill-puller
+
+FROM alpine:3.23
+
+RUN apk --no-cache add ca-certificates && \
+    addgroup -S skillpuller && adduser -S skillpuller -G skillpuller
+
+WORKDIR /app
+COPY --from=builder /skill-puller /app/skill-puller
+
+USER skillpuller
+
+EXPOSE 9100
+
+ENTRYPOINT ["/app/skill-puller"]

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ OUTDIR ?= deploy/generated/$(NAME)
 NAMESPACE ?=
 KUBECTL ?= oc
 
-.PHONY: build test lint fmt clean image image-push agent-build agent-image agent-push configmap-gen configmap-apply
+.PHONY: build build-skill-puller test lint fmt clean image image-push agent-build agent-image agent-push configmap-gen configmap-apply
 
 build:
 	go build -o $(BINDIR)/$(BINARY) ./cmd/docsclaw
+
+build-skill-puller:
+	go build -o $(BINDIR)/skill-puller ./cmd/skill-puller
 
 test:
 	go test ./...
@@ -100,25 +103,24 @@ endif
 		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
 		--dry-run=client -o yaml > $(OUTDIR)/config.yaml
 	@echo "  Created $(OUTDIR)/config.yaml"
-	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@# --- Per-skill ConfigMaps (only if skills/ exists) ---
 	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
-		SKILL_FILES=""; \
+		FOUND=0; \
 		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
 			skill_name=$$(basename "$$skill_dir"); \
-			[ -f "$$skill_dir/SKILL.md" ] && \
-				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
-		done; \
-		if [ -n "$$SKILL_FILES" ]; then \
-			$(KUBECTL) create configmap $(NAME)-skills \
-				$$SKILL_FILES \
+			[ -f "$$skill_dir/SKILL.md" ] || continue; \
+			FOUND=1; \
+			$(KUBECTL) create configmap $(NAME)-skill-$$skill_name \
+				--from-file=SKILL.md=$$skill_dir/SKILL.md \
 				$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
-				--dry-run=client -o yaml > $(OUTDIR)/skills.yaml; \
-			echo "  Created $(OUTDIR)/skills.yaml"; \
-		else \
-			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skills ConfigMap"; \
+				--dry-run=client -o yaml > $(OUTDIR)/skill-$$skill_name.yaml; \
+			echo "  Created $(OUTDIR)/skill-$$skill_name.yaml"; \
+		done; \
+		if [ "$$FOUND" = "0" ]; then \
+			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skill ConfigMaps"; \
 		fi; \
 	else \
-		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+		echo "  No skills/ directory found, skipping skill ConfigMaps"; \
 	fi
 	@echo "Done. Apply with: $(KUBECTL) apply -f $(OUTDIR)/"
 
@@ -139,24 +141,23 @@ endif
 		$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
 		--dry-run=client -o yaml | $(KUBECTL) apply -f -
 	@echo "  Applied $(NAME)-config"
-	@# --- Skills ConfigMap (only if skills/ exists) ---
+	@# --- Per-skill ConfigMaps (only if skills/ exists) ---
 	@if [ -d "$(CONFIG_DIR)/skills" ]; then \
-		SKILL_FILES=""; \
+		FOUND=0; \
 		for skill_dir in $(CONFIG_DIR)/skills/*/; do \
 			skill_name=$$(basename "$$skill_dir"); \
-			[ -f "$$skill_dir/SKILL.md" ] && \
-				SKILL_FILES="$$SKILL_FILES --from-file=$$skill_name.SKILL.md=$$skill_dir/SKILL.md"; \
-		done; \
-		if [ -n "$$SKILL_FILES" ]; then \
-			$(KUBECTL) create configmap $(NAME)-skills \
-				$$SKILL_FILES \
+			[ -f "$$skill_dir/SKILL.md" ] || continue; \
+			FOUND=1; \
+			$(KUBECTL) create configmap $(NAME)-skill-$$skill_name \
+				--from-file=SKILL.md=$$skill_dir/SKILL.md \
 				$(if $(NAMESPACE),--namespace $(NAMESPACE),) \
 				--dry-run=client -o yaml | $(KUBECTL) apply -f -; \
-			echo "  Applied $(NAME)-skills"; \
-		else \
-			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skills ConfigMap"; \
+			echo "  Applied $(NAME)-skill-$$skill_name"; \
+		done; \
+		if [ "$$FOUND" = "0" ]; then \
+			echo "  No SKILL.md files found in $(CONFIG_DIR)/skills/, skipping skill ConfigMaps"; \
 		fi; \
 	else \
-		echo "  No skills/ directory found, skipping skills ConfigMap"; \
+		echo "  No skills/ directory found, skipping skill ConfigMaps"; \
 	fi
 	@echo "Done."

--- a/cmd/skill-puller/main.go
+++ b/cmd/skill-puller/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/redhat-et/docsclaw/internal/skillpuller"
+)
+
+func main() {
+	port := flag.Int("port", 9100, "HTTP listen port")
+	skillsDir := flag.String("skills-dir", "/data/skills", "directory to write pulled skills into")
+	flag.Parse()
+
+	srv := skillpuller.NewServer(*skillsDir, *port)
+	if err := srv.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/skill-puller/main.go
+++ b/cmd/skill-puller/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"flag"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/redhat-et/docsclaw/internal/skillpuller"
 )
@@ -14,6 +15,7 @@ func main() {
 
 	srv := skillpuller.NewServer(*skillsDir, *port)
 	if err := srv.Run(); err != nil {
-		log.Fatal(err)
+		slog.Error("failed to run server", "error", err)
+		os.Exit(1)
 	}
 }

--- a/docs/dev/skill-puller-sidecar-design.md
+++ b/docs/dev/skill-puller-sidecar-design.md
@@ -1,0 +1,287 @@
+# Skill-puller sidecar design
+
+**Status:** Draft
+**Date:** 2026-05-30
+
+## Problem
+
+When DocsClaw runs on OpenShift, skills mounted via ConfigMaps or
+OCI image volumes are read-only and safe from tampering. But if
+the agent needs to **discover and pull skills dynamically** at
+runtime, we need a mechanism that:
+
+1. Lets the agent request new skills after the pod has started
+1. Ensures pulled skills cannot be modified by the agent process
+   (or by a malicious skill running inside it)
+1. Verifies skill authenticity before making them available
+
+## Approach
+
+A lightweight sidecar container (`skill-puller`) runs alongside
+the DocsClaw agent in the same pod. It owns the skills directory
+and exposes a local HTTP API for search, verification, and pull.
+The agent mounts the same directory **read-only**.
+
+### Why a sidecar
+
+We considered alternatives:
+
+| Approach | Verdict |
+| -------- | ------- |
+| Landlock (kernel self-sandboxing) | Self-imposed — a compromised agent could skip it |
+| SELinux MCS policies | Fragile on OpenShift, designed for inter-pod isolation |
+| Agent-side signature check only | Detects tampering but doesn't prevent writes |
+| CSI ephemeral driver | Heavy infrastructure investment for a simple problem |
+
+The sidecar with a read-only volume mount is the simplest
+Kubernetes-native solution. The enforcement is at the VFS mount
+level — the agent kernel-enforced cannot write to the skills
+path, regardless of what code runs inside it.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────┐
+│ Pod                                         │
+│                                             │
+│  ┌──────────────┐     ┌──────────────────┐  │
+│  │ docsclaw     │     │ skill-puller     │  │
+│  │ (agent)      │     │ (sidecar)        │  │
+│  │              │     │                  │  │
+│  │ POST /skills │────▶│  verify (cosign) │  │
+│  │  /pull       │     │  pull (multi-src)│  │
+│  │              │     │                  │  │
+│  │  reads from  │     │  writes to       │  │
+│  │  /skills/dyn │     │  /skills/dyn     │  │
+│  │  (read-only) │     │  (read-write)    │  │
+│  └──────┬───────┘     └────────┬─────────┘  │
+│         │                      │            │
+│         ▼                      ▼            │
+│     ┌──────────────────────────────┐        │
+│     │ emptyDir: dynamic-skills     │        │
+│     └──────────────────────────────┘        │
+└─────────────────────────────────────────────┘
+```
+
+### Volume mounts
+
+The sidecar and the agent share an `emptyDir` volume. The agent
+mounts it read-only, the sidecar mounts it read-write. The mount
+paths are independent — the agent's `--skills-dir` flag
+determines where it looks for skills, and the Deployment spec
+wires the volume to a subdirectory under that path. The sidecar
+writes to its own mount path and does not need to know the
+agent's configuration.
+
+```yaml
+volumes:
+  - name: dynamic-skills
+    emptyDir: {}
+containers:
+  - name: agent
+    args: ["serve", "--skills-dir", "/skills"]
+    volumeMounts:
+      - name: dynamic-skills
+        mountPath: /skills/dynamic
+        readOnly: true
+  - name: skill-puller
+    volumeMounts:
+      - name: dynamic-skills
+        mountPath: /data/skills
+        readOnly: false
+```
+
+### Directory layout
+
+The agent's `--skills-dir` points to `/skills` in this example.
+Static and dynamic skills coexist as sibling subdirectories.
+Most agents (including DocsClaw and Claude Code) scan the skills
+directory recursively, looking for subdirectories containing a
+`SKILL.md` file. The sidecar writes into the shared volume and
+the files appear alongside operator-mounted skills automatically:
+
+```text
+/skills/
+├── hr/                          # ConfigMap or image volume mount
+│   └── resume-reviewer/
+│       └── SKILL.md
+├── finance/                     # another static mount
+│   └── expense-policy/
+│       └── SKILL.md
+└── dynamic/                     # emptyDir, written by sidecar
+    ├── doc-summarizer/
+    │   └── SKILL.md
+    └── calendar-scheduler/
+        └── SKILL.md
+```
+
+The `/skills/dynamic/` mount is read-only in the agent container
+and read-write in the sidecar. All other mounts under `/skills/`
+are read-only by their nature (ConfigMap, image volume).
+
+### Skill hot-reload
+
+The sidecar's responsibility ends at writing the skill files to
+the shared volume. **Discovering newly available skills is the
+agent's responsibility.** Agent runtimes vary in how they handle
+this:
+
+- Some agents watch the skills directory and pick up new skills
+  immediately (inotify, polling)
+- Some agents require a signal (e.g. SIGHUP) to re-scan
+- Some agents only load skills at startup and require a restart
+
+The sidecar does not attempt to notify the agent — it has no
+knowledge of the agent's reload mechanism. If the agent runtime
+supports a reload trigger, the operator can configure a
+post-pull webhook in the sidecar or handle it via a shared
+signal mechanism. This is intentionally left to the agent side.
+
+## Sidecar API
+
+The sidecar listens on `localhost:9100` (pod-internal only).
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| POST | `/skills/pull` | Pull, verify, and install a skill |
+| GET | `/skills/list` | List currently available dynamic skills |
+| GET | `/healthz` | Liveness probe |
+
+Search is **out of scope** for the initial implementation. Skill
+search depends heavily on the registry backend (OCI catalog API,
+Quay REST API, GitHub search, etc.) and there is no universal
+search interface across these sources. For now, the agent or
+operator provides the exact reference to pull. Search can be
+added later per source type.
+
+### Skill sources
+
+The sidecar supports pulling skills from multiple source types.
+The agent specifies the source and reference in the pull request:
+
+```json
+{"source": "url", "ref": "https://example.com/skills/summarizer/SKILL.md"}
+{"source": "github", "ref": "org/repo/path/to/skill", "version": "v1.2.0"}
+{"source": "oci", "ref": "quay.io/redhat-et/skills/summarizer:1.2.0"}
+```
+
+| Source | How it works |
+| ------ | ------------ |
+| `url` | HTTP GET to fetch a single `SKILL.md` file |
+| `github` | Fetch from GitHub raw content API, with optional branch/tag |
+| `oci` | Pull and unpack an OCI image containing the skill |
+
+### Pull flow
+
+1. Fetch the skill content from the specified source
+1. Write to `/skills/dynamic/<skill-name>/`
+1. Return skill metadata (name, description, source) to the agent
+
+## Relationship to skillimage
+
+The sibling project `skillimage` provides OCI-specific tooling
+for skill images (build, push, pull, catalog indexing). The
+sidecar is **not** part of skillimage — it lives in docsclaw
+as a demo of the deployment pattern.
+
+The sidecar is source-agnostic by design. For the `oci` source
+type, it may reuse skillimage's pull logic (ORAS client, path
+traversal protection, credential chain) either as a Go module
+import or by vendoring the relevant code. The `url` and `github`
+source types are simple HTTP fetches with no skillimage
+dependency.
+
+The sidecar does not use skillimage's `SkillCard` schema. Skills
+are identified by the standard `SKILL.md` file, not by any
+registry-specific metadata format.
+
+## Future work
+
+### Signature verification
+
+The sidecar should eventually verify OCI image signatures before
+unpacking (cosign/sigstore). This is deferred from the initial
+implementation to focus on the core pull-and-serve pattern.
+
+### Authentication
+
+Private registries and GitHub repos require auth tokens. The
+credential handling is straightforward (Docker/Podman credential
+chain for OCI, GitHub token for `github` source) but is deferred
+from v1 to keep the demo focused on the concept.
+
+### Search
+
+Skill search depends on the registry backend and has no universal
+interface. Can be added per source type as needed.
+
+## Agent-side skill for sidecar interaction
+
+Some skill ecosystems use a "paste a prompt" installation
+pattern where the agent downloads and writes skill files
+directly. For example, Red Hat's [agentic skills page][rh-skills]
+provides a bootstrap prompt that the user pastes into their
+agent chat. The agent fetches a bootstrap skill from GitHub,
+which then pulls the remaining skills. This works well on
+developer workstations where the user is present and the agent
+has filesystem write access.
+
+In production on OpenShift, the agent cannot (and should not)
+write skill files — the skills directory is read-only. Instead,
+we provide a **`skill-pull` skill** that teaches the agent how
+to interact with the sidecar's HTTP API. The agent uses `curl`
+(or the built-in HTTP tool) to call the sidecar on localhost:
+
+```text
+# Pull a skill from a URL
+curl -X POST http://localhost:9100/skills/pull \
+  -d '{"source": "url", "ref": "https://example.com/skills/summarizer/SKILL.md"}'
+
+# Pull from GitHub
+curl -X POST http://localhost:9100/skills/pull \
+  -d '{"source": "github", "ref": "org/repo/path/to/skill", "version": "v1.2.0"}'
+
+# Pull from an OCI registry
+curl -X POST http://localhost:9100/skills/pull \
+  -d '{"source": "oci", "ref": "quay.io/redhat-et/skills/summarizer:1.2.0"}'
+
+# List available dynamic skills
+curl http://localhost:9100/skills/list
+```
+
+This skill can be included in the agent's static skill set
+(ConfigMap mount) or baked into the agent container image. It
+replaces the "agent writes files" pattern with a safe
+delegation to the sidecar, preserving the read-only enforcement.
+
+The flow becomes:
+
+1. Agent determines it needs a capability it doesn't have
+1. Agent (or operator) identifies the skill reference to pull
+1. Agent uses the `skill-pull` skill to request the sidecar
+   to fetch and verify the skill
+1. Skill appears in `/skills/dynamic/` (read-only to the agent)
+1. Agent discovers and loads the new skill (runtime-dependent;
+   see "Skill hot-reload" above)
+
+[rh-skills]: https://www.redhat.com/en/agentic-skills
+
+## Deployment
+
+The sidecar is added to the agent's Deployment spec. It should
+integrate with the existing `docsclaw deploy` command — when
+`agent-manifest.yaml` includes a `dynamicSkills` section,
+the generated Kubernetes manifest includes the sidecar container
+and the shared volume.
+
+Estimated resource footprint: ~15–20 MiB memory, minimal CPU
+(idle most of the time, brief spikes during pulls).
+
+## Open questions
+
+- Should skill pulls be allowed from any source or restricted
+  to an allow-list in the sidecar config?
+- Should the sidecar support skill eviction (removing a dynamic
+  skill to free space)?
+- How does the agent discover the sidecar endpoint — hardcoded
+  localhost:9100, env var, or DNS?

--- a/docs/dev/skill-puller-sidecar-design.md
+++ b/docs/dev/skill-puller-sidecar-design.md
@@ -35,8 +35,8 @@ We considered alternatives:
 
 The sidecar with a read-only volume mount is the simplest
 Kubernetes-native solution. The enforcement is at the VFS mount
-level — the agent kernel-enforced cannot write to the skills
-path, regardless of what code runs inside it.
+level — the kernel prevents the agent from writing to the
+skills path, regardless of what code runs inside it.
 
 ## Architecture
 

--- a/examples/skill-puller-sidecar/README.md
+++ b/examples/skill-puller-sidecar/README.md
@@ -1,0 +1,55 @@
+# Skill-puller sidecar example
+
+This example shows how to deploy DocsClaw with a skill-puller
+sidecar that lets the agent pull skills dynamically at runtime.
+
+## How it works
+
+The pod has two containers:
+
+- **agent** — runs DocsClaw, mounts `/skills/dynamic` as
+  **read-only**
+- **skill-puller** — lightweight HTTP server, mounts the same
+  `emptyDir` volume as **read-write**
+
+The agent cannot modify pulled skills. The read-only enforcement
+is at the kernel (VFS mount) level.
+
+## Directory structure
+
+```text
+/skills/
+├── static/        # ConfigMap mount (read-only)
+│   └── ...
+└── dynamic/       # emptyDir shared with skill-puller (read-only to agent)
+    └── ...
+```
+
+## Usage
+
+The agent uses the `skill-pull` skill (included in
+`skills/skill-pull/SKILL.md`) to call the sidecar API:
+
+```bash
+# Pull a skill from a URL
+curl -X POST http://localhost:9100/skills/pull \
+  -d '{"source": "url", "ref": "https://example.com/my-skill/SKILL.md"}'
+
+# Pull from GitHub
+curl -X POST http://localhost:9100/skills/pull \
+  -d '{"source": "github", "ref": "org/repo/skills/my-skill", "version": "v1.0.0"}'
+
+# List pulled skills
+curl http://localhost:9100/skills/list
+```
+
+## Deploy
+
+```bash
+kubectl apply -f deployment.yaml
+```
+
+## Design
+
+See `docs/dev/skill-puller-sidecar-design.md` for the full
+design document.

--- a/examples/skill-puller-sidecar/deployment.yaml
+++ b/examples/skill-puller-sidecar/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skill-puller-agent
+spec:
+  selector:
+    app: skill-puller-agent
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: skill-puller-agent
+spec:
+  to:
+    kind: Service
+    name: skill-puller-agent
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skill-puller-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: skill-puller-agent
+  template:
+    metadata:
+      labels:
+        app: skill-puller-agent
+    spec:
+      containers:
+        - name: agent
+          image: ghcr.io/redhat-et/docsclaw:e54a9c1
+          args: ["serve", "--skills-dir", "/skills"]
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            - name: skill-code-review
+              mountPath: /skills/static/code-review
+              readOnly: true
+            - name: skill-url-summary
+              mountPath: /skills/static/url-summary
+              readOnly: true
+            - name: skill-skill-pull
+              mountPath: /skills/static/skill-pull
+              readOnly: true
+            - name: dynamic-skills
+              mountPath: /skills/dynamic
+              readOnly: true
+          envFrom:
+            - secretRef:
+                name: llm-secret
+          env:
+            - name: DOCSCLAW_CONFIG_DIR
+              value: /config/agent
+          imagePullPolicy: Always
+
+        - name: skill-puller
+          image: ghcr.io/redhat-et/docsclaw-skill-puller:dev
+          args: ["--skills-dir", "/data/skills", "--port", "9100"]
+          ports:
+            - containerPort: 9100
+          volumeMounts:
+            - name: dynamic-skills
+              mountPath: /data/skills
+              readOnly: false
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9100
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: 16Mi
+              cpu: 10m
+            limits:
+              memory: 32Mi
+              cpu: 100m
+
+      volumes:
+        - name: agent-config
+          configMap:
+            name: skill-puller-config
+        - name: skill-code-review
+          configMap:
+            name: skill-puller-skill-code-review
+        - name: skill-url-summary
+          configMap:
+            name: skill-puller-skill-url-summary
+        - name: skill-skill-pull
+          configMap:
+            name: skill-puller-skill-skill-pull
+        - name: dynamic-skills
+          emptyDir: {}

--- a/examples/skill-puller-sidecar/deployment.yaml
+++ b/examples/skill-puller-sidecar/deployment.yaml
@@ -45,6 +45,7 @@ spec:
             - containerPort: 8000
           securityContext:
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
@@ -100,6 +101,7 @@ spec:
             - containerPort: 9100
           securityContext:
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]

--- a/examples/skill-puller-sidecar/deployment.yaml
+++ b/examples/skill-puller-sidecar/deployment.yaml
@@ -43,6 +43,13 @@ spec:
           args: ["serve", "--skills-dir", "/skills"]
           ports:
             - containerPort: 8000
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: agent-config
               mountPath: /config/agent
@@ -65,6 +72,25 @@ spec:
           env:
             - name: DOCSCLAW_CONFIG_DIR
               value: /config/agent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8001
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 10m
+            limits:
+              memory: 128Mi
+              cpu: 500m
           imagePullPolicy: Always
 
         - name: skill-puller
@@ -72,6 +98,13 @@ spec:
           args: ["--skills-dir", "/data/skills", "--port", "9100"]
           ports:
             - containerPort: 9100
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: dynamic-skills
               mountPath: /data/skills

--- a/examples/skill-puller-sidecar/skills/skill-pull/SKILL.md
+++ b/examples/skill-puller-sidecar/skills/skill-pull/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: skill-pull
+description: Pull skills dynamically via the skill-puller sidecar
+---
+
+# Skill pull
+
+You can pull additional skills at runtime using the skill-puller
+sidecar running at `http://localhost:9100`.
+
+## Pull a skill from a URL
+
+When you know the direct URL to a SKILL.md file:
+
+```bash
+curl -s -X POST http://localhost:9100/skills/pull \
+  -H "Content-Type: application/json" \
+  -d '{"source": "url", "ref": "URL_TO_SKILL_MD"}'
+```
+
+## Pull a skill from GitHub
+
+When the skill is in a GitHub repository, use the format
+`owner/repo/path/to/skill`:
+
+```bash
+curl -s -X POST http://localhost:9100/skills/pull \
+  -H "Content-Type: application/json" \
+  -d '{"source": "github", "ref": "owner/repo/path/to/skill", "version": "main"}'
+```
+
+The `version` field is optional and defaults to `main`. You can
+use any branch name or tag.
+
+## List available skills
+
+To see which skills have been pulled:
+
+```bash
+curl -s http://localhost:9100/skills/list
+```
+
+## Notes
+
+- Pulled skills appear in your skills directory automatically.
+- You cannot modify pulled skills — they are read-only.
+- If a skill with the same name already exists, it will be
+  overwritten by the new version.

--- a/internal/skillpuller/server.go
+++ b/internal/skillpuller/server.go
@@ -1,0 +1,193 @@
+package skillpuller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/redhat-et/docsclaw/internal/skillpuller/source"
+)
+
+type Server struct {
+	SkillsDir string
+	Port      int
+	log       *slog.Logger
+	sources   map[string]source.Source
+}
+
+func NewServer(skillsDir string, port int) *Server {
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	return &Server{
+		SkillsDir: skillsDir,
+		Port:      port,
+		log:       slog.Default(),
+		sources: map[string]source.Source{
+			"url":    &source.URLSource{Client: httpClient},
+			"github": &source.GitHubSource{Client: httpClient},
+		},
+	}
+}
+
+type pullRequest struct {
+	Source  string `json:"source"`
+	Ref     string `json:"ref"`
+	Version string `json:"version,omitempty"`
+}
+
+type pullResponse struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Status string `json:"status"`
+	Path   string `json:"path"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type listResponse struct {
+	Skills []string `json:"skills"`
+}
+
+func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
+	var req pullRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if req.Source == "" || req.Ref == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "source and ref are required"})
+		return
+	}
+
+	src, ok := s.sources[req.Source]
+	if !ok {
+		supported := make([]string, 0, len(s.sources))
+		for k := range s.sources {
+			supported = append(supported, k)
+		}
+		writeJSON(w, http.StatusBadRequest, errorResponse{
+			Error: fmt.Sprintf("unknown source %q, supported: %s", req.Source, strings.Join(supported, ", ")),
+		})
+		return
+	}
+
+	skill, err := src.Pull(r.Context(), req.Ref, source.PullOptions{Version: req.Version})
+	if err != nil {
+		s.log.Error("pull failed", "source", req.Source, "ref", req.Ref, "error", err)
+		writeJSON(w, http.StatusBadGateway, errorResponse{Error: err.Error()})
+		return
+	}
+
+	skillDir := filepath.Join(s.SkillsDir, skill.Name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		s.log.Error("create skill dir", "path", skillDir, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to create skill directory"})
+		return
+	}
+
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillPath, skill.Content, 0o644); err != nil {
+		s.log.Error("write skill", "path", skillPath, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to write skill file"})
+		return
+	}
+
+	s.log.Info("skill pulled", "name", skill.Name, "source", req.Source, "ref", req.Ref)
+
+	writeJSON(w, http.StatusOK, pullResponse{
+		Name:   skill.Name,
+		Source: req.Source,
+		Status: "ok",
+		Path:   skill.Name + "/SKILL.md",
+	})
+}
+
+func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
+	var skills []string
+
+	entries, err := os.ReadDir(s.SkillsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSON(w, http.StatusOK, listResponse{Skills: []string{}})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to read skills directory"})
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(s.SkillsDir, entry.Name(), "SKILL.md")
+		if _, err := os.Stat(skillFile); err == nil {
+			skills = append(skills, entry.Name())
+		}
+	}
+
+	if skills == nil {
+		skills = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, listResponse{Skills: skills})
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintln(w, "ok")
+}
+
+func (s *Server) Run() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /skills/pull", s.handlePull)
+	mux.HandleFunc("GET /skills/list", s.handleList)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+
+	addr := fmt.Sprintf(":%d", s.Port)
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+
+	done := make(chan bool)
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		<-sigCh
+		s.log.Info("shutting down skill-puller...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			s.log.Error("shutdown error", "error", err)
+		}
+		close(done)
+	}()
+
+	s.log.Info("skill-puller starting", "addr", addr, "skills_dir", s.SkillsDir)
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	<-done
+	s.log.Info("skill-puller stopped")
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/skillpuller/server.go
+++ b/internal/skillpuller/server.go
@@ -17,8 +17,8 @@ import (
 )
 
 type Server struct {
-	SkillsDir string
-	Port      int
+	skillsDir string
+	port      int
 	log       *slog.Logger
 	sources   map[string]source.Source
 }
@@ -26,8 +26,8 @@ type Server struct {
 func NewServer(skillsDir string, port int) *Server {
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	return &Server{
-		SkillsDir: skillsDir,
-		Port:      port,
+		skillsDir: skillsDir,
+		port:      port,
 		log:       slog.Default(),
 		sources: map[string]source.Source{
 			"url":    &source.URLSource{Client: httpClient},
@@ -58,6 +58,7 @@ type listResponse struct {
 }
 
 func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req pullRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON: " + err.Error()})
@@ -88,7 +89,7 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skillDir := filepath.Join(s.SkillsDir, skill.Name)
+	skillDir := filepath.Join(s.skillsDir, skill.Name)
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		s.log.Error("create skill dir", "path", skillDir, "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to create skill directory"})
@@ -96,9 +97,16 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	skillPath := filepath.Join(skillDir, "SKILL.md")
-	if err := os.WriteFile(skillPath, skill.Content, 0o644); err != nil {
-		s.log.Error("write skill", "path", skillPath, "error", err)
+	tmpPath := skillPath + ".tmp"
+	if err := os.WriteFile(tmpPath, skill.Content, 0o644); err != nil {
+		s.log.Error("write skill", "path", tmpPath, "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to write skill file"})
+		return
+	}
+	if err := os.Rename(tmpPath, skillPath); err != nil {
+		s.log.Error("rename skill", "from", tmpPath, "to", skillPath, "error", err)
+		_ = os.Remove(tmpPath)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to install skill file"})
 		return
 	}
 
@@ -115,7 +123,7 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
 	var skills []string
 
-	entries, err := os.ReadDir(s.SkillsDir)
+	entries, err := os.ReadDir(s.skillsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			writeJSON(w, http.StatusOK, listResponse{Skills: []string{}})
@@ -129,7 +137,7 @@ func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {
 		if !entry.IsDir() {
 			continue
 		}
-		skillFile := filepath.Join(s.SkillsDir, entry.Name(), "SKILL.md")
+		skillFile := filepath.Join(s.skillsDir, entry.Name(), "SKILL.md")
 		if _, err := os.Stat(skillFile); err == nil {
 			skills = append(skills, entry.Name())
 		}
@@ -153,7 +161,7 @@ func (s *Server) Run() error {
 	mux.HandleFunc("GET /skills/list", s.handleList)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 
-	addr := fmt.Sprintf(":%d", s.Port)
+	addr := fmt.Sprintf("127.0.0.1:%d", s.port)
 	server := &http.Server{
 		Addr:         addr,
 		Handler:      mux,
@@ -175,7 +183,7 @@ func (s *Server) Run() error {
 		close(done)
 	}()
 
-	s.log.Info("skill-puller starting", "addr", addr, "skills_dir", s.SkillsDir)
+	s.log.Info("skill-puller starting", "addr", addr, "skills_dir", s.skillsDir)
 
 	if err := server.ListenAndServe(); err != http.ErrServerClosed {
 		return fmt.Errorf("server error: %w", err)

--- a/internal/skillpuller/server.go
+++ b/internal/skillpuller/server.go
@@ -89,7 +89,20 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skillDir := filepath.Join(s.skillsDir, skill.Name)
+	// Sanitize skill name to prevent path traversal
+	cleanName := filepath.Base(filepath.Clean(skill.Name))
+	if cleanName == "." || cleanName == ".." || cleanName == "" || cleanName != skill.Name {
+		s.log.Error("invalid skill name", "name", skill.Name)
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "skill name contains invalid characters"})
+		return
+	}
+
+	skillDir := filepath.Join(s.skillsDir, cleanName)
+	if !strings.HasPrefix(skillDir, filepath.Clean(s.skillsDir)+string(filepath.Separator)) {
+		s.log.Error("path escapes skills directory", "name", skill.Name)
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "skill name contains invalid characters"})
+		return
+	}
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		s.log.Error("create skill dir", "path", skillDir, "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to create skill directory"})

--- a/internal/skillpuller/server.go
+++ b/internal/skillpuller/server.go
@@ -110,10 +110,30 @@ func (s *Server) handlePull(w http.ResponseWriter, r *http.Request) {
 	}
 
 	skillPath := filepath.Join(skillDir, "SKILL.md")
-	tmpPath := skillPath + ".tmp"
-	if err := os.WriteFile(tmpPath, skill.Content, 0o644); err != nil {
+	tmpFile, err := os.CreateTemp(skillDir, "skill-*.tmp")
+	if err != nil {
+		s.log.Error("create temp file", "dir", skillDir, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to create temp file"})
+		return
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(skill.Content); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 		s.log.Error("write skill", "path", tmpPath, "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to write skill file"})
+		return
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		s.log.Error("close temp file", "path", tmpPath, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to write skill file"})
+		return
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		_ = os.Remove(tmpPath)
+		s.log.Error("chmod temp file", "path", tmpPath, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "failed to set file permissions"})
 		return
 	}
 	if err := os.Rename(tmpPath, skillPath); err != nil {

--- a/internal/skillpuller/server_test.go
+++ b/internal/skillpuller/server_test.go
@@ -2,6 +2,7 @@ package skillpuller
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -148,6 +149,34 @@ func TestHandleList_WithSkills(t *testing.T) {
 	if resp.Skills[0] != "skill-a" || resp.Skills[1] != "skill-b" {
 		t.Errorf("skills = %v, want [skill-a skill-b]", resp.Skills)
 	}
+}
+
+func TestHandlePull_PathTraversal(t *testing.T) {
+	srv := newTestServer(t.TempDir())
+
+	// Inject a skill with a malicious name directly (simulates a
+	// source that returns a crafted skill name)
+	srv.sources["url"] = &pathTraversalSource{}
+
+	body, _ := json.Marshal(pullRequest{
+		Source: "url",
+		Ref:    "anything",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/skills/pull", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handlePull(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+type pathTraversalSource struct{}
+
+func (p *pathTraversalSource) Pull(_ context.Context, _ string, _ source.PullOptions) (*source.Skill, error) {
+	return &source.Skill{Name: "../../etc", Content: []byte("malicious")}, nil
 }
 
 func TestHandleHealthz(t *testing.T) {

--- a/internal/skillpuller/server_test.go
+++ b/internal/skillpuller/server_test.go
@@ -1,0 +1,150 @@
+package skillpuller
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandlePull_URL(t *testing.T) {
+	skillContent := "---\nname: fetched-skill\n---\nA test skill."
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(skillContent))
+	}))
+	defer upstream.Close()
+
+	skillsDir := t.TempDir()
+	srv := NewServer(skillsDir, 0)
+
+	body, _ := json.Marshal(pullRequest{
+		Source: "url",
+		Ref:    upstream.URL + "/skills/test-skill/SKILL.md",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/skills/pull", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handlePull(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp pullResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid response JSON: %v", err)
+	}
+
+	if resp.Name != "test-skill" {
+		t.Errorf("name = %q, want %q", resp.Name, "test-skill")
+	}
+
+	got, err := os.ReadFile(filepath.Join(skillsDir, "test-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("skill file not written: %v", err)
+	}
+	if string(got) != skillContent {
+		t.Errorf("file content = %q, want %q", string(got), skillContent)
+	}
+}
+
+func TestHandlePull_InvalidSource(t *testing.T) {
+	srv := NewServer(t.TempDir(), 0)
+
+	body, _ := json.Marshal(pullRequest{Source: "ftp", Ref: "example.com/skill"})
+	req := httptest.NewRequest(http.MethodPost, "/skills/pull", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handlePull(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandlePull_MissingFields(t *testing.T) {
+	srv := NewServer(t.TempDir(), 0)
+
+	body, _ := json.Marshal(pullRequest{Source: "url"})
+	req := httptest.NewRequest(http.MethodPost, "/skills/pull", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	srv.handlePull(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleList_Empty(t *testing.T) {
+	srv := NewServer(t.TempDir(), 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/skills/list", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleList(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp listResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(resp.Skills) != 0 {
+		t.Errorf("skills = %v, want empty", resp.Skills)
+	}
+}
+
+func TestHandleList_WithSkills(t *testing.T) {
+	skillsDir := t.TempDir()
+
+	for _, name := range []string{"skill-a", "skill-b"} {
+		dir := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(skillsDir, "not-a-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(skillsDir, 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/skills/list", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleList(w, req)
+
+	var resp listResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(resp.Skills) != 2 {
+		t.Fatalf("skills count = %d, want 2; got %v", len(resp.Skills), resp.Skills)
+	}
+}
+
+func TestHandleHealthz(t *testing.T) {
+	srv := NewServer(t.TempDir(), 0)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+
+	srv.handleHealthz(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}

--- a/internal/skillpuller/server_test.go
+++ b/internal/skillpuller/server_test.go
@@ -7,8 +7,18 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+
+	"github.com/redhat-et/docsclaw/internal/skillpuller/source"
 )
+
+func newTestServer(skillsDir string) *Server {
+	srv := NewServer(skillsDir, 0)
+	srv.sources["url"] = &source.URLSource{AllowPrivate: true}
+	srv.sources["github"] = &source.GitHubSource{AllowPrivate: true}
+	return srv
+}
 
 func TestHandlePull_URL(t *testing.T) {
 	skillContent := "---\nname: fetched-skill\n---\nA test skill."
@@ -19,7 +29,7 @@ func TestHandlePull_URL(t *testing.T) {
 	defer upstream.Close()
 
 	skillsDir := t.TempDir()
-	srv := NewServer(skillsDir, 0)
+	srv := newTestServer(skillsDir)
 
 	body, _ := json.Marshal(pullRequest{
 		Source: "url",
@@ -133,6 +143,10 @@ func TestHandleList_WithSkills(t *testing.T) {
 
 	if len(resp.Skills) != 2 {
 		t.Fatalf("skills count = %d, want 2; got %v", len(resp.Skills), resp.Skills)
+	}
+	slices.Sort(resp.Skills)
+	if resp.Skills[0] != "skill-a" || resp.Skills[1] != "skill-b" {
+		t.Errorf("skills = %v, want [skill-a skill-b]", resp.Skills)
 	}
 }
 

--- a/internal/skillpuller/source/github.go
+++ b/internal/skillpuller/source/github.go
@@ -4,20 +4,28 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 )
 
 type GitHubSource struct {
-	Client *http.Client
+	Client       *http.Client
+	BaseURL      string // override for testing; defaults to raw.githubusercontent.com
+	AllowPrivate bool   // skip SSRF checks (for testing only)
 }
 
 func (s *GitHubSource) Pull(ctx context.Context, ref string, opts PullOptions) (*Skill, error) {
-	rawURL, skillName, err := githubRawURL(ref, opts.Version)
+	baseURL := s.BaseURL
+	if baseURL == "" {
+		baseURL = "https://raw.githubusercontent.com"
+	}
+
+	rawURL, skillName, err := githubRawURL(ref, opts.Version, baseURL)
 	if err != nil {
 		return nil, err
 	}
 
-	urlSource := &URLSource{Client: s.Client}
+	urlSource := &URLSource{Client: s.Client, AllowPrivate: s.AllowPrivate}
 	skill, err := urlSource.Pull(ctx, rawURL, PullOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("github pull %q: %w", ref, err)
@@ -32,7 +40,9 @@ func (s *GitHubSource) Pull(ctx context.Context, ref string, opts PullOptions) (
 // skill name (last segment of the path).
 //
 // If the path does not end with SKILL.md, it is appended automatically.
-func githubRawURL(ref, version string) (string, string, error) {
+var safeSegment = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+func githubRawURL(ref, version, baseURL string) (string, string, error) {
 	parts := strings.SplitN(ref, "/", 3)
 	if len(parts) < 3 {
 		return "", "", fmt.Errorf("github ref must be owner/repo/path, got %q", ref)
@@ -40,8 +50,18 @@ func githubRawURL(ref, version string) (string, string, error) {
 
 	owner, repo, filePath := parts[0], parts[1], parts[2]
 
+	if !safeSegment.MatchString(owner) {
+		return "", "", fmt.Errorf("invalid owner %q", owner)
+	}
+	if !safeSegment.MatchString(repo) {
+		return "", "", fmt.Errorf("invalid repo %q", repo)
+	}
+
 	if version == "" {
 		version = "main"
+	}
+	if !safeSegment.MatchString(version) {
+		return "", "", fmt.Errorf("invalid version %q", version)
 	}
 
 	if !strings.HasSuffix(filePath, "SKILL.md") {
@@ -51,8 +71,8 @@ func githubRawURL(ref, version string) (string, string, error) {
 	// Extract skill name from the directory containing SKILL.md
 	skillName := skillNameFromPath(filePath)
 
-	rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
-		owner, repo, version, filePath)
+	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s",
+		baseURL, owner, repo, version, filePath)
 
 	return rawURL, skillName, nil
 }

--- a/internal/skillpuller/source/github.go
+++ b/internal/skillpuller/source/github.go
@@ -1,0 +1,73 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type GitHubSource struct {
+	Client *http.Client
+}
+
+func (s *GitHubSource) Pull(ctx context.Context, ref string, opts PullOptions) (*Skill, error) {
+	rawURL, skillName, err := githubRawURL(ref, opts.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	urlSource := &URLSource{Client: s.Client}
+	skill, err := urlSource.Pull(ctx, rawURL, PullOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("github pull %q: %w", ref, err)
+	}
+
+	skill.Name = skillName
+	return skill, nil
+}
+
+// githubRawURL converts a GitHub ref like "owner/repo/path/to/skill"
+// into a raw.githubusercontent.com URL. Returns the URL and the
+// skill name (last segment of the path).
+//
+// If the path does not end with SKILL.md, it is appended automatically.
+func githubRawURL(ref, version string) (string, string, error) {
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("github ref must be owner/repo/path, got %q", ref)
+	}
+
+	owner, repo, filePath := parts[0], parts[1], parts[2]
+
+	if version == "" {
+		version = "main"
+	}
+
+	if !strings.HasSuffix(filePath, "SKILL.md") {
+		filePath = filePath + "/SKILL.md"
+	}
+
+	// Extract skill name from the directory containing SKILL.md
+	skillName := skillNameFromPath(filePath)
+
+	rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+		owner, repo, version, filePath)
+
+	return rawURL, skillName, nil
+}
+
+// skillNameFromPath extracts the skill name from a file path.
+// For "path/to/my-skill/SKILL.md" returns "my-skill".
+func skillNameFromPath(p string) string {
+	parts := strings.Split(p, "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if strings.EqualFold(parts[i], "SKILL.md") && i > 0 {
+			return parts[i-1]
+		}
+	}
+	if len(parts) > 0 {
+		return strings.TrimSuffix(parts[len(parts)-1], ".md")
+	}
+	return "unknown"
+}

--- a/internal/skillpuller/source/github_test.go
+++ b/internal/skillpuller/source/github_test.go
@@ -1,0 +1,97 @@
+package source
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGithubRawURL(t *testing.T) {
+	tests := []struct {
+		ref     string
+		version string
+		wantURL string
+		wantErr bool
+	}{
+		{
+			ref:     "org/repo/path/to/my-skill",
+			version: "",
+			wantURL: "https://raw.githubusercontent.com/org/repo/main/path/to/my-skill/SKILL.md",
+		},
+		{
+			ref:     "org/repo/path/to/my-skill/SKILL.md",
+			version: "v1.2.0",
+			wantURL: "https://raw.githubusercontent.com/org/repo/v1.2.0/path/to/my-skill/SKILL.md",
+		},
+		{
+			ref:     "org/repo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		gotURL, _, err := githubRawURL(tt.ref, tt.version)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("githubRawURL(%q, %q) expected error", tt.ref, tt.version)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("githubRawURL(%q, %q) unexpected error: %v", tt.ref, tt.version, err)
+			continue
+		}
+		if gotURL != tt.wantURL {
+			t.Errorf("githubRawURL(%q, %q) = %q, want %q", tt.ref, tt.version, gotURL, tt.wantURL)
+		}
+	}
+}
+
+func TestGitHubSource_Pull(t *testing.T) {
+	content := "---\nname: test-skill\n---\nGitHub skill."
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/org/repo/main/skills/my-skill/SKILL.md"
+		if r.URL.Path != want {
+			t.Errorf("request path = %q, want %q", r.URL.Path, want)
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(content))
+	}))
+	defer srv.Close()
+
+	urlSrc := &URLSource{Client: srv.Client()}
+	skill, err := urlSrc.Pull(
+		context.Background(),
+		srv.URL+"/org/repo/main/skills/my-skill/SKILL.md",
+		PullOptions{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(skill.Content) != content {
+		t.Errorf("content = %q, want %q", string(skill.Content), content)
+	}
+
+}
+
+func TestSkillNameFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"path/to/my-skill/SKILL.md", "my-skill"},
+		{"SKILL.md", "SKILL"},
+		{"skills/summarizer/SKILL.md", "summarizer"},
+	}
+
+	for _, tt := range tests {
+		got := skillNameFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("skillNameFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/internal/skillpuller/source/github_test.go
+++ b/internal/skillpuller/source/github_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestGithubRawURL(t *testing.T) {
+	base := "https://raw.githubusercontent.com"
 	tests := []struct {
 		ref     string
 		version string
@@ -31,7 +32,7 @@ func TestGithubRawURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotURL, _, err := githubRawURL(tt.ref, tt.version)
+		gotURL, _, err := githubRawURL(tt.ref, tt.version, base)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("githubRawURL(%q, %q) expected error", tt.ref, tt.version)
@@ -62,20 +63,51 @@ func TestGitHubSource_Pull(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	urlSrc := &URLSource{Client: srv.Client()}
-	skill, err := urlSrc.Pull(
+	src := &GitHubSource{Client: srv.Client(), BaseURL: srv.URL, AllowPrivate: true}
+	skill, err := src.Pull(
 		context.Background(),
-		srv.URL+"/org/repo/main/skills/my-skill/SKILL.md",
+		"org/repo/skills/my-skill",
 		PullOptions{},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if skill.Name != "my-skill" {
+		t.Errorf("name = %q, want %q", skill.Name, "my-skill")
+	}
 	if string(skill.Content) != content {
 		t.Errorf("content = %q, want %q", string(skill.Content), content)
 	}
+}
 
+func TestGitHubSource_Pull_WithVersion(t *testing.T) {
+	content := "---\nname: versioned\n---\nVersioned skill."
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/org/repo/v1.2.0/skills/versioned/SKILL.md"
+		if r.URL.Path != want {
+			t.Errorf("request path = %q, want %q", r.URL.Path, want)
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(content))
+	}))
+	defer srv.Close()
+
+	src := &GitHubSource{Client: srv.Client(), BaseURL: srv.URL, AllowPrivate: true}
+	skill, err := src.Pull(
+		context.Background(),
+		"org/repo/skills/versioned",
+		PullOptions{Version: "v1.2.0"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if skill.Name != "versioned" {
+		t.Errorf("name = %q, want %q", skill.Name, "versioned")
+	}
 }
 
 func TestSkillNameFromPath(t *testing.T) {

--- a/internal/skillpuller/source/source.go
+++ b/internal/skillpuller/source/source.go
@@ -1,0 +1,16 @@
+package source
+
+import "context"
+
+type Skill struct {
+	Name    string
+	Content []byte
+}
+
+type PullOptions struct {
+	Version string
+}
+
+type Source interface {
+	Pull(ctx context.Context, ref string, opts PullOptions) (*Skill, error)
+}

--- a/internal/skillpuller/source/url.go
+++ b/internal/skillpuller/source/url.go
@@ -4,19 +4,39 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 )
 
+const maxSkillSize = 1 << 20 // 1 MiB
+
 type URLSource struct {
-	Client *http.Client
+	Client       *http.Client
+	AllowPrivate bool // skip SSRF checks (for testing only)
 }
 
 func (s *URLSource) Pull(ctx context.Context, ref string, _ PullOptions) (*Skill, error) {
 	client := s.Client
 	if client == nil {
 		client = http.DefaultClient
+	}
+
+	parsed, err := url.Parse(ref)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", ref, err)
+	}
+
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil, fmt.Errorf("unsupported scheme %q: only http and https are allowed", parsed.Scheme)
+	}
+
+	if !s.AllowPrivate {
+		if err := rejectPrivateHost(parsed.Hostname()); err != nil {
+			return nil, fmt.Errorf("blocked URL %q: %w", ref, err)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ref, nil)
@@ -34,14 +54,49 @@ func (s *URLSource) Pull(ctx context.Context, ref string, _ PullOptions) (*Skill
 		return nil, fmt.Errorf("fetch %q: status %d", ref, resp.StatusCode)
 	}
 
-	content, err := io.ReadAll(resp.Body)
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxSkillSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("read %q: %w", ref, err)
+	}
+	if len(content) > maxSkillSize {
+		return nil, fmt.Errorf("skill from %q exceeds size limit (%d bytes)", ref, maxSkillSize)
 	}
 
 	name := skillNameFromURL(ref)
 
 	return &Skill{Name: name, Content: content}, nil
+}
+
+// rejectPrivateHost blocks requests to loopback, link-local, and
+// private IP ranges to prevent SSRF.
+func rejectPrivateHost(host string) error {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		ips, err := net.LookupIP(host)
+		if err != nil || len(ips) == 0 {
+			return nil // let the HTTP client handle DNS failures
+		}
+		ip = ips[0]
+	}
+
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return fmt.Errorf("address %s is not allowed", ip)
+	}
+
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16",
+	}
+	for _, cidr := range privateRanges {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network.Contains(ip) {
+			return fmt.Errorf("address %s is in a private range", ip)
+		}
+	}
+
+	return nil
 }
 
 // skillNameFromURL extracts a skill name from a URL path.

--- a/internal/skillpuller/source/url.go
+++ b/internal/skillpuller/source/url.go
@@ -69,30 +69,42 @@ func (s *URLSource) Pull(ctx context.Context, ref string, _ PullOptions) (*Skill
 
 // rejectPrivateHost blocks requests to loopback, link-local, and
 // private IP ranges to prevent SSRF.
-func rejectPrivateHost(host string) error {
-	ip := net.ParseIP(host)
-	if ip == nil {
-		ips, err := net.LookupIP(host)
-		if err != nil || len(ips) == 0 {
-			return nil // let the HTTP client handle DNS failures
-		}
-		ip = ips[0]
-	}
+var privateNetworks []*net.IPNet
 
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-		return fmt.Errorf("address %s is not allowed", ip)
-	}
-
-	privateRanges := []string{
+func init() {
+	for _, cidr := range []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
 		"169.254.0.0/16",
-	}
-	for _, cidr := range privateRanges {
+		"127.0.0.0/8",
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	} {
 		_, network, _ := net.ParseCIDR(cidr)
-		if network.Contains(ip) {
-			return fmt.Errorf("address %s is in a private range", ip)
+		privateNetworks = append(privateNetworks, network)
+	}
+}
+
+func rejectPrivateHost(host string) error {
+	ips := []net.IP{net.ParseIP(host)}
+	if ips[0] == nil {
+		resolved, err := net.LookupIP(host)
+		if err != nil || len(resolved) == 0 {
+			return fmt.Errorf("cannot resolve host %q", host)
+		}
+		ips = resolved
+	}
+
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("address %s is not allowed", ip)
+		}
+		for _, network := range privateNetworks {
+			if network.Contains(ip) {
+				return fmt.Errorf("address %s is in a private range", ip)
+			}
 		}
 	}
 

--- a/internal/skillpuller/source/url.go
+++ b/internal/skillpuller/source/url.go
@@ -39,7 +39,10 @@ func (s *URLSource) Pull(ctx context.Context, ref string, _ PullOptions) (*Skill
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ref, nil)
+	// Build request from the parsed/validated URL, not the raw input,
+	// so static analysis can verify the URL was sanitized.
+	sanitizedURL := parsed.String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sanitizedURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL %q: %w", ref, err)
 	}

--- a/internal/skillpuller/source/url.go
+++ b/internal/skillpuller/source/url.go
@@ -1,0 +1,65 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+)
+
+type URLSource struct {
+	Client *http.Client
+}
+
+func (s *URLSource) Pull(ctx context.Context, ref string, _ PullOptions) (*Skill, error) {
+	client := s.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", ref, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %q: %w", ref, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %q: status %d", ref, resp.StatusCode)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", ref, err)
+	}
+
+	name := skillNameFromURL(ref)
+
+	return &Skill{Name: name, Content: content}, nil
+}
+
+// skillNameFromURL extracts a skill name from a URL path.
+// For ".../skill-name/SKILL.md" returns "skill-name".
+// For ".../SKILL.md" returns "SKILL".
+// For other paths returns the last path segment.
+func skillNameFromURL(rawURL string) string {
+	p := path.Base(rawURL)
+
+	if strings.EqualFold(p, "SKILL.md") {
+		dir := path.Dir(rawURL)
+		parent := path.Base(dir)
+		if parent != "" && parent != "." && parent != "/" &&
+			!strings.Contains(parent, ".") {
+			return parent
+		}
+		return strings.TrimSuffix(p, path.Ext(p))
+	}
+
+	return strings.TrimSuffix(p, path.Ext(p))
+}

--- a/internal/skillpuller/source/url_test.go
+++ b/internal/skillpuller/source/url_test.go
@@ -15,7 +15,7 @@ func TestURLSource_Pull(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src := &URLSource{Client: srv.Client()}
+	src := &URLSource{Client: srv.Client(), AllowPrivate: true}
 	skill, err := src.Pull(context.Background(), srv.URL+"/skills/my-skill/SKILL.md", PullOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -33,7 +33,7 @@ func TestURLSource_Pull_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.NotFoundHandler())
 	defer srv.Close()
 
-	src := &URLSource{Client: srv.Client()}
+	src := &URLSource{Client: srv.Client(), AllowPrivate: true}
 	_, err := src.Pull(context.Background(), srv.URL+"/missing/SKILL.md", PullOptions{})
 	if err == nil {
 		t.Fatal("expected error for 404 response")

--- a/internal/skillpuller/source/url_test.go
+++ b/internal/skillpuller/source/url_test.go
@@ -1,0 +1,60 @@
+package source
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestURLSource_Pull(t *testing.T) {
+	content := "---\nname: test-skill\n---\nDo something useful."
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(content))
+	}))
+	defer srv.Close()
+
+	src := &URLSource{Client: srv.Client()}
+	skill, err := src.Pull(context.Background(), srv.URL+"/skills/my-skill/SKILL.md", PullOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if skill.Name != "my-skill" {
+		t.Errorf("name = %q, want %q", skill.Name, "my-skill")
+	}
+	if string(skill.Content) != content {
+		t.Errorf("content = %q, want %q", string(skill.Content), content)
+	}
+}
+
+func TestURLSource_Pull_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	src := &URLSource{Client: srv.Client()}
+	_, err := src.Pull(context.Background(), srv.URL+"/missing/SKILL.md", PullOptions{})
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestSkillNameFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://example.com/skills/my-skill/SKILL.md", "my-skill"},
+		{"https://example.com/SKILL.md", "SKILL"},
+		{"https://example.com/path/to/summarizer/SKILL.md", "summarizer"},
+		{"https://example.com/some-file.yaml", "some-file"},
+	}
+
+	for _, tt := range tests {
+		got := skillNameFromURL(tt.url)
+		if got != tt.want {
+			t.Errorf("skillNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}

--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -26,6 +26,7 @@ func Discover(skillsDir string) ([]SkillMeta, error) {
 
 	err := filepath.WalkDir(skillsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			slog.Warn("error accessing path during skill discovery", "path", path, "error", err)
 			return nil
 		}
 		// Skip hidden directories (e.g. ..data, ..2024_01_01 created
@@ -87,7 +88,13 @@ func LoadContent(skillsDir, name string) (string, error) {
 	// Search recursively
 	var found string
 	_ = filepath.WalkDir(skillsDir, func(p string, d os.DirEntry, err error) error {
-		if err != nil || found != "" {
+		if err != nil {
+			return filepath.SkipDir
+		}
+		if found != "" {
+			return filepath.SkipAll
+		}
+		if d.IsDir() && strings.HasPrefix(d.Name(), "..") {
 			return filepath.SkipDir
 		}
 		if !d.IsDir() && d.Name() == "SKILL.md" && filepath.Base(filepath.Dir(p)) == name {

--- a/pkg/skills/loader.go
+++ b/pkg/skills/loader.go
@@ -15,63 +15,95 @@ type SkillMeta struct {
 	Dir         string
 }
 
-// Discover scans the skills directory for subdirectories containing
-// SKILL.md files and returns their metadata.
+// Discover recursively scans the skills directory for subdirectories
+// containing SKILL.md files and returns their metadata.
 func Discover(skillsDir string) ([]SkillMeta, error) {
-	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read skills directory: %w", err)
+	if _, err := os.Stat(skillsDir); os.IsNotExist(err) {
+		return nil, nil
 	}
 
 	var skills []SkillMeta
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		skillFile := filepath.Join(skillsDir, entry.Name(), "SKILL.md")
-		if _, err := os.Stat(skillFile); os.IsNotExist(err) {
-			continue
-		}
 
-		meta, err := ParseFrontmatter(skillFile)
+	err := filepath.WalkDir(skillsDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			slog.Warn("skipping skill with invalid SKILL.md", "dir", entry.Name(), "error", err)
-			continue
+			return nil
 		}
-		meta.Dir = filepath.Join(skillsDir, entry.Name())
+		// Skip hidden directories (e.g. ..data, ..2024_01_01 created
+		// by Kubernetes ConfigMap volume mounts)
+		if d.IsDir() && strings.HasPrefix(d.Name(), "..") {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
 
-		// If skill.yaml exists, prefer its description.
-		cardPath := filepath.Join(skillsDir, entry.Name(), "skill.yaml")
+		dir := filepath.Dir(path)
+
+		meta, err := ParseFrontmatter(path)
+		if err != nil {
+			slog.Warn("skipping skill with invalid SKILL.md", "path", path, "error", err)
+			return nil
+		}
+		meta.Dir = dir
+
+		cardPath := filepath.Join(dir, "skill.yaml")
 		if _, statErr := os.Stat(cardPath); statErr == nil {
 			if sy, parseErr := ParseSkillYAML(cardPath); parseErr == nil {
 				if sy.Metadata.Description != "" {
 					meta.Description = sy.Metadata.Description
 				}
 			} else {
-				slog.Warn("skill.yaml exists but failed to parse", "dir", entry.Name(), "error", parseErr)
+				slog.Warn("skill.yaml exists but failed to parse", "dir", dir, "error", parseErr)
 			}
 		}
 
 		skills = append(skills, meta)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk skills directory: %w", err)
 	}
 
 	return skills, nil
 }
 
 // LoadContent reads the full content of a skill's SKILL.md file.
+// It searches recursively under skillsDir for a directory matching
+// the skill name that contains a SKILL.md file.
 func LoadContent(skillsDir, name string) (string, error) {
-	// Validate skill name to prevent path traversal
 	if name == "" || name != filepath.Base(name) || name == "." || name == ".." {
 		return "", fmt.Errorf("invalid skill name: %q", name)
 	}
 
+	// Try direct path first (backward compatible)
 	path := filepath.Join(skillsDir, name, "SKILL.md")
-	data, err := os.ReadFile(path)
+	if data, err := os.ReadFile(path); err == nil {
+		return fmt.Sprintf("=== SKILL: %s ===\n%s", name, string(data)), nil
+	}
+
+	// Search recursively
+	var found string
+	_ = filepath.WalkDir(skillsDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || found != "" {
+			return filepath.SkipDir
+		}
+		if !d.IsDir() && d.Name() == "SKILL.md" && filepath.Base(filepath.Dir(p)) == name {
+			found = p
+			return filepath.SkipAll
+		}
+		return nil
+	})
+
+	if found == "" {
+		return "", fmt.Errorf("skill '%s' not found", name)
+	}
+
+	data, err := os.ReadFile(found)
 	if err != nil {
-		return "", fmt.Errorf("skill '%s' not found: %w", name, err)
+		return "", fmt.Errorf("skill '%s': %w", name, err)
 	}
 	return fmt.Sprintf("=== SKILL: %s ===\n%s", name, string(data)), nil
 }

--- a/pkg/skills/loader_test.go
+++ b/pkg/skills/loader_test.go
@@ -125,6 +125,98 @@ metadata:
 	}
 }
 
+func TestDiscoverNestedSkills(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, path := range []string{
+		"static/code-review",
+		"static/url-summary",
+		"dynamic/fetched-skill",
+	} {
+		skillDir := filepath.Join(dir, path)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		name := filepath.Base(path)
+		content := "---\nname: " + name + "\ndescription: test\n---\n"
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	skills, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skills) != 3 {
+		t.Fatalf("expected 3 skills, got %d", len(skills))
+	}
+
+	names := make(map[string]bool)
+	for _, s := range skills {
+		names[s.Name] = true
+	}
+	for _, want := range []string{"code-review", "url-summary", "fetched-skill"} {
+		if !names[want] {
+			t.Errorf("missing skill %q", want)
+		}
+	}
+}
+
+func TestDiscoverSkipsK8sDataSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate K8s ConfigMap mount: real file in ..data, symlink in skill dir
+	skillDir := filepath.Join(dir, "my-skill")
+	dataDir := filepath.Join(skillDir, "..data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "---\nname: my-skill\ndescription: test\n---\n"
+	if err := os.WriteFile(filepath.Join(dataDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink SKILL.md -> ..data/SKILL.md (like K8s does)
+	if err := os.Symlink("..data/SKILL.md", filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	skills, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should find exactly 1, not 2 (the ..data copy should be skipped)
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	if skills[0].Name != "my-skill" {
+		t.Errorf("name = %q, want %q", skills[0].Name, "my-skill")
+	}
+}
+
+func TestLoadContentRecursive(t *testing.T) {
+	dir := t.TempDir()
+
+	// Skill nested under static/
+	skillDir := filepath.Join(dir, "static", "deep-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: deep-skill\ndescription: nested\n---\n# Deep\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadContent(dir, "deep-skill")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "deep-skill") {
+		t.Errorf("result = %q, want to contain 'deep-skill'", result)
+	}
+}
+
 func TestBuildSkillSummary(t *testing.T) {
 	skills := []SkillMeta{
 		{Name: "code-review", Description: "Review code for bugs"},


### PR DESCRIPTION
## Summary

- Adds a lightweight sidecar container (`skill-puller`) that pulls skills
  dynamically into a running agent pod via a local HTTP API
- The agent mounts the shared `emptyDir` volume read-only — enforcement
  is at the kernel VFS level, not voluntary
- Supports URL and GitHub skill sources (OCI deferred to follow-up)
- Includes per-skill ConfigMap generation in the Makefile (replaces the
  bundled skills ConfigMap)
- Makes skill discovery recursive so nested layouts (`static/`, `dynamic/`)
  work, with a fix for Kubernetes ConfigMap symlink deduplication

## What's included

| Component | Path |
| --------- | ---- |
| Sidecar binary | `cmd/skill-puller/`, `internal/skillpuller/` |
| Source backends | `internal/skillpuller/source/` (URL, GitHub) |
| Dockerfile | `Dockerfile.skill-puller` |
| Example deployment | `examples/skill-puller-sidecar/` |
| Agent-side skill | `examples/skill-puller-sidecar/skills/skill-pull/SKILL.md` |
| Design doc | `docs/dev/skill-puller-sidecar-design.md` |
| Recursive skill discovery | `pkg/skills/loader.go` |

## Test plan

- [x] `make build-skill-puller` compiles
- [x] `go test ./internal/skillpuller/...` — 12 tests pass
- [x] `go test ./pkg/skills/...` — 19 tests pass
- [x] `golangci-lint run` — 0 issues on new code
- [x] Local smoke test: pulled Red Hat skill from GitHub via curl
- [x] OpenShift deployment: static skills mount correctly, dynamic
  pull works, read-only enforcement confirmed
- [ ] Review with Kimi (GLM)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill-puller sidecar for dynamic skill discovery and on-demand installation
  * HTTP API to pull/list skills from external sources (URL and GitHub) plus health endpoint
  * Pulled skills stored in a shared volume readable by the agent

* **Improvements / Bug Fixes**
  * Skill discovery now finds nested skills and avoids duplicate k8s mount copies
  * Content loading falls back to recursive lookup when needed

* **Documentation**
  * Design doc, example deployment, and usage README for the sidecar

* **Chores**
  * Container image and Makefile build target added for the skill-puller

* **Tests**
  * New tests covering pulling, listing, parsing, and security edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->