### PR TITLE
feat: add security-focused container image flavor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OUTDIR ?= deploy/generated/$(NAME)
 NAMESPACE ?=
 KUBECTL ?= oc
 
-.PHONY: build build-skill-puller test lint fmt clean image image-push agent-build agent-image agent-push configmap-gen configmap-apply
+.PHONY: build build-skill-puller test lint fmt clean image image-push image-security image-security-push agent-build agent-image agent-push configmap-gen configmap-apply
 
 build:
 	go build -o $(BINDIR)/$(BINARY) ./cmd/docsclaw
@@ -46,6 +46,15 @@ image:
 
 image-push: image
 	$(CONTAINER_ENGINE) push $(REGISTRY):$(DEV_TAG)
+
+image-security:
+	$(CONTAINER_ENGINE) build \
+		--platform linux/amd64 \
+		-t $(REGISTRY):$(DEV_TAG)-security \
+		-f containers/Containerfile.security .
+
+image-security-push: image-security
+	$(CONTAINER_ENGINE) push $(REGISTRY):$(DEV_TAG)-security
 
 # --- Agent image from manifest ---
 # Build a custom agent image from an agent manifest.

--- a/containers/Containerfile.security
+++ b/containers/Containerfile.security
@@ -13,6 +13,10 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Build the DocsClaw binary
 # ---------------------------------------------------------------------------
+# Base images use :latest intentionally — Red Hat Hardened Images receive
+# continuous security patches, and pinning to a digest would freeze those
+# updates. Trade-off: builds are not fully reproducible, but the runtime
+# always includes the latest CVE fixes from Red Hat.
 FROM registry.access.redhat.com/hi/go:latest AS builder
 
 WORKDIR /app

--- a/containers/Containerfile.security
+++ b/containers/Containerfile.security
@@ -1,0 +1,115 @@
+# =============================================================================
+# Containerfile.security — Security-focused DocsClaw image
+# =============================================================================
+# Bundles code scanning, vulnerability detection, and supply chain security
+# tools into the DocsClaw agent runtime using Red Hat Hardened Images.
+#
+# Build:
+#   podman build -f containers/Containerfile.security -t docsclaw:security .
+#
+# See also: https://github.com/redhat-et/docsclaw/issues/85
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the DocsClaw binary
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/hi/go:latest AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /docsclaw ./cmd/docsclaw
+
+# ---------------------------------------------------------------------------
+# Stage 2: Download security tool binaries
+# ---------------------------------------------------------------------------
+# Using standard UBI for downloads — this stage is discarded after build,
+# so hardening is not needed here. The hi/go image lacks curl/tar.
+FROM registry.access.redhat.com/ubi9/ubi:latest AS tools
+
+ARG TRIVY_VERSION=0.71.0
+ARG GOSEC_VERSION=2.27.1
+ARG GITLEAKS_VERSION=8.30.1
+ARG TRUFFLEHOG_VERSION=3.95.5
+ARG GRYPE_VERSION=0.113.0
+ARG SYFT_VERSION=1.45.0
+ARG COSIGN_VERSION=3.0.6
+
+WORKDIR /tools
+
+RUN curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+        | tar xz -C /tools trivy \
+    && curl -sSfL "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" \
+        | tar xz -C /tools gosec \
+    && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+        | tar xz -C /tools gitleaks \
+    && curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz" \
+        | tar xz -C /tools trufflehog \
+    && curl -sSfL "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+        | tar xz -C /tools grype \
+    && curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+        | tar xz -C /tools syft \
+    && curl -sSfL -o /tools/cosign "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64" \
+    && chmod +x /tools/cosign
+
+# ---------------------------------------------------------------------------
+# Stage 3: Assemble the security-focused runtime image
+# ---------------------------------------------------------------------------
+FROM registry.access.redhat.com/hi/core-runtime:latest
+
+USER root
+
+# tpm2-tss (a transitive dependency of containers-common/skopeo) ships a
+# %sysusers scriptlet that calls systemd-sysusers, which doesn't exist in
+# the hardened runtime. Provide a no-op stub so the scriptlet succeeds.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/bin/systemd-sysusers \
+    && chmod +x /usr/bin/systemd-sysusers
+
+RUN --mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-builder,target=/builder \
+    LD_LIBRARY_PATH=/builder/lib64:/builder/usr/lib64 \
+    RPM_CONFIGDIR=/builder/usr/lib/rpm \
+    /builder/usr/bin/dnf install -y \
+    --installroot=/ \
+    --setopt=reposdir=/builder/etc/yum.repos.d \
+    --setopt=install_weak_deps=False \
+    --setopt=tsflags=nodocs \
+    curl \
+    jq \
+    git-core \
+    make \
+    python3 \
+    python3-pip \
+    ShellCheck \
+    skopeo \
+    && rm -f /usr/bin/systemd-sysusers
+
+RUN python3 -m pip install --no-cache-dir semgrep bandit
+
+COPY --from=tools /tools/trivy      /usr/local/bin/trivy
+COPY --from=tools /tools/gosec      /usr/local/bin/gosec
+COPY --from=tools /tools/gitleaks   /usr/local/bin/gitleaks
+COPY --from=tools /tools/trufflehog /usr/local/bin/trufflehog
+COPY --from=tools /tools/grype      /usr/local/bin/grype
+COPY --from=tools /tools/syft       /usr/local/bin/syft
+COPY --from=tools /tools/cosign     /usr/local/bin/cosign
+
+RUN mkdir -p /tmp/agent-workspace \
+    && chown 65532:0 /tmp/agent-workspace \
+    && chmod 775 /tmp/agent-workspace
+
+# Trivy and grype need writable cache directories
+ENV TRIVY_CACHE_DIR=/tmp/agent-workspace/.cache/trivy
+ENV GRYPE_DB_CACHE_DIR=/tmp/agent-workspace/.cache/grype
+
+USER 65532
+
+WORKDIR /app
+COPY --from=builder /docsclaw /app/docsclaw
+
+EXPOSE 8000
+
+ENTRYPOINT ["/app/docsclaw"]
+CMD ["serve"]

