### PR TITLE
feat: make workspace path configurable via CLI flag

### DIFF
--- a/deploy/standalone-agent.yaml
+++ b/deploy/standalone-agent.yaml
@@ -126,7 +126,8 @@ spec:
           env:
             - name: DOCSCLAW_SERVICE_PORT
               value: "8000"
-            # Uncomment to override the workspace directory:
+            # Fallback workspace directory — used only when
+            # agent-config.yaml does not set tools.workspace:
             # - name: DOCSCLAW_WORKSPACE
             #   value: "/data/agent"
           envFrom:

--- a/deploy/standalone-agent.yaml
+++ b/deploy/standalone-agent.yaml
@@ -126,6 +126,9 @@ spec:
           env:
             - name: DOCSCLAW_SERVICE_PORT
               value: "8000"
+            # Uncomment to override the workspace directory:
+            # - name: DOCSCLAW_WORKSPACE
+            #   value: "/data/agent"
           envFrom:
             - secretRef:
                 name: llm-secret

--- a/docs/agent-config-guide.md
+++ b/docs/agent-config-guide.md
@@ -99,7 +99,7 @@ agent-config.yaml
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `allowed` | `[]string` | `[]` (none) | Tools the LLM may call. See [available tools](#available-tools). |
-| `workspace` | `string` | `/workspace` | Root directory for `read_file` and `write_file`. The agent cannot access files outside this path. Can also be set via `--workspace` flag or `DOCSCLAW_WORKSPACE` env var (config file takes precedence). |
+| `workspace` | `string` | `/workspace` | Root directory for `read_file` and `write_file`. The agent cannot access files outside this path. The workspace path can also be set via the `--workspace` flag or the `DOCSCLAW_WORKSPACE` env var; the config file value takes precedence. |
 
 ### `tools.exec`
 

--- a/docs/agent-config-guide.md
+++ b/docs/agent-config-guide.md
@@ -99,7 +99,7 @@ agent-config.yaml
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
 | `allowed` | `[]string` | `[]` (none) | Tools the LLM may call. See [available tools](#available-tools). |
-| `workspace` | `string` | `/workspace` | Root directory for `read_file` and `write_file`. The agent cannot access files outside this path. |
+| `workspace` | `string` | `/workspace` | Root directory for `read_file` and `write_file`. The agent cannot access files outside this path. Can also be set via `--workspace` flag or `DOCSCLAW_WORKSPACE` env var (config file takes precedence). |
 
 ### `tools.exec`
 
@@ -289,6 +289,9 @@ for a complete example.
 
 Workspace context loads regardless of whether `agent-config.yaml`
 exists. It works in both phase 1 (single-shot) and phase 2
-(agentic loop). The workspace directory defaults to `/workspace`;
-if `agent-config.yaml` specifies `tools.workspace`, that path is
-used instead.
+(agentic loop). The workspace directory is resolved with this
+priority:
+
+1. `agent-config.yaml` `tools.workspace` (config file wins)
+2. `--workspace` flag or `DOCSCLAW_WORKSPACE` env var
+3. Default: `/workspace`

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -281,11 +281,11 @@ type Config struct {
 }
 
 func resolveWorkspace(cfgWorkspace, flagWorkspace string) string {
-	if cfgWorkspace != "" {
-		return cfgWorkspace
+	if v := strings.TrimSpace(cfgWorkspace); v != "" {
+		return v
 	}
-	if flagWorkspace != "" {
-		return flagWorkspace
+	if v := strings.TrimSpace(flagWorkspace); v != "" {
+		return v
 	}
 	return defaultWorkspace
 }

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -251,10 +251,13 @@ func init() {
 	serveCmd.Flags().String("llm-model", "", "LLM model to use")
 	serveCmd.Flags().Int("llm-max-tokens", 4096, "Max tokens for LLM response")
 	serveCmd.Flags().Int("llm-timeout", 45, "LLM request timeout in seconds")
+	serveCmd.Flags().String("workspace", "",
+		"Workspace directory path (default: /workspace)")
 	serveCmd.Flags().String("session-db", "",
 		"Session database backend ('memory' for in-memory, or a file path for SQLite; default: memory)")
 
 	_ = v.BindPFlag("config_dir", serveCmd.Flags().Lookup("config-dir"))
+	_ = v.BindPFlag("workspace", serveCmd.Flags().Lookup("workspace"))
 	_ = v.BindPFlag("skills_dir", serveCmd.Flags().Lookup("skills-dir"))
 	_ = v.BindPFlag("document_service_url", serveCmd.Flags().Lookup("document-service-url"))
 	_ = v.BindPFlag("llm.provider", serveCmd.Flags().Lookup("llm-provider"))
@@ -271,9 +274,20 @@ type Config struct {
 	config.CommonConfig `mapstructure:",squash"`
 	ConfigDir          string     `mapstructure:"config_dir"`
 	SkillsDir          string     `mapstructure:"skills_dir"`
+	Workspace          string     `mapstructure:"workspace"`
 	DocumentServiceURL string     `mapstructure:"document_service_url"`
 	LLM                llm.Config `mapstructure:"llm"`
 	SessionDB          string     `mapstructure:"session_db"`
+}
+
+func resolveWorkspace(cfgWorkspace, flagWorkspace string) string {
+	if cfgWorkspace != "" {
+		return cfgWorkspace
+	}
+	if flagWorkspace != "" {
+		return flagWorkspace
+	}
+	return defaultWorkspace
 }
 
 // startAgent loads config from configDir and validates it.
@@ -338,6 +352,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve workspace path: agent-config.yaml > --workspace flag/env > default
+	var cfgWorkspace string
+	if agentCfg != nil {
+		cfgWorkspace = agentCfg.Tools.Workspace
+	}
+	workspace := resolveWorkspace(cfgWorkspace, cfg.Workspace)
+
 	// Set up tool registry and skill loading if agent config exists
 	var toolRegistry *tools.Registry
 	var loopCfg tools.LoopConfig
@@ -346,10 +367,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if agentCfg != nil {
 		toolRegistry = tools.NewRegistry(agentCfg.Tools.Allowed)
 
-		workspace := agentCfg.Tools.Workspace
-		if workspace == "" {
-			workspace = defaultWorkspace
-		}
 		if err := os.MkdirAll(workspace, 0755); err != nil {
 			return fmt.Errorf("failed to create workspace: %w", err)
 		}
@@ -385,10 +402,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 	slog.SetDefault(log.Logger)
 
 	// Load OpenClaw workspace context (works in both phase 1 and phase 2)
-	workspace := defaultWorkspace
-	if agentCfg != nil && agentCfg.Tools.Workspace != "" {
-		workspace = agentCfg.Tools.Workspace
-	}
 	systemPrompt += loadWorkspaceContext(workspace)
 
 	// Load OS tool inventory and inject into system prompt

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -188,6 +188,13 @@ func TestResolveWorkspaceDefault(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspaceWhitespaceIgnored(t *testing.T) {
+	result := resolveWorkspace("   ", "/from-flag")
+	if result != "/from-flag" {
+		t.Fatalf("expected /from-flag, got %q", result)
+	}
+}
+
 func TestLoadWorkspaceContextNonexistentDir(t *testing.T) {
 	result := loadWorkspaceContext("/nonexistent/path")
 

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -167,6 +167,27 @@ func TestLoadWorkspaceContextUnicodeTruncation(t *testing.T) {
 	}
 }
 
+func TestResolveWorkspaceConfigWins(t *testing.T) {
+	result := resolveWorkspace("/from-config", "/from-flag")
+	if result != "/from-config" {
+		t.Fatalf("expected /from-config, got %q", result)
+	}
+}
+
+func TestResolveWorkspaceFlagFallback(t *testing.T) {
+	result := resolveWorkspace("", "/from-flag")
+	if result != "/from-flag" {
+		t.Fatalf("expected /from-flag, got %q", result)
+	}
+}
+
+func TestResolveWorkspaceDefault(t *testing.T) {
+	result := resolveWorkspace("", "")
+	if result != defaultWorkspace {
+		t.Fatalf("expected %q, got %q", defaultWorkspace, result)
+	}
+}
+
 func TestLoadWorkspaceContextNonexistentDir(t *testing.T) {
 	result := loadWorkspaceContext("/nonexistent/path")
 


### PR DESCRIPTION
## Summary

- Add `--workspace` flag and `DOCSCLAW_WORKSPACE` env var to the `serve` command
- Priority: `agent-config.yaml` `tools.workspace` > `--workspace` flag/env > default (`/workspace`)
- Unify workspace resolution into a single `resolveWorkspace` function, replacing two inline resolution blocks

Closes #96

## Test plan

- [x] Unit test: config file value takes precedence over flag
- [x] Unit test: flag value used when config is empty
- [x] Unit test: default `/workspace` when both are empty
- [x] `golangci-lint run ./internal/cmd/...` — zero issues
- [x] `make test` — no regressions

Note: `make lint` has pre-existing failures in `demo/batch/` and `internal/logger/` — unrelated to this change.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable workspace path for the service, with support for a command-line option and environment-based fallback.
* **Bug Fixes**
  * Improved workspace selection precedence to consistently use the config file first, then the command-line/environment value, and finally the default path (whitespace-only config is ignored).
* **Documentation**
  * Clarified workspace precedence, access limits, and that workspace context loads in both phases.
* **Tests**
  * Added coverage for workspace precedence and whitespace-handling behavior.
* **Chores**
  * Updated deployment manifest comments for an optional fallback workspace variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->