### PR TITLE
feat: add OpenClaw workspace context loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,25 @@ DocsClaw reads its personality from a config directory:
 
 ```text
 my-agent/
-├── system-prompt.txt       # Who the agent is
+├── system-prompt.txt       # Who the agent is (operator)
 ├── agent-card.json         # A2A metadata (name, skills, URL)
 ├── agent-config.yaml       # Which tools to allow, loop settings
 └── skills/                 # Optional SKILL.md instructions
     └── url-summary/
         └── SKILL.md
+
+/workspace/                 # Optional OpenClaw workspace files
+├── AGENTS.md               # Operating instructions
+├── SOUL.md                 # Persona and tone
+├── USER.md                 # User context
+├── IDENTITY.md             # Agent name and role
+└── TOOLS.md                # Tool guidance
 ```
 
-Same binary, different config = different agent.
+Same binary, different config = different agent. If OpenClaw
+workspace files are present in the workspace directory, they are
+loaded as project context alongside the system prompt — giving
+users a migration path from OpenClaw to a leaner runtime.
 
 Without `agent-config.yaml`, DocsClaw runs in **single-shot mode**
 (no tools, prompt-in/response-out). With it, the **agentic loop**
@@ -172,6 +182,21 @@ tools:
 loop:
   max_iterations: 10  # Max tool-use rounds before giving up
 ```
+
+### Workspace context (OpenClaw compatibility)
+
+DocsClaw loads OpenClaw-compatible workspace files from the
+workspace directory (`/workspace` by default) and appends them to
+the system prompt as a `## Project Context` section. The operator
+defines the agent's job via `system-prompt.txt`; the user provides
+project context via workspace files. All files are optional and
+work in both single-shot and agentic modes.
+
+Files are loaded in order: AGENTS.md, SOUL.md, USER.md,
+IDENTITY.md, TOOLS.md. Each file is capped at 20,000 characters;
+total context is capped at 60,000 characters. See the
+[agent config guide](docs/agent-config-guide.md#workspace-context)
+for details and deployment examples.
 
 ### Built-in tools
 

--- a/deploy/openclaw-workspace-agent.yaml
+++ b/deploy/openclaw-workspace-agent.yaml
@@ -97,7 +97,7 @@ spec:
       initContainers:
         - name: seed-workspace
           image: ghcr.io/redhat-et/docsclaw:latest
-          command: ["sh", "-c", "cp /openclaw-files/*.md /workspace/"]
+          command: ["sh", "-c", "for f in /openclaw-files/*.md; do [ -e \"$f\" ] && cp \"$f\" /workspace/; done; true"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/deploy/openclaw-workspace-agent.yaml
+++ b/deploy/openclaw-workspace-agent.yaml
@@ -1,0 +1,187 @@
+# Standalone docsclaw deployment with OpenClaw workspace files.
+#
+# This example shows how to mount OpenClaw-compatible workspace files
+# (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md) as a ConfigMap
+# so DocsClaw loads them as "Project Context" in the system prompt.
+#
+# The base system-prompt.txt defines what the agent does (operator).
+# The workspace files define how it interacts (user/project context).
+#
+# Prerequisites:
+#   oc new-project docsclaw
+#   oc apply -f secrets/anthropic.yaml  (or openai/maas)
+#
+# Deploy:
+#   oc apply -f openclaw-workspace-agent.yaml
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docsclaw-config
+data:
+  system-prompt.txt: |
+    You are a helpful research assistant with access to tools.
+
+    You can:
+    - Execute shell commands (exec)
+    - Fetch web pages (web_fetch)
+    - Read and write files in your workspace (read_file, write_file)
+
+    When given a task, break it into steps and use your tools to complete it.
+    Be concise in your responses. Show your work.
+  agent-card.json: |
+    {
+      "name": "docsclaw",
+      "description": "Research agent with OpenClaw workspace context",
+      "version": "2.0.0",
+      "protocolVersion": "0.3.0",
+      "url": "http://docsclaw:8000",
+      "capabilities": {},
+      "defaultInputModes": ["application/json"],
+      "defaultOutputModes": ["text/plain"]
+    }
+  agent-config.yaml: |
+    tools:
+      allowed:
+        - exec
+        - web_fetch
+        - read_file
+        - write_file
+      exec:
+        timeout: 30
+        max_output: 50000
+      workspace: /workspace
+    loop:
+      max_iterations: 10
+
+---
+# OpenClaw workspace files — mount these to /workspace alongside
+# any other workspace content. All files are optional; DocsClaw
+# loads whichever files are present.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docsclaw-workspace
+data:
+  SOUL.md: |
+    Be direct and concise. Avoid unnecessary pleasantries.
+    Prefer showing code over describing it.
+    When uncertain, say so rather than guessing.
+  USER.md: |
+    Pavel, OCTO team at Red Hat.
+    Prefers Go, familiar with Kubernetes and container technologies.
+  IDENTITY.md: |
+    Name: Research Assistant
+    Role: Technical research and document analysis
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docsclaw
+  labels:
+    app: docsclaw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docsclaw
+  template:
+    metadata:
+      labels:
+        app: docsclaw
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: docsclaw
+          image: ghcr.io/redhat-et/docsclaw:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - serve
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8100
+              name: health
+          env:
+            - name: DOCSCLAW_SERVICE_PORT
+              value: "8000"
+          envFrom:
+            - secretRef:
+                name: llm-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: agent-config
+              mountPath: /config/agent
+              readOnly: true
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: agent-config
+          configMap:
+            name: docsclaw-config
+        - name: workspace
+          configMap:
+            name: docsclaw-workspace
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docsclaw
+  labels:
+    app: docsclaw
+spec:
+  selector:
+    app: docsclaw
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: docsclaw
+  annotations:
+    haproxy.router.openshift.io/timeout: 120s
+  labels:
+    app: docsclaw
+spec:
+  to:
+    kind: Service
+    name: docsclaw
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/deploy/openclaw-workspace-agent.yaml
+++ b/deploy/openclaw-workspace-agent.yaml
@@ -94,6 +94,24 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+      initContainers:
+        - name: seed-workspace
+          image: ghcr.io/redhat-et/docsclaw:latest
+          command: ["sh", "-c", "cp /openclaw-files/*.md /workspace/"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: openclaw-files
+              mountPath: /openclaw-files
+              readOnly: true
+            - name: workspace
+              mountPath: /workspace
       containers:
         - name: docsclaw
           image: ghcr.io/redhat-et/docsclaw:latest
@@ -148,9 +166,11 @@ spec:
         - name: agent-config
           configMap:
             name: docsclaw-config
-        - name: workspace
+        - name: openclaw-files
           configMap:
             name: docsclaw-workspace
+        - name: workspace
+          emptyDir: {}
 
 ---
 apiVersion: v1

--- a/docs/agent-config-guide.md
+++ b/docs/agent-config-guide.md
@@ -182,3 +182,99 @@ registered automatically when the MCP server connects.
 
 To run in phase 1, simply omit `agent-config.yaml` from the config
 directory.
+
+## Workspace context
+
+DocsClaw supports [OpenClaw](https://openclaw.dev)-compatible
+workspace files. When present in the workspace directory, these
+files are loaded at startup and appended to the system prompt as
+structured project context. See the
+[OpenClaw agent workspace docs](https://docs.openclaw.ai/concepts/agent-workspace)
+for the full specification of these files.
+
+This creates an overlay model: the operator controls the base
+behavior via `system-prompt.txt`, while users provide project-level
+personality and context through workspace files.
+
+### Supported files
+
+Files are loaded in this order (all optional):
+
+| File | Purpose |
+| ---- | ------- |
+| `AGENTS.md` | Operating instructions |
+| `SOUL.md` | Persona and tone |
+| `USER.md` | User context |
+| `IDENTITY.md` | Agent name and role |
+| `TOOLS.md` | Tool guidance (advisory) |
+
+Missing files are skipped silently. Empty files are ignored.
+
+### Truncation limits
+
+| Limit | Default | Description |
+| ----- | ------- | ----------- |
+| Per file | 20,000 chars | Files exceeding this are truncated with a warning log |
+| Total | 60,000 chars | Combined content across all files is capped; files load in order and the last file crossing the boundary is truncated |
+
+### Prompt assembly order
+
+The final system prompt is assembled in this order:
+
+1. `system-prompt.txt` content (from config directory)
+2. Workspace path injection (`"Your workspace directory is ..."`)
+3. **Workspace context** (`## Project Context` with `### <FILE>`
+   headers per loaded file)
+4. OS tool inventory (if `/etc/docsclaw/tools.json` exists)
+5. Skills summary (if skills are discovered)
+
+### Example output
+
+When SOUL.md and USER.md are present, the injected section looks
+like:
+
+```text
+## Project Context
+
+### SOUL
+Be direct and concise. Avoid unnecessary pleasantries.
+
+### USER
+Pavel, OCTO team at Red Hat.
+```
+
+### Deployment
+
+Mount workspace files as a ConfigMap to the workspace directory:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docsclaw-workspace
+data:
+  SOUL.md: |
+    Be direct and concise.
+  USER.md: |
+    Pavel, OCTO team at Red Hat.
+---
+# In the Deployment spec:
+volumeMounts:
+  - name: workspace
+    mountPath: /workspace
+volumes:
+  - name: workspace
+    configMap:
+      name: docsclaw-workspace
+```
+
+See [`deploy/openclaw-workspace-agent.yaml`](../deploy/openclaw-workspace-agent.yaml)
+for a complete example.
+
+### Phase compatibility
+
+Workspace context loads regardless of whether `agent-config.yaml`
+exists. It works in both phase 1 (single-shot) and phase 2
+(agentic loop). The workspace directory defaults to `/workspace`;
+if `agent-config.yaml` specifies `tools.workspace`, that path is
+used instead.

--- a/docs/agent-config-guide.md
+++ b/docs/agent-config-guide.md
@@ -245,7 +245,8 @@ Pavel, OCTO team at Red Hat.
 
 ### Deployment
 
-Mount workspace files as a ConfigMap to the workspace directory:
+Store workspace files in a ConfigMap and use an init container to
+seed them into a writable emptyDir (so `write_file` still works):
 
 ```yaml
 apiVersion: v1
@@ -259,13 +260,26 @@ data:
     Pavel, OCTO team at Red Hat.
 ---
 # In the Deployment spec:
+initContainers:
+  - name: seed-workspace
+    image: ghcr.io/redhat-et/docsclaw:latest
+    command: ["sh", "-c", "cp /openclaw-files/*.md /workspace/"]
+    volumeMounts:
+      - name: openclaw-files
+        mountPath: /openclaw-files
+        readOnly: true
+      - name: workspace
+        mountPath: /workspace
+# Main container:
 volumeMounts:
   - name: workspace
     mountPath: /workspace
 volumes:
-  - name: workspace
+  - name: openclaw-files
     configMap:
       name: docsclaw-workspace
+  - name: workspace
+    emptyDir: {}
 ```
 
 See [`deploy/openclaw-workspace-agent.yaml`](../deploy/openclaw-workspace-agent.yaml)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -120,6 +120,73 @@ func loadToolsJSON(path string) (*manifest.ToolsJSON, error) {
 
 const defaultWorkspace = "/workspace"
 
+var openClawFiles = []string{
+	"AGENTS.md",
+	"SOUL.md",
+	"USER.md",
+	"IDENTITY.md",
+	"TOOLS.md",
+}
+
+const (
+	maxPerFileChars = 20_000
+	maxTotalChars   = 60_000
+)
+
+func loadWorkspaceContext(workspaceDir string) string {
+	var loaded []string
+	var sections []string
+	totalChars := 0
+
+	for _, name := range openClawFiles {
+		if totalChars >= maxTotalChars {
+			break
+		}
+
+		data, err := os.ReadFile(filepath.Join(workspaceDir, name))
+		if err != nil {
+			continue
+		}
+
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			continue
+		}
+
+		if len(content) > maxPerFileChars {
+			slog.Warn("workspace file truncated",
+				"file", name,
+				"original_chars", len(content),
+				"limit", maxPerFileChars)
+			content = content[:maxPerFileChars]
+		}
+
+		remaining := maxTotalChars - totalChars
+		if len(content) > remaining {
+			slog.Warn("workspace context truncated at total limit",
+				"file", name,
+				"used_chars", len(content[:remaining]),
+				"total_limit", maxTotalChars)
+			content = content[:remaining]
+		}
+
+		totalChars += len(content)
+		header := strings.TrimSuffix(name, ".md")
+		sections = append(sections, fmt.Sprintf("### %s\n%s", header, content))
+		loaded = append(loaded, name)
+	}
+
+	if len(sections) == 0 {
+		return ""
+	}
+
+	slog.Info("loaded workspace context",
+		"files", loaded,
+		"total_chars", totalChars)
+
+	return "\n\n## Project Context\n\n" + strings.Join(sections, "\n\n")
+}
+
 var toolNameAllowed = regexp.MustCompile(`[^a-zA-Z0-9 _-]`)
 
 func sanitizeToolName(name string) string {
@@ -293,6 +360,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+
+	// Load OpenClaw workspace context (works in both phase 1 and phase 2)
+	workspace := defaultWorkspace
+	if agentCfg != nil && agentCfg.Tools.Workspace != "" {
+		workspace = agentCfg.Tools.Workspace
+	}
+	systemPrompt += loadWorkspaceContext(workspace)
 
 	log := logger.New(logger.ComponentAgent)
 	slog.SetDefault(log.Logger)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
@@ -133,6 +134,19 @@ const (
 	maxTotalChars   = 60_000
 )
 
+// truncateRunes returns s truncated to at most n runes, without
+// splitting multi-byte characters.
+func truncateRunes(s string, n int) string {
+	runes := 0
+	for i := range s {
+		if runes >= n {
+			return s[:i]
+		}
+		runes++
+	}
+	return s
+}
+
 func loadWorkspaceContext(workspaceDir string) string {
 	var loaded []string
 	var sections []string
@@ -153,24 +167,27 @@ func loadWorkspaceContext(workspaceDir string) string {
 			continue
 		}
 
-		if len(content) > maxPerFileChars {
+		runeCount := utf8.RuneCountInString(content)
+		if runeCount > maxPerFileChars {
 			slog.Warn("workspace file truncated",
 				"file", name,
-				"original_chars", len(content),
+				"original_chars", runeCount,
 				"limit", maxPerFileChars)
-			content = content[:maxPerFileChars]
+			content = truncateRunes(content, maxPerFileChars)
+			runeCount = maxPerFileChars
 		}
 
 		remaining := maxTotalChars - totalChars
-		if len(content) > remaining {
+		if runeCount > remaining {
 			slog.Warn("workspace context truncated at total limit",
 				"file", name,
-				"used_chars", len(content[:remaining]),
+				"used_chars", remaining,
 				"total_limit", maxTotalChars)
-			content = content[:remaining]
+			content = truncateRunes(content, remaining)
+			runeCount = remaining
 		}
 
-		totalChars += len(content)
+		totalChars += runeCount
 		header := strings.TrimSuffix(name, ".md")
 		sections = append(sections, fmt.Sprintf("### %s\n%s", header, content))
 		loaded = append(loaded, name)
@@ -361,15 +378,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	log := logger.New(logger.ComponentAgent)
+	slog.SetDefault(log.Logger)
+
 	// Load OpenClaw workspace context (works in both phase 1 and phase 2)
 	workspace := defaultWorkspace
 	if agentCfg != nil && agentCfg.Tools.Workspace != "" {
 		workspace = agentCfg.Tools.Workspace
 	}
 	systemPrompt += loadWorkspaceContext(workspace)
-
-	log := logger.New(logger.ComponentAgent)
-	slog.SetDefault(log.Logger)
 
 	// Load OS tool inventory and inject into system prompt
 	const toolsJSONPath = "/etc/docsclaw/tools.json"

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -159,6 +159,9 @@ func loadWorkspaceContext(workspaceDir string) string {
 
 		data, err := os.ReadFile(filepath.Join(workspaceDir, name))
 		if err != nil {
+			if !os.IsNotExist(err) {
+				slog.Warn("failed to read workspace file", "file", name, "error", err)
+			}
 			continue
 		}
 

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file %s: %v", path, err)
+	}
+}
+
+func TestLoadWorkspaceContextAllFiles(t *testing.T) {
+	dir := filepath.Join("..", "..", "testdata", "openclaw-workspace")
+	result := loadWorkspaceContext(dir)
+
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+	if !strings.Contains(result, "## Project Context") {
+		t.Fatal("expected '## Project Context' header")
+	}
+
+	expectedHeaders := []string{"### AGENTS", "### SOUL", "### USER", "### IDENTITY", "### TOOLS"}
+	for _, h := range expectedHeaders {
+		if !strings.Contains(result, h) {
+			t.Fatalf("missing section header: %s", h)
+		}
+	}
+
+	agentsIdx := strings.Index(result, "### AGENTS")
+	soulIdx := strings.Index(result, "### SOUL")
+	userIdx := strings.Index(result, "### USER")
+	identityIdx := strings.Index(result, "### IDENTITY")
+	toolsIdx := strings.Index(result, "### TOOLS")
+
+	if agentsIdx >= soulIdx || soulIdx >= userIdx || userIdx >= identityIdx || identityIdx >= toolsIdx {
+		t.Fatal("sections not in expected order: AGENTS, SOUL, USER, IDENTITY, TOOLS")
+	}
+}
+
+func TestLoadWorkspaceContextPartialFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "SOUL.md"), "Be direct.")
+	writeTestFile(t, filepath.Join(dir, "USER.md"), "Pavel, OCTO team")
+
+	result := loadWorkspaceContext(dir)
+
+	if !strings.Contains(result, "### SOUL") {
+		t.Fatal("expected SOUL section")
+	}
+	if !strings.Contains(result, "### USER") {
+		t.Fatal("expected USER section")
+	}
+	if strings.Contains(result, "### AGENTS") {
+		t.Fatal("should not contain AGENTS section")
+	}
+	if strings.Contains(result, "### IDENTITY") {
+		t.Fatal("should not contain IDENTITY section")
+	}
+	if strings.Contains(result, "### TOOLS") {
+		t.Fatal("should not contain TOOLS section")
+	}
+}
+
+func TestLoadWorkspaceContextNoFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	result := loadWorkspaceContext(dir)
+
+	if result != "" {
+		t.Fatalf("expected empty string, got %q", result)
+	}
+}
+
+func TestLoadWorkspaceContextPerFileTruncation(t *testing.T) {
+	dir := t.TempDir()
+
+	largeContent := strings.Repeat("a", 25_000)
+	writeTestFile(t, filepath.Join(dir, "AGENTS.md"), largeContent)
+
+	result := loadWorkspaceContext(dir)
+
+	contentStart := strings.Index(result, "### AGENTS\n") + len("### AGENTS\n")
+	content := result[contentStart:]
+	if len(content) > maxPerFileChars {
+		t.Fatalf("content should be truncated to %d chars, got %d", maxPerFileChars, len(content))
+	}
+}
+
+func TestLoadWorkspaceContextTotalTruncation(t *testing.T) {
+	dir := t.TempDir()
+
+	fileContent := strings.Repeat("x", 18_000)
+	for _, name := range openClawFiles {
+		writeTestFile(t, filepath.Join(dir, name), fileContent)
+	}
+
+	result := loadWorkspaceContext(dir)
+
+	totalContent := 0
+	for _, name := range openClawFiles {
+		header := "### " + strings.TrimSuffix(name, ".md") + "\n"
+		idx := strings.Index(result, header)
+		if idx < 0 {
+			continue
+		}
+		sectionStart := idx + len(header)
+		nextHeader := strings.Index(result[sectionStart:], "\n\n### ")
+		var section string
+		if nextHeader < 0 {
+			section = result[sectionStart:]
+		} else {
+			section = result[sectionStart : sectionStart+nextHeader]
+		}
+		totalContent += len(section)
+	}
+
+	if totalContent > maxTotalChars {
+		t.Fatalf("total content should not exceed %d chars, got %d", maxTotalChars, totalContent)
+	}
+}
+
+func TestLoadWorkspaceContextEmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(dir, "AGENTS.md"), "")
+	writeTestFile(t, filepath.Join(dir, "SOUL.md"), "   \n  ")
+	writeTestFile(t, filepath.Join(dir, "USER.md"), "has content")
+
+	result := loadWorkspaceContext(dir)
+
+	if strings.Contains(result, "### AGENTS") {
+		t.Fatal("should skip empty AGENTS.md")
+	}
+	if strings.Contains(result, "### SOUL") {
+		t.Fatal("should skip whitespace-only SOUL.md")
+	}
+	if !strings.Contains(result, "### USER") {
+		t.Fatal("should include USER.md with content")
+	}
+}
+
+func TestLoadWorkspaceContextNonexistentDir(t *testing.T) {
+	result := loadWorkspaceContext("/nonexistent/path")
+
+	if result != "" {
+		t.Fatalf("expected empty string for nonexistent dir, got %q", result)
+	}
+}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func writeTestFile(t *testing.T, path, content string) {
@@ -142,6 +143,27 @@ func TestLoadWorkspaceContextEmptyFiles(t *testing.T) {
 	}
 	if !strings.Contains(result, "### USER") {
 		t.Fatal("should include USER.md with content")
+	}
+}
+
+func TestLoadWorkspaceContextUnicodeTruncation(t *testing.T) {
+	dir := t.TempDir()
+
+	// Each character is 3 bytes in UTF-8; 25K runes = 75K bytes.
+	// Truncation should preserve whole runes, not split mid-character.
+	unicodeContent := strings.Repeat("日", 25_000)
+	writeTestFile(t, filepath.Join(dir, "AGENTS.md"), unicodeContent)
+
+	result := loadWorkspaceContext(dir)
+
+	contentStart := strings.Index(result, "### AGENTS\n") + len("### AGENTS\n")
+	content := result[contentStart:]
+	runeCount := utf8.RuneCountInString(content)
+	if runeCount > maxPerFileChars {
+		t.Fatalf("expected at most %d runes, got %d", maxPerFileChars, runeCount)
+	}
+	if !utf8.ValidString(content) {
+		t.Fatal("truncated content is not valid UTF-8")
 	}
 }
 

--- a/testdata/openclaw-workspace/AGENTS.md
+++ b/testdata/openclaw-workspace/AGENTS.md
@@ -1,0 +1,2 @@
+You are a helpful assistant focused on software engineering tasks.
+Follow the user's instructions carefully and provide clear, actionable responses.

--- a/testdata/openclaw-workspace/IDENTITY.md
+++ b/testdata/openclaw-workspace/IDENTITY.md
@@ -1,0 +1,2 @@
+Name: DocsClaw Agent
+Role: Document processing and code assistance

--- a/testdata/openclaw-workspace/SOUL.md
+++ b/testdata/openclaw-workspace/SOUL.md
@@ -1,0 +1,2 @@
+Be direct and concise. Avoid unnecessary pleasantries.
+Prefer showing code over describing it.

--- a/testdata/openclaw-workspace/TOOLS.md
+++ b/testdata/openclaw-workspace/TOOLS.md
@@ -1,0 +1,2 @@
+Use the exec tool for running shell commands.
+Use the readfile tool before modifying files.

--- a/testdata/openclaw-workspace/USER.md
+++ b/testdata/openclaw-workspace/USER.md
@@ -1,0 +1,2 @@
+Pavel, OCTO team at Red Hat.
+Prefers Go, familiar with Kubernetes and container technologies.


### PR DESCRIPTION
## Summary

- Load OpenClaw-compatible workspace files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md) from the workspace directory and inject as `## Project Context` in the system prompt
- Works in both phase 1 (single-shot) and phase 2 (agentic loop) modes — existing deployments with only `system-prompt.txt` are unaffected
- Per-file truncation at 20K chars, total at 60K chars, matching OpenClaw defaults
- Rune-safe truncation preserves valid UTF-8 at boundaries

## Test plan

- [x] Unit tests: all five files present (order and headers verified)
- [x] Unit tests: partial files, no files, empty files, nonexistent directory
- [x] Unit tests: per-file truncation at 20K chars
- [x] Unit tests: total truncation at 60K chars
- [x] Unit tests: Unicode content truncation (rune safety)
- [x] `golangci-lint run ./internal/cmd/...` passes (zero issues in changed packages)
- [x] `make test` passes (no regressions)
- [ ] Deploy with OpenClaw workspace ConfigMap and verify context appears in LLM prompts

Note: `make lint` has pre-existing failures in `demo/batch/document-service/main.go` and `internal/logger/logger.go` — unrelated to this change.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading OpenClaw-compatible workspace context files at startup and injecting them into the agent prompt.
  * Added a deployable manifest for running with workspace context (including health endpoints and external exposure).

* **Documentation**
  * Updated README “How it works” and the agent configuration guide with workspace context layout, load order, truncation rules, and compatibility details.
  * Added/expanded guidance on how workspace files become project context.

* **Tests**
  * Added tests covering workspace context generation, missing/empty file skipping, per-file and total truncation, and Unicode-safe handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->