### PR TITLE
fix: route all slog output through component logger

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -290,6 +291,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	log := logger.New(logger.ComponentAgent)
+	slog.SetDefault(log.Logger)
 
 	// Load OS tool inventory and inject into system prompt
 	const toolsJSONPath = "/etc/docsclaw/tools.json"


### PR DESCRIPTION
## Summary

- Set `slog.SetDefault` after creating the component logger so direct `slog.Info()` calls use the same format

Fixes inconsistent log output in K8s: startup logs used JSON (via component logger) but tool loop logs used Go's default text format (via direct `slog.Info()` calls).

**Before** (K8s):
```
{"time":"...","level":"INFO","msg":"LLM provider initialized","component":"DOCSCLAW",...}
2026/06/04 01:12:45 INFO LLM response received provider=openai ...
```

**After** (K8s):
```
{"time":"...","level":"INFO","msg":"LLM provider initialized","component":"DOCSCLAW",...}
{"time":"...","level":"INFO","msg":"LLM response received","component":"DOCSCLAW",...}
```

## Test plan

- [x] `go build` and `go test ./internal/cmd/` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration to ensure consistent logger usage throughout the process by aligning the default logger with the service's configured logging setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->