--- a/containers/Containerfile.security
+++ b/containers/Containerfile.security
@@ -31,28 +31,42 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /docsclaw ./cmd/docsclaw
 FROM registry.access.redhat.com/ubi9/ubi:latest AS tools
 
 ARG TRIVY_VERSION=0.71.0
+ARG TRIVY_SHA256=30a3d22b23f88c233f1658f562fb477cae3b3e8b4761109d515b7698daf85814
 ARG GOSEC_VERSION=2.27.1
+ARG GOSEC_SHA256=a1cc5fba45fb51131ba05dee4029b364f62f4b6739b8f24236f93de82f40da40
 ARG GITLEAKS_VERSION=8.30.1
+ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 ARG TRUFFLEHOG_VERSION=3.95.5
+ARG TRUFFLEHOG_SHA256=8d151a19465973bec226be5992a2a11b053f4ab92c77861f642089892ae9aa58
 ARG GRYPE_VERSION=0.113.0
+ARG GRYPE_SHA256=d87059d11616446a5dd817a47c21823676b4b24bdaac529695ca404a32ba339d
 ARG SYFT_VERSION=1.45.0
+ARG SYFT_SHA256=cd5efa489e93ecde99c03a218db5dee8b3f03610466d7565cefd735610d1b28b
 ARG COSIGN_VERSION=3.0.6
+ARG COSIGN_SHA256=c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
 
 WORKDIR /tools
 
-RUN curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
-        | tar xz -C /tools trivy \
-    && curl -sSfL "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" \
-        | tar xz -C /tools gosec \
-    && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-        | tar xz -C /tools gitleaks \
-    && curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz" \
-        | tar xz -C /tools trufflehog \
-    && curl -sSfL "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
-        | tar xz -C /tools grype \
-    && curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
-        | tar xz -C /tools syft \
+RUN curl -sSfL -o trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+    && echo "${TRIVY_SHA256}  trivy.tar.gz" | sha256sum -c - \
+    && tar xzf trivy.tar.gz -C /tools trivy && rm trivy.tar.gz \
+    && curl -sSfL -o gosec.tar.gz "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GOSEC_SHA256}  gosec.tar.gz" | sha256sum -c - \
+    && tar xzf gosec.tar.gz -C /tools gosec && rm gosec.tar.gz \
+    && curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+    && echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c - \
+    && tar xzf gitleaks.tar.gz -C /tools gitleaks && rm gitleaks.tar.gz \
+    && curl -sSfL -o trufflehog.tar.gz "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz" \
+    && echo "${TRUFFLEHOG_SHA256}  trufflehog.tar.gz" | sha256sum -c - \
+    && tar xzf trufflehog.tar.gz -C /tools trufflehog && rm trufflehog.tar.gz \
+    && curl -sSfL -o grype.tar.gz "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GRYPE_SHA256}  grype.tar.gz" | sha256sum -c - \
+    && tar xzf grype.tar.gz -C /tools grype && rm grype.tar.gz \
+    && curl -sSfL -o syft.tar.gz "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+    && echo "${SYFT_SHA256}  syft.tar.gz" | sha256sum -c - \
+    && tar xzf syft.tar.gz -C /tools syft && rm syft.tar.gz \
     && curl -sSfL -o /tools/cosign "https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64" \
+    && echo "${COSIGN_SHA256}  /tools/cosign" | sha256sum -c - \
     && chmod +x /tools/cosign
 
 # ---------------------------------------------------------------------------
@@ -86,7 +100,11 @@ RUN --mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-bui
     skopeo \
     && rm -f /usr/bin/systemd-sysusers
 
-RUN python3 -m pip install --no-cache-dir semgrep bandit
+ARG SEMGREP_VERSION=1.164.0
+ARG BANDIT_VERSION=1.9.4
+RUN python3 -m pip install --no-cache-dir \
+    semgrep==${SEMGREP_VERSION} \
+    bandit==${BANDIT_VERSION}
 
 COPY --from=tools /tools/trivy      /usr/local/bin/trivy
 COPY --from=tools /tools/gosec      /usr/local/bin/gosec


### PR DESCRIPTION
## Summary

- Add `containers/Containerfile.security` — a three-stage build using Red Hat Hardened Images that bundles 13 security tools (code scanning, secrets detection, vulnerability/SBOM analysis, supply chain verification)
- Add `make image-security` and `make image-security-push` Makefile targets
- Establish `containers/` directory for future image flavors (#7)

## Tools included

| Category | Tools |
|----------|-------|
| Code scanning | semgrep, gosec, shellcheck, bandit |
| Secrets detection | gitleaks, trufflehog |
| Vulnerability/SBOM | trivy, grype, syft |
| Supply chain | skopeo, cosign |
| Base utilities | git, make, python3, curl, jq |

## Design decisions

- **Three-stage build**: Go builder → tool downloader (UBI9) → hardened runtime assembly. The hi/go image lacks curl/tar, so downloads use a standard UBI stage (discarded after build)
- **SHA256 checksum verification**: All 7 downloaded binaries are verified against pinned checksums. Build fails on mismatch.
- **Version pinning**: All tools version-pinned via Dockerfile ARGs, including pip packages (semgrep==1.164.0, bandit==1.9.4)
- **systemd-sysusers stub**: tpm2-tss (transitive dep of skopeo) ships a `%sysusers` scriptlet that fails in the hardened runtime; a no-op stub is created before dnf and removed after
- **Floating `:latest` base images**: Intentional — Red Hat Hardened Images receive continuous CVE fixes; pinning digests would freeze those updates. Trade-off documented in Containerfile.
- **Non-root execution** (uid 65532) with writable cache dirs for trivy/grype via env vars
- **Image size**: ~1.25 GB (semgrep + Python runtime dominate; acceptable for a specialized scanning image vs. 63 MB base)

## Test plan

- [x] Full build on RHEL 10 x86_64 via `podman -c rhel build`
- [x] All 13 tools verified working inside container (`--entrypoint sh`)
- [x] SHA256 checksums verified for all 7 downloaded binaries (all OK)
- [x] Runs as non-root (uid 65532)
- [ ] Test with security-scanner skill on OpenShift

## Follow-up

- #87 — pip hash verification (--require-hashes) and OCI labels

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A security-focused container image is now available, bundled with industry-standard security and supply-chain analysis tools for vulnerability scanning, secrets detection, and code analysis.

* **Chores**
  * Build infrastructure updated to support building and pushing the security container image variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->