### PR TITLE
feat: OpenClaw/Hermes tool compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,8 @@ demo/batch/dashboard/dashboard
 # Local documentation drafts
 /docs/superpowers/
 
+# Git worktrees
+.worktrees/
+
 # PDF files
 *.pdf

--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ RUN --mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-bui
     --setopt=reposdir=/builder/etc/yum.repos.d \
     --setopt=install_weak_deps=False \
     --setopt=tsflags=nodocs \
-    curl jq
+    curl jq ripgrep
 USER 65532
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /docsclaw ./cmd/docsclaw
 
 FROM alpine:3.24
 
-RUN apk --no-cache add ca-certificates curl && \
+RUN apk --no-cache add ca-certificates curl ripgrep && \
     addgroup -S docsclaw && adduser -S docsclaw -G docsclaw
 
 WORKDIR /app

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -12,7 +12,7 @@ RUN --mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-bui
     --setopt=reposdir=/builder/etc/yum.repos.d \
     --setopt=install_weak_deps=False \
     --setopt=tsflags=nodocs \
-    curl jq
+    curl jq ripgrep
 USER 65532
 
 COPY --chmod=0755 docsclaw /usr/local/bin/docsclaw

--- a/containers/Containerfile.security
+++ b/containers/Containerfile.security
@@ -96,6 +96,7 @@ RUN --mount=type=bind,from=registry.access.redhat.com/hi/core-runtime:latest-bui
     --setopt=tsflags=nodocs \
     curl \
     jq \
+    ripgrep \
     git-core \
     make \
     python3 \

--- a/docs/dev/2026-05-15-rag-feature.md
+++ b/docs/dev/2026-05-15-rag-feature.md
@@ -119,7 +119,9 @@ if cfg.RAG != nil {
     if err != nil {
         return fmt.Errorf("rag: %w", err)
     }
-    registry.Register(tools.NewRAGSearchTool(ragClient, cfg.RAG))
+    if err := registry.RegisterAlwaysAllowed(ragsearch.NewRAGSearchTool(ragClient, cfg.RAG)); err != nil {
+        return fmt.Errorf("register rag_search tool: %w", err)
+    }
 }
 ```
 

--- a/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
+++ b/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
@@ -20,18 +20,27 @@ without breaking existing DocsClaw tools.
 
 ## Alias resolution
 
-The `tools.Registry` already supports aliases: `Get(alias)` resolves to the
-canonical tool, while `Definitions()` only exposes canonical names. The
+This PR adds alias support to `tools.Registry`. `RegisterAlias(alias,
+canonical)` maps an alias to a canonical tool name; `Get(alias)` resolves to
+the canonical tool, while `Definitions()` only exposes canonical names. The
 following aliases are registered when Phase 2 mode is enabled:
 
-| Alias     | Canonical tool |
-| --------- | -------------- |
-| `read`    | `read_file`    |
-| `write`   | `write_file`   |
-| `terminal`| `exec`         |
+| Alias      | Canonical tool |
+| ---------- | -------------- |
+| `read`     | `read_file`    |
+| `write`    | `write_file`   |
+| `terminal` | `exec`         |
 
 The allowed-tools filter is applied to the canonical name, so an alias is
-usable only when its canonical target is allowed.
+usable only when its canonical target is allowed. Registering a tool whose
+name collides with an existing alias (or vice versa) returns an error.
+
+### Breaking API change
+
+`Registry.Register` and `Registry.RegisterAlwaysAllowed` now return `error` so
+that collisions between tools and aliases can be surfaced to callers. Existing
+call sites in `internal/cmd/serve.go` and tests have been updated to check the
+returned error.
 
 ## New tools
 
@@ -56,11 +65,19 @@ usable only when its canonical target is allowed.
   ripgrep (rg) is not installed; search_files requires it
   ```
 - **Container images**: `ripgrep` is installed in `Containerfile`, `Dockerfile`,
-  `Dockerfile.release`, and `containers/Containerfile.security`.
+  `Dockerfile.release`, and `containers/Containerfile.security`. Image builds
+  were updated locally but were not exercised in CI for this change.
 - **Behavior**: runs `rg --no-config --json -e <regex> -- <path>` (with optional
   `-g <file_pattern>`), parses JSON match events, and returns lines as
   `file:line:match`. Output is truncated at 50,000 characters. Returns
   "No matches found." when ripgrep exits with code 1 and no matches.
+- **Safety features**:
+  - The `regex` argument is pre-validated with `regexp.Compile` before invoking
+    ripgrep; a malformed pattern returns a clear error instead of a subprocess
+    failure.
+  - Execution is bounded by a 30-second context timeout.
+  - The stdout scanner uses a 4 MiB maximum token size so a single oversized
+    line cannot exhaust the parser.
 
 ### `web_search`
 
@@ -95,6 +112,10 @@ usable only when its canonical target is allowed.
   - The target file must exist.
   - Applies hunks sequentially; each hunk's context lines must match exactly.
   - On mismatch, returns an error identifying the hunk/line.
+  - Handles the `\ No newline at end of file` marker best-effort: the final
+    output omits a trailing newline when the marker appears on the last hunk.
+    If the marker refers only to the old side of the last hunk, the output may
+    incorrectly lose its trailing newline.
   - On success, returns `Patched <path>`.
 
 ### `edit`
@@ -108,6 +129,8 @@ usable only when its canonical target is allowed.
   - The target file must exist.
   - Replaces the first exact occurrence of `old_string` with `new_string`.
   - Returns an error if `old_string` is empty or not found.
+  - When `old_string` occurs more than once, the first occurrence is replaced
+    and the success message includes a warning with the total occurrence count.
   - On success, returns `Edited <path>`.
 
 ## Registration in `serve.go`
@@ -123,14 +146,30 @@ When Phase 2 mode is enabled (`toolRegistry != nil` block in
    `search_files`).
 3. Register new tools: `web_search`, `apply_patch`, `edit`.
 
+### Registration error policy
+
+- Alias registration errors log a warning and continue. A duplicate or
+  conflicting alias does not prevent the agent from starting because the
+  canonical tools are still available.
+- Tool registration errors abort startup. A missing canonical tool would leave
+  the agent unable to perform basic operations, so startup fails fast with a
+  clear error.
+
+## Implementation details
+
+- `internal/fileutil.WriteFileAtomically` is a small helper used by
+  `apply_patch` and `edit` to write changes through a temp file and rename,
+  reducing the chance of leaving a file partially written on error or crash.
+
 ## Testing
 
 - Unit tests in each tool package (`internal/searchfiles`,
   `internal/websearch`, `internal/applypatch`, `internal/edit`).
-- Existing `pkg/tools/registry_test.go` already covers alias registration and
-  allowed-tool filtering.
+- `pkg/tools/registry_test.go` covers alias registration, allowed-tool
+  filtering, and the new collision behavior between tools and aliases.
 - Run `go test ./...`, `make test`, and `make lint` before merging.
-- Verify container images build and contain `rg`.
+- Container image Dockerfiles/Containerfiles were updated to install
+  `ripgrep`, but image builds were not verified in CI for this change.
 
 ## Risks and mitigations
 

--- a/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
+++ b/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
@@ -1,0 +1,29 @@
+# OpenClaw Tool Compatibility
+
+**Date**: 2026-08-22
+**Status**: In Progress
+
+## Goal
+
+Ensure DocsClaw's OpenClaw-compatible tool set works reliably in shipped
+container images, with clear runtime errors when a required external binary
+is missing.
+
+## search_files
+
+The `search_files` tool shells out to [ripgrep](https://github.com/BurntSushi/ripgrep)
+(`rg`) to search file contents. At execution time it checks for `rg` on
+`PATH` using `exec.LookPath`; if ripgrep is not installed, the tool returns
+the error:
+
+```
+ripgrep (rg) is not installed; search_files requires it
+```
+
+All shipped container images install the `ripgrep` package so the tool
+works at runtime:
+
+- `Containerfile`
+- `Dockerfile`
+- `Dockerfile.release`
+- `containers/Containerfile.security`

--- a/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
+++ b/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
@@ -123,9 +123,6 @@ When Phase 2 mode is enabled (`toolRegistry != nil` block in
    `search_files`).
 3. Register new tools: `web_search`, `apply_patch`, `edit`.
 
-Registration of the new tools is intentionally batched in Task 7; `web_search`
-is not registered yet.
-
 ## Testing
 
 - Unit tests in each tool package (`internal/searchfiles`,

--- a/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
+++ b/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
@@ -3,27 +3,152 @@
 **Date**: 2026-08-22
 **Status**: In Progress
 
+## Context
+
+DocsClaw's Phase 2 agentic loop uses a local `tools.Registry`. Several
+OpenClaw-style clients expect tool names such as `read`, `write`, and
+`terminal`, and rely on tools such as `search_files`, `web_search`,
+`apply_patch`, and `edit` that either have different names in DocsClaw or do
+not exist yet. This design adds the missing aliases and tools while keeping
+DocsClaw's workspace-scoped security model.
+
 ## Goal
 
-Ensure DocsClaw's OpenClaw-compatible tool set works reliably in shipped
-container images, with clear runtime errors when a required external binary
-is missing.
+Make DocsClaw's Phase 2 tool set compatible with common OpenClaw agent tool
+names, with clear runtime errors when a required external binary is missing and
+without breaking existing DocsClaw tools.
 
-## search_files
+## Alias resolution
 
-The `search_files` tool shells out to [ripgrep](https://github.com/BurntSushi/ripgrep)
-(`rg`) to search file contents. At execution time it checks for `rg` on
-`PATH` using `exec.LookPath`; if ripgrep is not installed, the tool returns
-the error:
+The `tools.Registry` already supports aliases: `Get(alias)` resolves to the
+canonical tool, while `Definitions()` only exposes canonical names. The
+following aliases are registered when Phase 2 mode is enabled:
 
-```
-ripgrep (rg) is not installed; search_files requires it
-```
+| Alias     | Canonical tool |
+| --------- | -------------- |
+| `read`    | `read_file`    |
+| `write`   | `write_file`   |
+| `terminal`| `exec`         |
 
-All shipped container images install the `ripgrep` package so the tool
-works at runtime:
+The allowed-tools filter is applied to the canonical name, so an alias is
+usable only when its canonical target is allowed.
 
-- `Containerfile`
-- `Dockerfile`
-- `Dockerfile.release`
-- `containers/Containerfile.security`
+## New tools
+
+| Tool name      | Purpose                                          | Package                    |
+| -------------- | ------------------------------------------------ | -------------------------- |
+| `search_files` | Search file contents with ripgrep                | `internal/searchfiles`     |
+| `web_search`   | Search the web via DuckDuckGo                    | `internal/websearch`       |
+| `apply_patch`  | Apply a unified-diff style patch to a file       | `internal/applypatch`      |
+| `edit`         | Replace a single string occurrence inside a file | `internal/edit`            |
+
+## Per-tool details
+
+### `search_files`
+
+- **Parameters**:
+  - `path` (string, required): directory to search, resolved against the workspace.
+  - `regex` (string, required): regular expression to match.
+  - `file_pattern` (string, optional): glob filter such as `*.go`.
+- **Runtime dependency**: shells out to `rg` (ripgrep). On execution it calls
+  `exec.LookPath("rg")`; if ripgrep is missing it returns:
+  ```
+  ripgrep (rg) is not installed; search_files requires it
+  ```
+- **Container images**: `ripgrep` is installed in `Containerfile`, `Dockerfile`,
+  `Dockerfile.release`, and `containers/Containerfile.security`.
+- **Behavior**: runs `rg --no-config --json -e <regex> -- <path>` (with optional
+  `-g <file_pattern>`), parses JSON match events, and returns lines as
+  `file:line:match`. Output is truncated at 50,000 characters. Returns
+  "No matches found." when ripgrep exits with code 1 and no matches.
+
+### `web_search`
+
+- **Provider interface** (`internal/websearch`):
+  ```go
+  type Provider interface {
+      Search(ctx context.Context, query string, numResults int) ([]Result, error)
+  }
+  type Result struct {
+      Title   string
+      Snippet string
+      URL     string
+  }
+  ```
+- **DuckDuckGo provider** (`internal/websearch/duckduckgo.go`):
+  - Posts `q=<query>` to `https://html.duckduckgo.com/html/`.
+  - Sets `User-Agent: DocsClaw web_search tool (...)`.
+  - Parses `result__a` title links and `result__snippet` snippets.
+  - Resolves DuckDuckGo redirect URLs (`/l/?uddg=...`) to the target URL.
+- **Parameters**:
+  - `query` (string, required): search query.
+  - `num_results` (integer, optional): defaults to 5, clamped to the range 1-10.
+- **Output**: markdown list `* [Title](URL): Snippet`.
+
+### `apply_patch`
+
+- **Parameters**:
+  - `path` (string, required): file to patch, resolved against the workspace.
+  - `patch` (string, required): unified-diff style patch string.
+- **Behavior**:
+  - Rejects paths outside the workspace.
+  - The target file must exist.
+  - Applies hunks sequentially; each hunk's context lines must match exactly.
+  - On mismatch, returns an error identifying the hunk/line.
+  - On success, returns `Patched <path>`.
+
+### `edit`
+
+- **Parameters**:
+  - `path` (string, required): file to edit, resolved against the workspace.
+  - `old_string` (string, required): exact text to replace.
+  - `new_string` (string, required): replacement text.
+- **Behavior**:
+  - Rejects paths outside the workspace.
+  - The target file must exist.
+  - Replaces the first exact occurrence of `old_string` with `new_string`.
+  - Returns an error if `old_string` is empty or not found.
+  - On success, returns `Edited <path>`.
+
+## Registration in `serve.go`
+
+When Phase 2 mode is enabled (`toolRegistry != nil` block in
+`internal/cmd/serve.go`):
+
+1. Register aliases:
+   - `read` -> `read_file`
+   - `write` -> `write_file`
+   - `terminal` -> `exec`
+2. Register canonical tools already present (`read_file`, `write_file`, `exec`,
+   `search_files`).
+3. Register new tools: `web_search`, `apply_patch`, `edit`.
+
+Registration of the new tools is intentionally batched in Task 7; `web_search`
+is not registered yet.
+
+## Testing
+
+- Unit tests in each tool package (`internal/searchfiles`,
+  `internal/websearch`, `internal/applypatch`, `internal/edit`).
+- Existing `pkg/tools/registry_test.go` already covers alias registration and
+  allowed-tool filtering.
+- Run `go test ./...`, `make test`, and `make lint` before merging.
+- Verify container images build and contain `rg`.
+
+## Risks and mitigations
+
+| Risk                                              | Mitigation                                              |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| DuckDuckGo HTML layout changes and breaks parsing | Keep parsing regexes localized; provider interface allows swapping backends later. |
+| `rg` missing in a custom image                    | Runtime `LookPath` check returns a clear error; official images install `ripgrep`. |
+| Workspace escape via aliases or new tools         | All file tools use `workspace.IsInsideWorkspace` before reading/writing. |
+| Patch application corrupts file on partial match  | Validate context lines before writing; abort on first mismatch. |
+| `edit` replaces wrong occurrence                  | Require exact `old_string`; only the first match is replaced. |
+
+## Out of scope
+
+- Additional search providers for `web_search` (Google, Bing, etc.).
+- Semantic/file-content search beyond ripgrep regex.
+- Interactive or multi-file patch editors.
+- Git-specific tools (commit, push, diff generation).
+- Network-mounted or remote filesystem support.

--- a/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
+++ b/docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md
@@ -32,8 +32,18 @@ following aliases are registered when Phase 2 mode is enabled:
 | `terminal` | `exec`         |
 
 The allowed-tools filter is applied to the canonical name, so an alias is
-usable only when its canonical target is allowed. Registering a tool whose
-name collides with an existing alias (or vice versa) returns an error.
+usable only when its canonical target is allowed.
+
+### Reserved names
+
+The aliases `read`, `write`, and `terminal` are reserved for
+OpenClaw/Hermes compatibility. Their canonical targets `read_file`,
+`write_file`, and `exec` are also reserved names. Registering a tool whose
+name collides with an existing alias or canonical name (or vice versa)
+returns an error. Because aliases and canonical tools are registered before
+MCP tools in `internal/cmd/serve.go`, any later registration—including from
+an MCP server—that tries to reuse a reserved alias or canonical name will
+fail startup.
 
 ### Breaking API change
 
@@ -153,7 +163,9 @@ When Phase 2 mode is enabled (`toolRegistry != nil` block in
   canonical tools are still available.
 - Tool registration errors abort startup. A missing canonical tool would leave
   the agent unable to perform basic operations, so startup fails fast with a
-  clear error.
+  clear error. This also applies to MCP tools that collide with reserved
+  aliases (`read`, `write`, `terminal`) or canonical names (`read_file`,
+  `write_file`, `exec`).
 
 ## Implementation details
 

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -246,7 +245,7 @@ func parseRange(s string) (start, count int, err error) {
 		return 0, 0, fmt.Errorf("invalid range count: %q", countStr)
 	}
 	if start == 0 && count != 0 {
-		count = 0
+		return 0, 0, fmt.Errorf("invalid range: %s", s)
 	}
 	if start < 0 || count < 0 {
 		return 0, 0, fmt.Errorf("negative range: %s", s)
@@ -255,10 +254,6 @@ func parseRange(s string) (start, count int, err error) {
 }
 
 func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
-	sort.Slice(hunks, func(i, j int) bool {
-		return hunks[i].oldStart < hunks[j].oldStart
-	})
-
 	result := make([]string, 0, len(original))
 	origIdx := 0
 
@@ -269,7 +264,7 @@ func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
 		}
 
 		if insertAt < origIdx {
-			return nil, false, fmt.Errorf("hunk %d overlaps a previous hunk", i+1)
+			return nil, false, fmt.Errorf("hunk %d is out of order or overlaps a previous hunk", i+1)
 		}
 		if insertAt > len(original) {
 			return nil, false, fmt.Errorf("hunk %d starts beyond end of file", i+1)

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -78,16 +78,22 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		return tools.Errorf("no hunks found in patch")
 	}
 
-	original, err := os.ReadFile(absPath)
+	info, err := os.Stat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return tools.Errorf("file does not exist: %s", absPath)
 		}
+		return tools.Errorf("failed to stat file: %s", err)
+	}
+	originalMode := info.Mode().Perm()
+
+	original, err := os.ReadFile(absPath)
+	if err != nil {
 		return tools.Errorf("failed to read file: %s", err)
 	}
 
 	originalLines := strings.Split(string(original), "\n")
-	newLines, err := applyHunks(originalLines, hunks)
+	newLines, noTrailingNewline, err := applyHunks(originalLines, hunks)
 	if err != nil {
 		return tools.Errorf("patch failed: %s", err)
 	}
@@ -98,6 +104,9 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		output = ""
 	} else {
 		output = strings.Join(newLines, "\n")
+	}
+	if noTrailingNewline && strings.HasSuffix(output, "\n") {
+		output = strings.TrimSuffix(output, "\n")
 	}
 
 	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), filepath.Base(absPath)+".*.tmp")
@@ -115,7 +124,7 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		_ = os.Remove(tmpPath)
 		return tools.Errorf("failed to close temp file: %s", err)
 	}
-	if err := os.Chmod(tmpPath, 0644); err != nil {
+	if err := os.Chmod(tmpPath, originalMode); err != nil {
 		_ = os.Remove(tmpPath)
 		return tools.Errorf("failed to set file permissions: %s", err)
 	}
@@ -141,11 +150,12 @@ type diffLine struct {
 }
 
 type hunk struct {
-	oldStart int
-	oldCount int
-	newStart int
-	newCount int
-	lines    []diffLine
+	oldStart       int
+	oldCount       int
+	newStart       int
+	newCount       int
+	lines          []diffLine
+	noNewlineAtEnd bool
 }
 
 func parsePatch(patch string) ([]hunk, error) {
@@ -173,7 +183,13 @@ func parsePatch(patch string) ([]hunk, error) {
 		}
 
 		if line == "\\ No newline at end of file" {
-			// Not tracked; we preserve the original file's trailing newline state.
+			// The marker is emitted when the last line of a hunk (on either
+			// or both sides) lacks a trailing newline. We record it on the
+			// hunk and use it for the new file when the hunk contributes the
+			// final lines of the output. This is a best-effort interpretation:
+			// if the marker refers only to the old side of the last hunk, the
+			// output may incorrectly lose its trailing newline.
+			current.noNewlineAtEnd = true
 			continue
 		}
 
@@ -213,37 +229,6 @@ func parseHunkHeader(line string) (hunk, error) {
 		return hunk{}, fmt.Errorf("invalid hunk ranges: %q", ranges)
 	}
 
-	parseRange := func(s string) (start, count int, err error) {
-		if len(s) < 2 {
-			return 0, 0, fmt.Errorf("invalid range: %q", s)
-		}
-		body := s[1:]
-		idx := strings.Index(body, ",")
-		var startStr, countStr string
-		if idx == -1 {
-			startStr = body
-			countStr = "1"
-		} else {
-			startStr = body[:idx]
-			countStr = body[idx+1:]
-		}
-		start, err = strconv.Atoi(startStr)
-		if err != nil {
-			return 0, 0, fmt.Errorf("invalid range start: %q", startStr)
-		}
-		count, err = strconv.Atoi(countStr)
-		if err != nil {
-			return 0, 0, fmt.Errorf("invalid range count: %q", countStr)
-		}
-		if start == 0 && count != 0 {
-			count = 0
-		}
-		if start < 0 || count < 0 {
-			return 0, 0, fmt.Errorf("negative range: %s", s)
-		}
-		return start, count, nil
-	}
-
 	var h hunk
 	var err error
 	h.oldStart, h.oldCount, err = parseRange(fields[0])
@@ -257,7 +242,38 @@ func parseHunkHeader(line string) (hunk, error) {
 	return h, nil
 }
 
-func applyHunks(original []string, hunks []hunk) ([]string, error) {
+func parseRange(s string) (start, count int, err error) {
+	if len(s) < 2 {
+		return 0, 0, fmt.Errorf("invalid range: %q", s)
+	}
+	body := s[1:]
+	idx := strings.Index(body, ",")
+	var startStr, countStr string
+	if idx == -1 {
+		startStr = body
+		countStr = "1"
+	} else {
+		startStr = body[:idx]
+		countStr = body[idx+1:]
+	}
+	start, err = strconv.Atoi(startStr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid range start: %q", startStr)
+	}
+	count, err = strconv.Atoi(countStr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid range count: %q", countStr)
+	}
+	if start == 0 && count != 0 {
+		count = 0
+	}
+	if start < 0 || count < 0 {
+		return 0, 0, fmt.Errorf("negative range: %s", s)
+	}
+	return start, count, nil
+}
+
+func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
 	sort.Slice(hunks, func(i, j int) bool {
 		return hunks[i].oldStart < hunks[j].oldStart
 	})
@@ -272,17 +288,17 @@ func applyHunks(original []string, hunks []hunk) ([]string, error) {
 		}
 
 		if insertAt < origIdx {
-			return nil, fmt.Errorf("hunk %d overlaps a previous hunk", i+1)
+			return nil, false, fmt.Errorf("hunk %d overlaps a previous hunk", i+1)
 		}
 		if insertAt > len(original) {
-			return nil, fmt.Errorf("hunk %d starts beyond end of file", i+1)
+			return nil, false, fmt.Errorf("hunk %d starts beyond end of file", i+1)
 		}
 
 		result = append(result, original[origIdx:insertAt]...)
 		origIdx = insertAt
 
 		if origIdx+h.oldCount > len(original) {
-			return nil, fmt.Errorf("hunk %d extends past end of file", i+1)
+			return nil, false, fmt.Errorf("hunk %d extends past end of file", i+1)
 		}
 
 		oldConsumed := 0
@@ -292,14 +308,14 @@ func applyHunks(original []string, hunks []hunk) ([]string, error) {
 			switch dl.op {
 			case diffContext:
 				if original[origIdx+oldConsumed] != dl.text {
-					return nil, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
+					return nil, false, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
 				}
 				result = append(result, dl.text)
 				oldConsumed++
 				contextCount++
 			case diffRemove:
 				if original[origIdx+oldConsumed] != dl.text {
-					return nil, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
+					return nil, false, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
 				}
 				oldConsumed++
 			case diffAdd:
@@ -309,15 +325,16 @@ func applyHunks(original []string, hunks []hunk) ([]string, error) {
 		}
 
 		if oldConsumed != h.oldCount {
-			return nil, fmt.Errorf("hunk %d expected %d old lines, got %d", i+1, h.oldCount, oldConsumed)
+			return nil, false, fmt.Errorf("hunk %d expected %d old lines, got %d", i+1, h.oldCount, oldConsumed)
 		}
 		if contextCount+addCount != h.newCount {
-			return nil, fmt.Errorf("hunk %d expected %d new lines, got %d", i+1, h.newCount, contextCount+addCount)
+			return nil, false, fmt.Errorf("hunk %d expected %d new lines, got %d", i+1, h.newCount, contextCount+addCount)
 		}
 
 		origIdx += h.oldCount
 	}
 
 	result = append(result, original[origIdx:]...)
-	return result, nil
+	noTrailingNewline := len(hunks) > 0 && hunks[len(hunks)-1].noNewlineAtEnd
+	return result, noTrailingNewline, nil
 }

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -1,0 +1,306 @@
+package applypatch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/redhat-et/docsclaw/internal/workspace"
+	"github.com/redhat-et/docsclaw/pkg/tools"
+)
+
+type applyPatchTool struct {
+	workspaceDir string
+}
+
+// NewApplyPatchTool creates a new apply patch tool scoped to the given workspace.
+func NewApplyPatchTool(workspaceDir string) tools.Tool {
+	return &applyPatchTool{workspaceDir: workspaceDir}
+}
+
+func (t *applyPatchTool) Name() string { return "apply_patch" }
+func (t *applyPatchTool) Description() string {
+	return "Apply a unified diff patch to a file atomically. " +
+		"All hunks must apply cleanly; otherwise the file is left unchanged."
+}
+func (t *applyPatchTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Path to the file to patch",
+			},
+			"patch": map[string]any{
+				"type":        "string",
+				"description": "Unified diff patch string",
+			},
+		},
+		"required": []string{"path", "patch"},
+	}
+}
+
+func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.ToolResult {
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return tools.Errorf("path is required")
+	}
+
+	patch, ok := args["patch"].(string)
+	if !ok || patch == "" {
+		return tools.Errorf("patch is required")
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return tools.Errorf("failed to resolve path: %s", err)
+	}
+
+	if t.workspaceDir != "" {
+		if !workspace.IsInsideWorkspace(absPath, t.workspaceDir) {
+			return tools.Errorf("Access denied: path outside workspace")
+		}
+	}
+
+	hunks, err := parsePatch(patch)
+	if err != nil {
+		return tools.Errorf("failed to parse patch: %s", err)
+	}
+	if len(hunks) == 0 {
+		return tools.Errorf("no hunks found in patch")
+	}
+
+	original := []byte{}
+	if _, statErr := os.Stat(absPath); statErr == nil {
+		original, err = os.ReadFile(absPath)
+		if err != nil {
+			return tools.Errorf("failed to read file: %s", err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return tools.Errorf("failed to stat file: %s", statErr)
+	}
+
+	originalLines := strings.Split(string(original), "\n")
+	newLines, err := applyHunks(originalLines, hunks)
+	if err != nil {
+		return tools.Errorf("patch failed: %s", err)
+	}
+
+	var output string
+	if len(newLines) == 1 && newLines[0] == "" {
+		// Split of an empty file produces [""]; avoid writing a blank line.
+		output = ""
+	} else {
+		output = strings.Join(newLines, "\n")
+	}
+
+	dir := filepath.Dir(absPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return tools.Errorf("failed to create directory: %s", err)
+	}
+
+	if err := os.WriteFile(absPath, []byte(output), 0644); err != nil {
+		return tools.Errorf("failed to write file: %s", err)
+	}
+
+	return tools.OK(absPath)
+}
+
+type diffOp int
+
+const (
+	diffContext diffOp = iota
+	diffRemove
+	diffAdd
+)
+
+type diffLine struct {
+	op   diffOp
+	text string
+}
+
+type hunk struct {
+	oldStart int
+	oldCount int
+	newStart int
+	newCount int
+	lines    []diffLine
+}
+
+func parsePatch(patch string) ([]hunk, error) {
+	var hunks []hunk
+	var current *hunk
+
+	for _, raw := range strings.Split(patch, "\n") {
+		line := strings.TrimRight(raw, "\r")
+
+		if strings.HasPrefix(line, "@@") {
+			if current != nil {
+				hunks = append(hunks, *current)
+			}
+			newHunk, err := parseHunkHeader(line)
+			if err != nil {
+				return nil, err
+			}
+			current = &newHunk
+			continue
+		}
+
+		if current == nil {
+			// Ignore everything before the first hunk header.
+			continue
+		}
+
+		if line == "\\ No newline at end of file" {
+			// Not tracked; we preserve the original file's trailing newline state.
+			continue
+		}
+
+		if len(line) == 0 {
+			// Ignore empty lines; a real blank context line is represented as " ".
+			continue
+		}
+
+		switch line[0] {
+		case ' ':
+			current.lines = append(current.lines, diffLine{op: diffContext, text: line[1:]})
+		case '-':
+			current.lines = append(current.lines, diffLine{op: diffRemove, text: line[1:]})
+		case '+':
+			current.lines = append(current.lines, diffLine{op: diffAdd, text: line[1:]})
+		default:
+			// Ignore patch metadata such as file headers.
+		}
+	}
+
+	if current != nil {
+		hunks = append(hunks, *current)
+	}
+
+	return hunks, nil
+}
+
+func parseHunkHeader(line string) (hunk, error) {
+	parts := strings.SplitN(line, "@@", 3)
+	if len(parts) < 3 {
+		return hunk{}, fmt.Errorf("invalid hunk header: %q", line)
+	}
+
+	ranges := strings.TrimSpace(parts[1])
+	fields := strings.Fields(ranges)
+	if len(fields) != 2 {
+		return hunk{}, fmt.Errorf("invalid hunk ranges: %q", ranges)
+	}
+
+	parseRange := func(s string) (start, count int, err error) {
+		if len(s) < 2 {
+			return 0, 0, fmt.Errorf("invalid range: %q", s)
+		}
+		body := s[1:]
+		idx := strings.Index(body, ",")
+		var startStr, countStr string
+		if idx == -1 {
+			startStr = body
+			countStr = "1"
+		} else {
+			startStr = body[:idx]
+			countStr = body[idx+1:]
+		}
+		start, err = strconv.Atoi(startStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range start: %q", startStr)
+		}
+		count, err = strconv.Atoi(countStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid range count: %q", countStr)
+		}
+		if start == 0 && count != 0 {
+			count = 0
+		}
+		if start < 0 || count < 0 {
+			return 0, 0, fmt.Errorf("negative range: %s", s)
+		}
+		return start, count, nil
+	}
+
+	var h hunk
+	var err error
+	h.oldStart, h.oldCount, err = parseRange(fields[0])
+	if err != nil {
+		return hunk{}, err
+	}
+	h.newStart, h.newCount, err = parseRange(fields[1])
+	if err != nil {
+		return hunk{}, err
+	}
+	return h, nil
+}
+
+func applyHunks(original []string, hunks []hunk) ([]string, error) {
+	sort.Slice(hunks, func(i, j int) bool {
+		return hunks[i].oldStart < hunks[j].oldStart
+	})
+
+	result := make([]string, 0, len(original))
+	origIdx := 0
+
+	for i, h := range hunks {
+		insertAt := h.oldStart - 1
+		if h.oldStart == 0 {
+			insertAt = 0
+		}
+
+		if insertAt < origIdx {
+			return nil, fmt.Errorf("hunk %d overlaps a previous hunk", i+1)
+		}
+		if insertAt > len(original) {
+			return nil, fmt.Errorf("hunk %d starts beyond end of file", i+1)
+		}
+
+		result = append(result, original[origIdx:insertAt]...)
+		origIdx = insertAt
+
+		if origIdx+h.oldCount > len(original) {
+			return nil, fmt.Errorf("hunk %d extends past end of file", i+1)
+		}
+
+		oldConsumed := 0
+		contextCount := 0
+		addCount := 0
+		for _, dl := range h.lines {
+			switch dl.op {
+			case diffContext:
+				if original[origIdx+oldConsumed] != dl.text {
+					return nil, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
+				}
+				result = append(result, dl.text)
+				oldConsumed++
+				contextCount++
+			case diffRemove:
+				if original[origIdx+oldConsumed] != dl.text {
+					return nil, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
+				}
+				oldConsumed++
+			case diffAdd:
+				result = append(result, dl.text)
+				addCount++
+			}
+		}
+
+		if oldConsumed != h.oldCount {
+			return nil, fmt.Errorf("hunk %d expected %d old lines, got %d", i+1, h.oldCount, oldConsumed)
+		}
+		if contextCount+addCount != h.newCount {
+			return nil, fmt.Errorf("hunk %d expected %d new lines, got %d", i+1, h.newCount, contextCount+addCount)
+		}
+
+		origIdx += h.oldCount
+	}
+
+	result = append(result, original[origIdx:]...)
+	return result, nil
+}

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -55,19 +54,9 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		return tools.Errorf("patch is required")
 	}
 
-	if t.workspaceDir != "" && !filepath.IsAbs(path) {
-		path = filepath.Join(t.workspaceDir, path)
-	}
-
-	absPath, err := filepath.Abs(path)
+	absPath, err := workspace.ResolveWorkspacePath(path, t.workspaceDir)
 	if err != nil {
-		return tools.Errorf("failed to resolve path: %s", err)
-	}
-
-	if t.workspaceDir != "" {
-		if !workspace.IsInsideWorkspace(absPath, t.workspaceDir) {
-			return tools.Errorf("Access denied: path outside workspace")
-		}
+		return tools.Errorf("%s", err)
 	}
 
 	hunks, err := parsePatch(patch)

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -81,8 +81,14 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		return tools.Errorf("failed to read file: %s", err)
 	}
 
-	originalLines := strings.Split(string(original), "\n")
-	newLines, noTrailingNewline, err := applyHunks(originalLines, hunks)
+	originalText := string(original)
+	originalLines := strings.Split(originalText, "\n")
+	originalHadTrailingNewline := strings.HasSuffix(originalText, "\n")
+	if originalHadTrailingNewline && len(originalLines) > 0 {
+		// Drop the trailing empty element so strings.Join produces the correct text.
+		originalLines = originalLines[:len(originalLines)-1]
+	}
+	newLines, noTrailingNewline, oldNoNewline, err := applyHunks(originalLines, hunks)
 	if err != nil {
 		return tools.Errorf("patch failed: %s", err)
 	}
@@ -94,8 +100,10 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 	} else {
 		output = strings.Join(newLines, "\n")
 	}
-	if noTrailingNewline && strings.HasSuffix(output, "\n") {
+	if noTrailingNewline {
 		output = strings.TrimSuffix(output, "\n")
+	} else if originalHadTrailingNewline || oldNoNewline {
+		output += "\n"
 	}
 
 	if err := fileutil.WriteFileAtomically(absPath, []byte(output), originalMode); err != nil {
@@ -124,14 +132,21 @@ type hunk struct {
 	newStart       int
 	newCount       int
 	lines          []diffLine
-	noNewlineAtEnd bool
+	oldNoNewline   bool
+	newNoNewline   bool
 }
 
 func parsePatch(patch string) ([]hunk, error) {
 	var hunks []hunk
 	var current *hunk
 
-	for _, raw := range strings.Split(patch, "\n") {
+	lines := strings.Split(patch, "\n")
+	// Ignore the trailing empty element produced when the patch ends with a newline.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	for _, raw := range lines {
 		line := strings.TrimRight(raw, "\r")
 
 		if strings.HasPrefix(line, "@@") {
@@ -152,18 +167,36 @@ func parsePatch(patch string) ([]hunk, error) {
 		}
 
 		if line == "\\ No newline at end of file" {
-			// The marker is emitted when the last line of a hunk (on either
-			// or both sides) lacks a trailing newline. We record it on the
-			// hunk and use it for the new file when the hunk contributes the
-			// final lines of the output. This is a best-effort interpretation:
-			// if the marker refers only to the old side of the last hunk, the
-			// output may incorrectly lose its trailing newline.
-			current.noNewlineAtEnd = true
+			// The marker is emitted when the preceding line (on either or both
+			// sides) lacks a trailing newline. Walk backward to find the most
+			// recent change line to decide which side the marker applies to. In
+			// a remove/add pair, the marker that appears once refers to the
+			// removed (old) line unless a second marker follows the added line.
+			for i := len(current.lines) - 1; i >= 0; i-- {
+				switch current.lines[i].op {
+				case diffRemove:
+					current.oldNoNewline = true
+					goto markerDone
+				case diffAdd:
+					current.newNoNewline = true
+					goto markerDone
+				case diffContext:
+					current.oldNoNewline = true
+					current.newNoNewline = true
+					goto markerDone
+				}
+			}
+			// No prior line in the hunk; conservatively apply to both sides.
+			current.oldNoNewline = true
+			current.newNoNewline = true
+		markerDone:
 			continue
 		}
 
 		if len(line) == 0 {
-			// Ignore empty lines; a real blank context line is represented as " ".
+			// Blank lines inside a hunk are context. Only the trailing element
+			// produced by strings.Split after the final newline is skipped here.
+			current.lines = append(current.lines, diffLine{op: diffContext, text: ""})
 			continue
 		}
 
@@ -242,7 +275,7 @@ func parseRange(s string) (start, count int, err error) {
 	return start, count, nil
 }
 
-func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
+func applyHunks(original []string, hunks []hunk) ([]string, bool, bool, error) {
 	result := make([]string, 0, len(original))
 	origIdx := 0
 
@@ -253,17 +286,17 @@ func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
 		}
 
 		if insertAt < origIdx {
-			return nil, false, fmt.Errorf("hunk %d is out of order or overlaps a previous hunk", i+1)
+			return nil, false, false, fmt.Errorf("hunk %d is out of order or overlaps a previous hunk", i+1)
 		}
 		if insertAt > len(original) {
-			return nil, false, fmt.Errorf("hunk %d starts beyond end of file", i+1)
+			return nil, false, false, fmt.Errorf("hunk %d starts beyond end of file", i+1)
 		}
 
 		result = append(result, original[origIdx:insertAt]...)
 		origIdx = insertAt
 
 		if origIdx+h.oldCount > len(original) {
-			return nil, false, fmt.Errorf("hunk %d extends past end of file", i+1)
+			return nil, false, false, fmt.Errorf("hunk %d extends past end of file", i+1)
 		}
 
 		oldConsumed := 0
@@ -272,15 +305,21 @@ func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
 		for _, dl := range h.lines {
 			switch dl.op {
 			case diffContext:
+				if origIdx+oldConsumed >= len(original) {
+					return nil, false, false, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
+				}
 				if original[origIdx+oldConsumed] != dl.text {
-					return nil, false, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
+					return nil, false, false, fmt.Errorf("hunk %d context mismatch at line %d", i+1, origIdx+oldConsumed+1)
 				}
 				result = append(result, dl.text)
 				oldConsumed++
 				contextCount++
 			case diffRemove:
+				if origIdx+oldConsumed >= len(original) {
+					return nil, false, false, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
+				}
 				if original[origIdx+oldConsumed] != dl.text {
-					return nil, false, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
+					return nil, false, false, fmt.Errorf("hunk %d removal mismatch at line %d", i+1, origIdx+oldConsumed+1)
 				}
 				oldConsumed++
 			case diffAdd:
@@ -290,16 +329,19 @@ func applyHunks(original []string, hunks []hunk) ([]string, bool, error) {
 		}
 
 		if oldConsumed != h.oldCount {
-			return nil, false, fmt.Errorf("hunk %d expected %d old lines, got %d", i+1, h.oldCount, oldConsumed)
+			return nil, false, false, fmt.Errorf("hunk %d expected %d old lines, got %d", i+1, h.oldCount, oldConsumed)
 		}
 		if contextCount+addCount != h.newCount {
-			return nil, false, fmt.Errorf("hunk %d expected %d new lines, got %d", i+1, h.newCount, contextCount+addCount)
+			return nil, false, false, fmt.Errorf("hunk %d expected %d new lines, got %d", i+1, h.newCount, contextCount+addCount)
 		}
 
 		origIdx += h.oldCount
 	}
 
 	result = append(result, original[origIdx:]...)
-	noTrailingNewline := len(hunks) > 0 && hunks[len(hunks)-1].noNewlineAtEnd
-	return result, noTrailingNewline, nil
+	lastHunk := len(hunks) - 1
+	if lastHunk < 0 {
+		return result, false, false, nil
+	}
+	return result, hunks[lastHunk].newNoNewline, hunks[lastHunk].oldNoNewline, nil
 }

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/redhat-et/docsclaw/internal/fileutil"
 	"github.com/redhat-et/docsclaw/internal/workspace"
 	"github.com/redhat-et/docsclaw/pkg/tools"
 )
@@ -109,27 +110,7 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		output = strings.TrimSuffix(output, "\n")
 	}
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), filepath.Base(absPath)+".*.tmp")
-	if err != nil {
-		return tools.Errorf("failed to create temp file: %s", err)
-	}
-	tmpPath := tmpFile.Name()
-
-	if _, err := tmpFile.WriteString(output); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to write file: %s", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to close temp file: %s", err)
-	}
-	if err := os.Chmod(tmpPath, originalMode); err != nil {
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to set file permissions: %s", err)
-	}
-	if err := os.Rename(tmpPath, absPath); err != nil {
-		_ = os.Remove(tmpPath)
+	if err := fileutil.WriteFileAtomically(absPath, []byte(output), originalMode); err != nil {
 		return tools.Errorf("failed to apply patch: %s", err)
 	}
 

--- a/internal/applypatch/applypatch.go
+++ b/internal/applypatch/applypatch.go
@@ -33,7 +33,7 @@ func (t *applyPatchTool) Parameters() map[string]any {
 		"properties": map[string]any{
 			"path": map[string]any{
 				"type":        "string",
-				"description": "Path to the file to patch",
+				"description": "Path to the file to patch within the workspace. Relative paths are resolved against the workspace directory.",
 			},
 			"patch": map[string]any{
 				"type":        "string",
@@ -55,6 +55,10 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		return tools.Errorf("patch is required")
 	}
 
+	if t.workspaceDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(t.workspaceDir, path)
+	}
+
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return tools.Errorf("failed to resolve path: %s", err)
@@ -74,14 +78,12 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		return tools.Errorf("no hunks found in patch")
 	}
 
-	original := []byte{}
-	if _, statErr := os.Stat(absPath); statErr == nil {
-		original, err = os.ReadFile(absPath)
-		if err != nil {
-			return tools.Errorf("failed to read file: %s", err)
+	original, err := os.ReadFile(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return tools.Errorf("file does not exist: %s", absPath)
 		}
-	} else if !os.IsNotExist(statErr) {
-		return tools.Errorf("failed to stat file: %s", statErr)
+		return tools.Errorf("failed to read file: %s", err)
 	}
 
 	originalLines := strings.Split(string(original), "\n")
@@ -98,16 +100,31 @@ func (t *applyPatchTool) Execute(_ context.Context, args map[string]any) *tools.
 		output = strings.Join(newLines, "\n")
 	}
 
-	dir := filepath.Dir(absPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return tools.Errorf("failed to create directory: %s", err)
+	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), filepath.Base(absPath)+".*.tmp")
+	if err != nil {
+		return tools.Errorf("failed to create temp file: %s", err)
 	}
+	tmpPath := tmpFile.Name()
 
-	if err := os.WriteFile(absPath, []byte(output), 0644); err != nil {
+	if _, err := tmpFile.WriteString(output); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
 		return tools.Errorf("failed to write file: %s", err)
 	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to close temp file: %s", err)
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to set file permissions: %s", err)
+	}
+	if err := os.Rename(tmpPath, absPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to apply patch: %s", err)
+	}
 
-	return tools.OK(absPath)
+	return tools.OK("Patched " + absPath)
 }
 
 type diffOp int

--- a/internal/applypatch/applypatch_test.go
+++ b/internal/applypatch/applypatch_test.go
@@ -35,8 +35,8 @@ func TestApplyPatchCleanApply(t *testing.T) {
 	if result.Error {
 		t.Fatalf("unexpected error: %s", result.Output)
 	}
-	if !strings.Contains(result.Output, path) {
-		t.Fatalf("expected result to contain path, got %q", result.Output)
+	if result.Output != "Patched "+path {
+		t.Fatalf("expected success message %q, got %q", "Patched "+path, result.Output)
 	}
 
 	data, err := os.ReadFile(path)
@@ -110,5 +110,76 @@ func TestApplyPatchWorkspaceEscapeBlocked(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "workspace") {
 		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+}
+
+func TestApplyPatchMissingFileReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "missing.txt")
+
+	patch := strings.Join([]string{
+		"--- a/missing.txt",
+		"+++ b/missing.txt",
+		"@@ -1,1 +1,1 @@",
+		"-old",
+		"+new",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(result.Output, "does not exist") {
+		t.Fatalf("expected missing file error, got %q", result.Output)
+	}
+}
+
+func TestApplyPatchRelativePathResolvedAgainstWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	relPath := "subdir/file.txt"
+	absPath := filepath.Join(dir, relPath)
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(absPath, []byte("line1\nline2\nline3\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/subdir/file.txt",
+		"+++ b/subdir/file.txt",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		" line3",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  relPath,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if result.Output != "Patched "+absPath {
+		t.Fatalf("expected success message %q, got %q", "Patched "+absPath, result.Output)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline2modified\nline3\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
 	}
 }

--- a/internal/applypatch/applypatch_test.go
+++ b/internal/applypatch/applypatch_test.go
@@ -341,6 +341,87 @@ func TestApplyPatchRejectsOutOfOrderHunks(t *testing.T) {
 	}
 }
 
+func TestApplyPatchBlankContextLine(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	original := "line1\n\nline3\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		" ",
+		"-line3",
+		"+line3modified",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\n\nline3modified\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
+func TestApplyPatchOldSideOnlyNoNewlineMarker(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	// Original file has no trailing newline.
+	original := "line1\nline2"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Replace the last line; the no-newline marker follows the removed line, so
+	// it applies only to the old side. The added line should keep a trailing newline.
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,2 +1,2 @@",
+		" line1",
+		"-line2",
+		"\\ No newline at end of file",
+		"+line2modified",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline2modified\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
 func TestApplyPatchRejectsMalformedHunkHeader(t *testing.T) {
 	dir := t.TempDir()
 	tool := NewApplyPatchTool(dir)

--- a/internal/applypatch/applypatch_test.go
+++ b/internal/applypatch/applypatch_test.go
@@ -297,6 +297,93 @@ func TestApplyPatchNoNewlineAtEndOfFile(t *testing.T) {
 	}
 }
 
+func TestApplyPatchRejectsOutOfOrderHunks(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	original := "line1\nline2\nline3\nline4\nline5\nline6\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -5,2 +5,2 @@",
+		" line5",
+		"-line6",
+		"+line6modified",
+		"@@ -1,2 +1,2 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for out-of-order hunks")
+	}
+	if !strings.Contains(result.Output, "out of order or overlaps a previous hunk") {
+		t.Fatalf("expected out of order error, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("file should be unchanged, expected %q, got %q", original, string(data))
+	}
+}
+
+func TestApplyPatchRejectsMalformedHunkHeader(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	original := "line1\nline2\nline3\nline4\nline5\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -0,5 +0,5 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		" line3",
+		" line4",
+		" line5",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for malformed hunk header")
+	}
+	if !strings.Contains(result.Output, "invalid range") {
+		t.Fatalf("expected invalid range error, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("file should be unchanged, expected %q, got %q", original, string(data))
+	}
+}
+
 func TestApplyPatchRelativePathResolvedAgainstWorkspace(t *testing.T) {
 	dir := t.TempDir()
 	tool := NewApplyPatchTool(dir)

--- a/internal/applypatch/applypatch_test.go
+++ b/internal/applypatch/applypatch_test.go
@@ -139,6 +139,164 @@ func TestApplyPatchMissingFileReturnsError(t *testing.T) {
 	}
 }
 
+func TestApplyPatchPreservesFileMode(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "script.sh")
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho hello\n"), 0755); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/script.sh",
+		"+++ b/script.sh",
+		"@@ -1,2 +1,2 @@",
+		" #!/bin/sh",
+		"-echo hello",
+		"+echo world",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Fatalf("expected mode 0755, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestApplyPatchMultiHunk(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	original := "line1\nline2\nline3\nline4\nline5\nline6\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,2 +1,2 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		"@@ -5,2 +5,2 @@",
+		" line5",
+		"-line6",
+		"+line6modified",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline2modified\nline3\nline4\nline5\nline6modified\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
+func TestApplyPatchSymlinkWorkspaceEscapeBlocked(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	outsideFile := filepath.Join(dir, "..", "outside.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret\n"), 0644); err != nil {
+		t.Fatalf("failed to create outside file: %v", err)
+	}
+
+	linkPath := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/link.txt",
+		"+++ b/link.txt",
+		"@@ -1,1 +1,1 @@",
+		"-secret",
+		"+modified",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  linkPath,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for symlink escaping workspace")
+	}
+	if !strings.Contains(result.Output, "workspace") {
+		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(outsideFile)
+	if err != nil {
+		t.Fatalf("failed to read outside file: %v", err)
+	}
+	if string(data) != "secret\n" {
+		t.Fatalf("outside file should be unchanged, got %q", string(data))
+	}
+}
+
+func TestApplyPatchNoNewlineAtEndOfFile(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("line1\nline2\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,2 +1,2 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		"\\ No newline at end of file",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline2modified"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
 func TestApplyPatchRelativePathResolvedAgainstWorkspace(t *testing.T) {
 	dir := t.TempDir()
 	tool := NewApplyPatchTool(dir)

--- a/internal/applypatch/applypatch_test.go
+++ b/internal/applypatch/applypatch_test.go
@@ -1,0 +1,114 @@
+package applypatch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyPatchCleanApply(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("line1\nline2\nline3\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		"-line2",
+		"+line2modified",
+		" line3",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, path) {
+		t.Fatalf("expected result to contain path, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "line1\nline2modified\nline3\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
+func TestApplyPatchFailedHunkReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	original := "line1\nline2\nline3\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	patch := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1,3 +1,3 @@",
+		" line1",
+		"-wrongline",
+		"+replacement",
+		" line3",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for failed hunk")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) != original {
+		t.Fatalf("file should be unchanged, expected %q, got %q", original, string(data))
+	}
+}
+
+func TestApplyPatchWorkspaceEscapeBlocked(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewApplyPatchTool(dir)
+	path := filepath.Join(dir, "..", "escaped.txt")
+
+	patch := strings.Join([]string{
+		"--- a/escaped.txt",
+		"+++ b/escaped.txt",
+		"@@ -1,1 +1,1 @@",
+		"-old",
+		"+new",
+		"",
+	}, "\n")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  path,
+		"patch": patch,
+	})
+	if !result.Error {
+		t.Fatal("expected error for path outside workspace")
+	}
+	if !strings.Contains(result.Output, "workspace") {
+		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -437,7 +437,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Register additional tools and skills when in phase 2 mode
 	if toolRegistry != nil {
-		// Register aliases first
+		// Register aliases first. Alias conflicts are logged but not fatal:
+		// the canonical tools are still usable, so the agent can function.
 		if err := toolRegistry.RegisterAlias("read", "read_file"); err != nil {
 			log.Warn("failed to register tool alias", "alias", "read", "error", err)
 		}
@@ -448,7 +449,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 			log.Warn("failed to register tool alias", "alias", "terminal", "error", err)
 		}
 
-		// Register existing tools
+		// Register existing tools. Missing canonical tools are fatal because
+		// the agent would be unable to perform basic operations without them.
 		if err := toolRegistry.Register(exec.NewExecTool(exec.ExecConfig{
 			Timeout:   agentCfg.Tools.Exec.Timeout,
 			MaxOutput: agentCfg.Tools.Exec.MaxOutput,

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -307,8 +307,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 			defer func() { _ = mcpMgr.Close() }()
 
 			for _, t := range mcpMgr.Tools() {
-				toolRegistry.RegisterAlwaysAllowed(t)
+				if err := toolRegistry.RegisterAlwaysAllowed(t); err != nil {
+					return fmt.Errorf("failed to register MCP tool %q: %w", t.Name(), err)
+				}
 			}
+
 		}
 	}
 
@@ -446,51 +449,75 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 
 		// Register existing tools
-		toolRegistry.Register(exec.NewExecTool(exec.ExecConfig{
+		if err := toolRegistry.Register(exec.NewExecTool(exec.ExecConfig{
 			Timeout:   agentCfg.Tools.Exec.Timeout,
 			MaxOutput: agentCfg.Tools.Exec.MaxOutput,
-		}))
-		toolRegistry.Register(webfetch.NewWebFetchTool(webfetch.WebFetchConfig{
+		})); err != nil {
+			return fmt.Errorf("failed to register exec tool: %w", err)
+		}
+		if err := toolRegistry.Register(webfetch.NewWebFetchTool(webfetch.WebFetchConfig{
 			AllowedHosts: agentCfg.Tools.WebFetch.AllowedHosts,
-		}))
-		toolRegistry.Register(readfile.NewReadFileTool(workspace))
-		toolRegistry.Register(writefile.NewWriteFileTool(workspace))
-		toolRegistry.Register(searchfiles.NewSearchFilesTool(workspace))
-		toolRegistry.Register(memorytool.NewRememberTool(
+		})); err != nil {
+			return fmt.Errorf("failed to register webfetch tool: %w", err)
+		}
+		if err := toolRegistry.Register(readfile.NewReadFileTool(workspace)); err != nil {
+			return fmt.Errorf("failed to register readfile tool: %w", err)
+		}
+		if err := toolRegistry.Register(writefile.NewWriteFileTool(workspace)); err != nil {
+			return fmt.Errorf("failed to register writefile tool: %w", err)
+		}
+		if err := toolRegistry.Register(searchfiles.NewSearchFilesTool(workspace)); err != nil {
+			return fmt.Errorf("failed to register searchfiles tool: %w", err)
+		}
+		if err := toolRegistry.Register(memorytool.NewRememberTool(
 			memory.NewFileStore(filepath.Join(workspace, "MEMORY.md")),
-		))
+		)); err != nil {
+			return fmt.Errorf("failed to register remember tool: %w", err)
+		}
 
 		if agentCfg.RAG != nil {
 			ragClient, err := rag.NewClient(agentCfg.RAG)
 			if err != nil {
 				return fmt.Errorf("rag: %w", err)
 			}
-			toolRegistry.RegisterAlwaysAllowed(ragsearch.NewRAGSearchTool(
-				ragClient, agentCfg.RAG))
+			if err := toolRegistry.RegisterAlwaysAllowed(ragsearch.NewRAGSearchTool(
+				ragClient, agentCfg.RAG)); err != nil {
+				return fmt.Errorf("failed to register ragsearch tool: %w", err)
+			}
 			log.Info("RAG search enabled",
 				"backend", agentCfg.RAG.Backend,
 				"collection", agentCfg.RAG.Collection)
 		}
 
 		// Register fetch_document tool (uses delegation transport)
-		toolRegistry.Register(fetchdoc.NewFetchDocTool(
+		if err := toolRegistry.Register(fetchdoc.NewFetchDocTool(
 			func(ctx context.Context, docID, token string) (map[string]any, error) {
 				return fetchDocument(ctx, docID, token)
 			},
-		))
+		)); err != nil {
+			return fmt.Errorf("failed to register fetchdoc tool: %w", err)
+		}
 
 		// Register new tools after existing ones
-		toolRegistry.Register(websearch.NewWebSearchTool(websearch.NewDuckDuckGoProvider(httpClient)))
-		toolRegistry.Register(applypatch.NewApplyPatchTool(workspace))
-		toolRegistry.Register(edit.NewEditTool(workspace))
+		if err := toolRegistry.Register(websearch.NewWebSearchTool(websearch.NewDuckDuckGoProvider(httpClient))); err != nil {
+			return fmt.Errorf("failed to register websearch tool: %w", err)
+		}
+		if err := toolRegistry.Register(applypatch.NewApplyPatchTool(workspace)); err != nil {
+			return fmt.Errorf("failed to register applypatch tool: %w", err)
+		}
+		if err := toolRegistry.Register(edit.NewEditTool(workspace)); err != nil {
+			return fmt.Errorf("failed to register edit tool: %w", err)
+		}
 
 		// Register skill loading tool in phase 2
 		if len(discoveredSkills) > 0 {
 			skillsSummary = skills.BuildSummary(discoveredSkills)
 
-			toolRegistry.RegisterAlwaysAllowed(&loadSkillTool{
+			if err := toolRegistry.RegisterAlwaysAllowed(&loadSkillTool{
 				skillsDir: skillsDir,
-			})
+			}); err != nil {
+				return fmt.Errorf("failed to register load_skill tool: %w", err)
+			}
 		}
 
 		log.Info("Tools enabled",

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -19,8 +19,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
+	"github.com/redhat-et/docsclaw/internal/applypatch"
 	"github.com/redhat-et/docsclaw/internal/bridge"
 	"github.com/redhat-et/docsclaw/internal/config"
+	"github.com/redhat-et/docsclaw/internal/edit"
 	"github.com/redhat-et/docsclaw/internal/exec"
 	"github.com/redhat-et/docsclaw/internal/fetchdoc"
 	"github.com/redhat-et/docsclaw/internal/logger"
@@ -34,6 +36,7 @@ import (
 	"github.com/redhat-et/docsclaw/internal/session"
 	"github.com/redhat-et/docsclaw/internal/telemetry"
 	"github.com/redhat-et/docsclaw/internal/webfetch"
+	"github.com/redhat-et/docsclaw/internal/websearch"
 	"github.com/redhat-et/docsclaw/internal/writefile"
 	"github.com/redhat-et/docsclaw/pkg/agentcontext"
 	"github.com/redhat-et/docsclaw/pkg/llm"
@@ -294,20 +297,6 @@ func runServe(cmd *cobra.Command, args []string) error {
 		systemPrompt += fmt.Sprintf(
 			"\n\nYour workspace directory is %s. Always write files there.", workspace)
 
-		toolRegistry.Register(exec.NewExecTool(exec.ExecConfig{
-			Timeout:   agentCfg.Tools.Exec.Timeout,
-			MaxOutput: agentCfg.Tools.Exec.MaxOutput,
-		}))
-		toolRegistry.Register(webfetch.NewWebFetchTool(webfetch.WebFetchConfig{
-			AllowedHosts: agentCfg.Tools.WebFetch.AllowedHosts,
-		}))
-		toolRegistry.Register(readfile.NewReadFileTool(workspace))
-		toolRegistry.Register(writefile.NewWriteFileTool(workspace))
-		toolRegistry.Register(searchfiles.NewSearchFilesTool(workspace))
-		toolRegistry.Register(memorytool.NewRememberTool(
-			memory.NewFileStore(filepath.Join(workspace, "MEMORY.md")),
-		))
-
 		loopCfg = agentCfg.toLoopConfig()
 
 		if len(agentCfg.Tools.MCP) > 0 {
@@ -445,6 +434,32 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Register additional tools and skills when in phase 2 mode
 	if toolRegistry != nil {
+		// Register aliases first
+		if err := toolRegistry.RegisterAlias("read", "read_file"); err != nil {
+			slog.Warn("failed to register tool alias", "alias", "read", "error", err)
+		}
+		if err := toolRegistry.RegisterAlias("write", "write_file"); err != nil {
+			slog.Warn("failed to register tool alias", "alias", "write", "error", err)
+		}
+		if err := toolRegistry.RegisterAlias("terminal", "exec"); err != nil {
+			slog.Warn("failed to register tool alias", "alias", "terminal", "error", err)
+		}
+
+		// Register existing tools
+		toolRegistry.Register(exec.NewExecTool(exec.ExecConfig{
+			Timeout:   agentCfg.Tools.Exec.Timeout,
+			MaxOutput: agentCfg.Tools.Exec.MaxOutput,
+		}))
+		toolRegistry.Register(webfetch.NewWebFetchTool(webfetch.WebFetchConfig{
+			AllowedHosts: agentCfg.Tools.WebFetch.AllowedHosts,
+		}))
+		toolRegistry.Register(readfile.NewReadFileTool(workspace))
+		toolRegistry.Register(writefile.NewWriteFileTool(workspace))
+		toolRegistry.Register(searchfiles.NewSearchFilesTool(workspace))
+		toolRegistry.Register(memorytool.NewRememberTool(
+			memory.NewFileStore(filepath.Join(workspace, "MEMORY.md")),
+		))
+
 		if agentCfg.RAG != nil {
 			ragClient, err := rag.NewClient(agentCfg.RAG)
 			if err != nil {
@@ -463,6 +478,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 				return fetchDocument(ctx, docID, token)
 			},
 		))
+
+		// Register new tools after existing ones
+		toolRegistry.Register(websearch.NewWebSearchTool(websearch.NewDuckDuckGoProvider(httpClient)))
+		toolRegistry.Register(applypatch.NewApplyPatchTool(workspace))
+		toolRegistry.Register(edit.NewEditTool(workspace))
 
 		// Register skill loading tool in phase 2
 		if len(discoveredSkills) > 0 {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -30,6 +30,7 @@ import (
 	"github.com/redhat-et/docsclaw/internal/openaiapi"
 	"github.com/redhat-et/docsclaw/internal/ragsearch"
 	"github.com/redhat-et/docsclaw/internal/readfile"
+	"github.com/redhat-et/docsclaw/internal/searchfiles"
 	"github.com/redhat-et/docsclaw/internal/session"
 	"github.com/redhat-et/docsclaw/internal/telemetry"
 	"github.com/redhat-et/docsclaw/internal/webfetch"
@@ -302,6 +303,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}))
 		toolRegistry.Register(readfile.NewReadFileTool(workspace))
 		toolRegistry.Register(writefile.NewWriteFileTool(workspace))
+		toolRegistry.Register(searchfiles.NewSearchFilesTool(workspace))
 		toolRegistry.Register(memorytool.NewRememberTool(
 			memory.NewFileStore(filepath.Join(workspace, "MEMORY.md")),
 		))

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -306,6 +306,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}
 			defer func() { _ = mcpMgr.Close() }()
 
+			// MCP tools are registered after the OpenClaw/Hermes aliases and
+			// canonical tools. Registry registration rejects names that collide
+			// with existing aliases or canonical tools, so an MCP tool named
+			// read/write/terminal (or their canonical counterparts
+			// read_file/write_file/exec) aborts startup instead of shadowing
+			// the reserved tools.
 			for _, t := range mcpMgr.Tools() {
 				if err := toolRegistry.RegisterAlwaysAllowed(t); err != nil {
 					return fmt.Errorf("failed to register MCP tool %q: %w", t.Name(), err)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -436,13 +436,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if toolRegistry != nil {
 		// Register aliases first
 		if err := toolRegistry.RegisterAlias("read", "read_file"); err != nil {
-			slog.Warn("failed to register tool alias", "alias", "read", "error", err)
+			log.Warn("failed to register tool alias", "alias", "read", "error", err)
 		}
 		if err := toolRegistry.RegisterAlias("write", "write_file"); err != nil {
-			slog.Warn("failed to register tool alias", "alias", "write", "error", err)
+			log.Warn("failed to register tool alias", "alias", "write", "error", err)
 		}
 		if err := toolRegistry.RegisterAlias("terminal", "exec"); err != nil {
-			slog.Warn("failed to register tool alias", "alias", "terminal", "error", err)
+			log.Warn("failed to register tool alias", "alias", "terminal", "error", err)
 		}
 
 		// Register existing tools

--- a/internal/edit/edit.go
+++ b/internal/edit/edit.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/redhat-et/docsclaw/internal/fileutil"
 	"github.com/redhat-et/docsclaw/internal/workspace"
 	"github.com/redhat-et/docsclaw/pkg/tools"
 )
@@ -108,27 +109,7 @@ func (t *editTool) Execute(_ context.Context, args map[string]any) *tools.ToolRe
 	count := strings.Count(content, oldString)
 	replaced := strings.Replace(content, oldString, newString, 1)
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), filepath.Base(absPath)+".*.tmp")
-	if err != nil {
-		return tools.Errorf("failed to create temp file: %s", err)
-	}
-	tmpPath := tmpFile.Name()
-
-	if _, err := tmpFile.WriteString(replaced); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to write file: %s", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to close temp file: %s", err)
-	}
-	if err := os.Chmod(tmpPath, originalMode); err != nil {
-		_ = os.Remove(tmpPath)
-		return tools.Errorf("failed to set file permissions: %s", err)
-	}
-	if err := os.Rename(tmpPath, absPath); err != nil {
-		_ = os.Remove(tmpPath)
+	if err := fileutil.WriteFileAtomically(absPath, []byte(replaced), originalMode); err != nil {
 		return tools.Errorf("failed to apply edit: %s", err)
 	}
 

--- a/internal/edit/edit.go
+++ b/internal/edit/edit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/redhat-et/docsclaw/internal/fileutil"
@@ -69,19 +68,9 @@ func (t *editTool) Execute(_ context.Context, args map[string]any) *tools.ToolRe
 		return tools.Errorf("new_string is required")
 	}
 
-	if t.workspaceDir != "" && !filepath.IsAbs(path) {
-		path = filepath.Join(t.workspaceDir, path)
-	}
-
-	absPath, err := filepath.Abs(path)
+	absPath, err := workspace.ResolveWorkspacePath(path, t.workspaceDir)
 	if err != nil {
-		return tools.Errorf("failed to resolve path: %s", err)
-	}
-
-	if t.workspaceDir != "" {
-		if !workspace.IsInsideWorkspace(absPath, t.workspaceDir) {
-			return tools.Errorf("Access denied: path outside workspace")
-		}
+		return tools.Errorf("%s", err)
 	}
 
 	info, err := os.Stat(absPath)

--- a/internal/edit/edit.go
+++ b/internal/edit/edit.go
@@ -1,0 +1,135 @@
+package edit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-et/docsclaw/internal/workspace"
+	"github.com/redhat-et/docsclaw/pkg/tools"
+)
+
+type editTool struct {
+	workspaceDir string
+}
+
+// NewEditTool creates a new edit tool scoped to the given workspace.
+func NewEditTool(workspaceDir string) tools.Tool {
+	return &editTool{workspaceDir: workspaceDir}
+}
+
+func (t *editTool) Name() string { return "edit" }
+func (t *editTool) Description() string {
+	return "Replace the first occurrence of an exact string in a file. " +
+		"If the old string occurs multiple times, only the first is replaced " +
+		"and a warning is returned."
+}
+func (t *editTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Path to the file to edit. Relative paths are resolved against the workspace directory.",
+			},
+			"old_string": map[string]any{
+				"type":        "string",
+				"description": "Exact string to replace",
+			},
+			"new_string": map[string]any{
+				"type":        "string",
+				"description": "Replacement string",
+			},
+		},
+		"required": []string{"path", "old_string", "new_string"},
+	}
+}
+
+func (t *editTool) Execute(_ context.Context, args map[string]any) *tools.ToolResult {
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return tools.Errorf("path is required")
+	}
+
+	oldString, ok := args["old_string"].(string)
+	if !ok {
+		return tools.Errorf("old_string is required")
+	}
+	if oldString == "" {
+		return tools.Errorf("old_string must not be empty")
+	}
+
+	newString, ok := args["new_string"].(string)
+	if !ok {
+		return tools.Errorf("new_string is required")
+	}
+
+	if t.workspaceDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(t.workspaceDir, path)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return tools.Errorf("failed to resolve path: %s", err)
+	}
+
+	if t.workspaceDir != "" {
+		if !workspace.IsInsideWorkspace(absPath, t.workspaceDir) {
+			return tools.Errorf("Access denied: path outside workspace")
+		}
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return tools.Errorf("file does not exist: %s", absPath)
+		}
+		return tools.Errorf("failed to stat file: %s", err)
+	}
+	originalMode := info.Mode().Perm()
+
+	original, err := os.ReadFile(absPath)
+	if err != nil {
+		return tools.Errorf("failed to read file: %s", err)
+	}
+
+	content := string(original)
+	if !strings.Contains(content, oldString) {
+		return tools.Errorf("old_string not found in file: %s", absPath)
+	}
+
+	count := strings.Count(content, oldString)
+	replaced := strings.Replace(content, oldString, newString, 1)
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(absPath), filepath.Base(absPath)+".*.tmp")
+	if err != nil {
+		return tools.Errorf("failed to create temp file: %s", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.WriteString(replaced); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to write file: %s", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to close temp file: %s", err)
+	}
+	if err := os.Chmod(tmpPath, originalMode); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to set file permissions: %s", err)
+	}
+	if err := os.Rename(tmpPath, absPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return tools.Errorf("failed to apply edit: %s", err)
+	}
+
+	output := fmt.Sprintf("Edited %s", absPath)
+	if count > 1 {
+		output += fmt.Sprintf("\nWarning: %d occurrences of old_string found; only the first was replaced", count)
+	}
+	return tools.OK(output)
+}

--- a/internal/edit/edit.go
+++ b/internal/edit/edit.go
@@ -16,6 +16,8 @@ type editTool struct {
 }
 
 // NewEditTool creates a new edit tool scoped to the given workspace.
+// An empty workspaceDir disables workspace sandboxing, allowing absolute
+// paths anywhere on the filesystem (consistent with read_file/write_file).
 func NewEditTool(workspaceDir string) tools.Tool {
 	return &editTool{workspaceDir: workspaceDir}
 }
@@ -87,6 +89,9 @@ func (t *editTool) Execute(_ context.Context, args map[string]any) *tools.ToolRe
 			return tools.Errorf("file does not exist: %s", absPath)
 		}
 		return tools.Errorf("failed to stat file: %s", err)
+	}
+	if !info.Mode().IsRegular() {
+		return tools.Errorf("path is not a regular file: %s", absPath)
 	}
 	originalMode := info.Mode().Perm()
 

--- a/internal/edit/edit_test.go
+++ b/internal/edit/edit_test.go
@@ -156,6 +156,136 @@ func TestEditToolRelativePathResolvedAgainstWorkspace(t *testing.T) {
 	}
 }
 
+func TestEditToolEmptyOldString(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "",
+		"new_string": "replacement",
+	})
+	if !result.Error {
+		t.Fatal("expected error for empty old_string")
+	}
+	if !strings.Contains(result.Output, "old_string must not be empty") {
+		t.Fatalf("expected old_string must not be empty error, got %q", result.Output)
+	}
+}
+
+func TestEditToolMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "missing.txt")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "old",
+		"new_string": "new",
+	})
+	if !result.Error {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(result.Output, "file does not exist") {
+		t.Fatalf("expected file does not exist error, got %q", result.Output)
+	}
+}
+
+func TestEditToolDirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	subdir := filepath.Join(dir, "subdir")
+
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       subdir,
+		"old_string": "old",
+		"new_string": "new",
+	})
+	if !result.Error {
+		t.Fatal("expected error for directory path")
+	}
+	if !strings.Contains(result.Output, "path is not a regular file") {
+		t.Fatalf("expected not a regular file error, got %q", result.Output)
+	}
+}
+
+func TestEditToolSymlinkEscapeBlocked(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+
+	outsideFile := filepath.Join(dir, "..", "outside.txt")
+	outsideFile, err := filepath.Abs(outsideFile)
+	if err != nil {
+		t.Fatalf("failed to resolve outside file: %v", err)
+	}
+	if err := os.WriteFile(outsideFile, []byte("secret\n"), 0644); err != nil {
+		t.Fatalf("failed to create outside file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(outsideFile) })
+
+	linkPath := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       linkPath,
+		"old_string": "secret",
+		"new_string": "exposed",
+	})
+	if !result.Error {
+		t.Fatal("expected error for symlink workspace escape")
+	}
+	if !strings.Contains(result.Output, "outside workspace") {
+		t.Fatalf("expected outside workspace error, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(outsideFile)
+	if err != nil {
+		t.Fatalf("failed to read outside file: %v", err)
+	}
+	if string(data) != "secret\n" {
+		t.Fatalf("outside file should be unchanged, got %q", string(data))
+	}
+}
+
+func TestEditToolEmptyWorkspaceAllowsAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool("")
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "world",
+		"new_string": "universe",
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "hello universe\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+}
+
 func TestEditToolPreservesFileMode(t *testing.T) {
 	dir := t.TempDir()
 	tool := NewEditTool(dir)

--- a/internal/edit/edit_test.go
+++ b/internal/edit/edit_test.go
@@ -1,0 +1,184 @@
+package edit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEditToolSuccess(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("hello world\nline two\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "world",
+		"new_string": "universe",
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "hello universe\nline two\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+	if !strings.HasPrefix(result.Output, "Edited ") {
+		t.Fatalf("expected success output, got %q", result.Output)
+	}
+}
+
+func TestEditToolMissingOldString(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "missing",
+		"new_string": "replacement",
+	})
+	if !result.Error {
+		t.Fatal("expected error for missing old_string")
+	}
+	if !strings.Contains(result.Output, "old_string not found") {
+		t.Fatalf("expected old_string not found error, got %q", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) != "hello world\n" {
+		t.Fatalf("file should be unchanged, got %q", string(data))
+	}
+}
+
+func TestEditToolMultipleOccurrencesWarns(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("foo bar foo baz\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "foo",
+		"new_string": "qux",
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "qux bar foo baz\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+	if !strings.Contains(result.Output, "Warning") {
+		t.Fatalf("expected warning in output, got %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "2") {
+		t.Fatalf("expected occurrence count in output, got %q", result.Output)
+	}
+}
+
+func TestEditToolWorkspaceEscapeBlocked(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "..", "escaped.txt")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "old",
+		"new_string": "new",
+	})
+	if !result.Error {
+		t.Fatal("expected error for path outside workspace")
+	}
+	if !strings.Contains(result.Output, "outside workspace") {
+		t.Fatalf("expected outside workspace error, got %q", result.Output)
+	}
+}
+
+func TestEditToolRelativePathResolvedAgainstWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	relPath := "subdir/file.txt"
+	absPath := filepath.Join(dir, relPath)
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if err := os.WriteFile(absPath, []byte("alpha\nbeta\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       relPath,
+		"old_string": "beta",
+		"new_string": "gamma",
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	expected := "alpha\ngamma\n"
+	if string(data) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(data))
+	}
+	if !strings.Contains(result.Output, absPath) {
+		t.Fatalf("expected absolute path in output, got %q", result.Output)
+	}
+}
+
+func TestEditToolPreservesFileMode(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewEditTool(dir)
+	path := filepath.Join(dir, "script.sh")
+
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho hello\n"), 0755); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "echo hello",
+		"new_string": "echo world",
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Fatalf("expected mode 0755, got %04o", info.Mode().Perm())
+	}
+}

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -1,0 +1,41 @@
+package fileutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteFileAtomically writes content to target atomically using a temp file in
+// the target's directory. It preserves the given file mode, closes the temp
+// file before renaming, and removes the temp file on any error.
+func WriteFileAtomically(target string, content []byte, mode os.FileMode) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(target), filepath.Base(target)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
+
+	if _, err := tmpFile.Write(content); err != nil {
+		_ = tmpFile.Close()
+		cleanup()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		cleanup()
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+	return nil
+}

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -1,0 +1,53 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomically(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+
+	if err := WriteFileAtomically(target, []byte("hello"), 0640); err != nil {
+		t.Fatalf("WriteFileAtomically failed: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read target: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected content %q, got %q", "hello", string(content))
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("failed to stat target: %v", err)
+	}
+	if info.Mode().Perm() != 0640 {
+		t.Fatalf("expected mode 0640, got %o", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileAtomicallyOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+
+	if err := os.WriteFile(target, []byte("original"), 0600); err != nil {
+		t.Fatalf("failed to write original file: %v", err)
+	}
+
+	if err := WriteFileAtomically(target, []byte("updated"), 0644); err != nil {
+		t.Fatalf("WriteFileAtomically failed: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read target: %v", err)
+	}
+	if string(content) != "updated" {
+		t.Fatalf("expected content %q, got %q", "updated", string(content))
+	}
+}

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -101,6 +101,11 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 		return tools.Errorf("invalid regex: %s", err)
 	}
 
+	// search_files shells out to ripgrep; make sure it is available at runtime.
+	if _, err := exec.LookPath("rg"); err != nil {
+		return tools.Errorf("ripgrep (rg) is not installed; search_files requires it")
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -86,15 +85,9 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 		filePattern = v
 	}
 
-	searchPath := path
-	if t.workspaceDir != "" && !filepath.IsAbs(path) {
-		searchPath = filepath.Join(t.workspaceDir, path)
-	}
-
-	if t.workspaceDir != "" {
-		if !workspace.IsInsideWorkspace(searchPath, t.workspaceDir) {
-			return tools.Errorf("Access denied: path outside workspace")
-		}
+	searchPath, err := workspace.ResolveWorkspacePath(path, t.workspaceDir)
+	if err != nil {
+		return tools.Errorf("%s", err)
 	}
 
 	if _, err := regexp.Compile(regex); err != nil {

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -1,0 +1,142 @@
+package searchfiles
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/redhat-et/docsclaw/internal/workspace"
+	"github.com/redhat-et/docsclaw/pkg/tools"
+)
+
+const maxOutput = 50000
+
+// searchFilesTool searches file contents with ripgrep.
+type searchFilesTool struct {
+	workspaceDir string
+}
+
+// NewSearchFilesTool creates a new search files tool scoped to the given workspace.
+func NewSearchFilesTool(workspaceDir string) tools.Tool {
+	return &searchFilesTool{workspaceDir: workspaceDir}
+}
+
+func (t *searchFilesTool) Name() string { return "search_files" }
+func (t *searchFilesTool) Description() string {
+	return "Search for a regular expression inside files within a directory. " +
+		"Returns matches as file:line:match."
+}
+func (t *searchFilesTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Directory to search within the workspace",
+			},
+			"regex": map[string]any{
+				"type":        "string",
+				"description": "Regular expression to search for",
+			},
+			"file_pattern": map[string]any{
+				"type":        "string",
+				"description": "Optional glob pattern to filter files (e.g. '*.go')",
+			},
+		},
+		"required": []string{"path", "regex"},
+	}
+}
+
+// rgEvent represents the subset of ripgrep's --json output we care about.
+type rgEvent struct {
+	Type string `json:"type"`
+	Data struct {
+		Path struct {
+			Text string `json:"text"`
+		} `json:"path"`
+		Lines struct {
+			Text string `json:"text"`
+		} `json:"lines"`
+		LineNumber int `json:"line_number"`
+	} `json:"data"`
+}
+
+func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return tools.Errorf("path is required")
+	}
+
+	regex, ok := args["regex"].(string)
+	if !ok || regex == "" {
+		return tools.Errorf("regex is required")
+	}
+
+	var filePattern string
+	if v, ok := args["file_pattern"].(string); ok {
+		filePattern = v
+	}
+
+	if t.workspaceDir != "" {
+		if !workspace.IsInsideWorkspace(path, t.workspaceDir) {
+			return tools.Errorf("Access denied: path outside workspace")
+		}
+	}
+
+	if _, err := regexp.Compile(regex); err != nil {
+		return tools.Errorf("invalid regex: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	rgArgs := []string{"--json"}
+	if filePattern != "" {
+		rgArgs = append(rgArgs, "-g", filePattern)
+	}
+	rgArgs = append(rgArgs, "-e", regex, path)
+
+	cmd := exec.CommandContext(ctx, "rg", rgArgs...)
+	output, err := cmd.CombinedOutput()
+
+	var matches []string
+	if len(output) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(output))
+		for scanner.Scan() {
+			var ev rgEvent
+			if json.Unmarshal(scanner.Bytes(), &ev) != nil {
+				continue
+			}
+			if ev.Type != "match" {
+				continue
+			}
+			line := strings.TrimSpace(ev.Data.Lines.Text)
+			matches = append(matches, fmt.Sprintf("%s:%d:%s", ev.Data.Path.Text, ev.Data.LineNumber, line))
+		}
+	}
+
+	if len(matches) == 0 {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return tools.OK("No matches found.")
+		}
+		if err != nil {
+			return tools.Errorf("search failed: %s", err)
+		}
+		return tools.OK("No matches found.")
+	}
+
+	result := strings.Join(matches, "\n")
+	if len(result) > maxOutput {
+		result = result[:maxOutput] + "\n...(truncated)"
+	}
+
+	return tools.OK(result)
+}

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -162,7 +162,7 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 
 	result := strings.Join(matches, "\n")
 	if len(result) > maxOutput {
-		result = result[:maxOutput] + "\n...(truncated)"
+		result = strings.ToValidUTF8(result[:maxOutput], "") + "\n...(truncated)"
 	}
 
 	return tools.OK(result)

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -93,7 +93,7 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 
 	if t.workspaceDir != "" {
 		if !workspace.IsInsideWorkspace(searchPath, t.workspaceDir) {
-			return tools.Errorf("Access denied: path outside workspace")
+			return tools.Errorf("access denied: path outside workspace")
 		}
 	}
 
@@ -104,7 +104,7 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	rgArgs := []string{"--json"}
+	rgArgs := []string{"--no-config", "--json"}
 	if filePattern != "" {
 		rgArgs = append(rgArgs, "-g", filePattern)
 	}

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -109,17 +109,24 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 	rgArgs = append(rgArgs, "-e", regex, "--", searchPath)
 
 	cmd := exec.CommandContext(ctx, "rg", rgArgs...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	runErr := cmd.Run()
+	stdout, pipeErr := cmd.StdoutPipe()
+	if pipeErr != nil {
+		return tools.Errorf("search failed: %s", pipeErr)
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		return tools.Errorf("search failed: %s", startErr)
+	}
 
 	const maxScanTokenSize = 4 * 1024 * 1024
 	scannerBuf := make([]byte, 0, 64*1024)
 
-	var matches []string
-	scanner := bufio.NewScanner(&stdout)
+	var result strings.Builder
+	truncated := false
+	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(scannerBuf, maxScanTokenSize)
 	for scanner.Scan() {
 		var ev rgEvent
@@ -130,16 +137,38 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 			continue
 		}
 		line := strings.TrimSpace(ev.Data.Lines.Text)
-		matches = append(matches, fmt.Sprintf("%s:%d:%s", ev.Data.Path.Text, ev.Data.LineNumber, line))
+		match := fmt.Sprintf("%s:%d:%s", ev.Data.Path.Text, ev.Data.LineNumber, line)
+
+		sep := ""
+		if result.Len() > 0 {
+			sep = "\n"
+		}
+
+		if result.Len()+len(sep)+len(match) > maxOutput {
+			allowed := maxOutput - result.Len() - len(sep)
+			if allowed > 0 {
+				result.WriteString(sep)
+				result.WriteString(match[:allowed])
+			}
+			truncated = true
+			cancel()
+			break
+		}
+
+		result.WriteString(sep)
+		result.WriteString(match)
 	}
 
 	if scanErr := scanner.Err(); scanErr != nil {
 		return tools.Errorf("search failed: reading rg output: %s", scanErr)
 	}
 
-	if runErr != nil {
+	runErr := cmd.Wait()
+	_ = stdout.Close()
+
+	if runErr != nil && !truncated {
 		var exitErr *exec.ExitError
-		if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1 && stdout.Len() == 0 {
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1 && result.Len() == 0 {
 			return tools.OK("No matches found.")
 		}
 		errMsg := runErr.Error()
@@ -149,14 +178,14 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 		return tools.Errorf("search failed: %s", errMsg)
 	}
 
-	if len(matches) == 0 {
+	if result.Len() == 0 {
 		return tools.OK("No matches found.")
 	}
 
-	result := strings.Join(matches, "\n")
-	if len(result) > maxOutput {
-		result = strings.ToValidUTF8(result[:maxOutput], "") + "\n...(truncated)"
+	output := result.String()
+	if truncated {
+		output = strings.ToValidUTF8(output, "") + "\n...(truncated)"
 	}
 
-	return tools.OK(result)
+	return tools.OK(output)
 }

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -93,7 +93,7 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 
 	if t.workspaceDir != "" {
 		if !workspace.IsInsideWorkspace(searchPath, t.workspaceDir) {
-			return tools.Errorf("access denied: path outside workspace")
+			return tools.Errorf("Access denied: path outside workspace")
 		}
 	}
 

--- a/internal/searchfiles/searchfiles.go
+++ b/internal/searchfiles/searchfiles.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -31,6 +32,7 @@ func NewSearchFilesTool(workspaceDir string) tools.Tool {
 func (t *searchFilesTool) Name() string { return "search_files" }
 func (t *searchFilesTool) Description() string {
 	return "Search for a regular expression inside files within a directory. " +
+		"Relative paths are resolved against the workspace directory. " +
 		"Returns matches as file:line:match."
 }
 func (t *searchFilesTool) Parameters() map[string]any {
@@ -39,7 +41,7 @@ func (t *searchFilesTool) Parameters() map[string]any {
 		"properties": map[string]any{
 			"path": map[string]any{
 				"type":        "string",
-				"description": "Directory to search within the workspace",
+				"description": "Directory to search within the workspace. Relative paths are resolved against the workspace directory.",
 			},
 			"regex": map[string]any{
 				"type":        "string",
@@ -84,8 +86,13 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 		filePattern = v
 	}
 
+	searchPath := path
+	if t.workspaceDir != "" && !filepath.IsAbs(path) {
+		searchPath = filepath.Join(t.workspaceDir, path)
+	}
+
 	if t.workspaceDir != "" {
-		if !workspace.IsInsideWorkspace(path, t.workspaceDir) {
+		if !workspace.IsInsideWorkspace(searchPath, t.workspaceDir) {
 			return tools.Errorf("Access denied: path outside workspace")
 		}
 	}
@@ -101,35 +108,50 @@ func (t *searchFilesTool) Execute(ctx context.Context, args map[string]any) *too
 	if filePattern != "" {
 		rgArgs = append(rgArgs, "-g", filePattern)
 	}
-	rgArgs = append(rgArgs, "-e", regex, path)
+	rgArgs = append(rgArgs, "-e", regex, "--", searchPath)
 
 	cmd := exec.CommandContext(ctx, "rg", rgArgs...)
-	output, err := cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	const maxScanTokenSize = 4 * 1024 * 1024
+	scannerBuf := make([]byte, 0, 64*1024)
 
 	var matches []string
-	if len(output) > 0 {
-		scanner := bufio.NewScanner(bytes.NewReader(output))
-		for scanner.Scan() {
-			var ev rgEvent
-			if json.Unmarshal(scanner.Bytes(), &ev) != nil {
-				continue
-			}
-			if ev.Type != "match" {
-				continue
-			}
-			line := strings.TrimSpace(ev.Data.Lines.Text)
-			matches = append(matches, fmt.Sprintf("%s:%d:%s", ev.Data.Path.Text, ev.Data.LineNumber, line))
+	scanner := bufio.NewScanner(&stdout)
+	scanner.Buffer(scannerBuf, maxScanTokenSize)
+	for scanner.Scan() {
+		var ev rgEvent
+		if json.Unmarshal(scanner.Bytes(), &ev) != nil {
+			continue
 		}
+		if ev.Type != "match" {
+			continue
+		}
+		line := strings.TrimSpace(ev.Data.Lines.Text)
+		matches = append(matches, fmt.Sprintf("%s:%d:%s", ev.Data.Path.Text, ev.Data.LineNumber, line))
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		return tools.Errorf("search failed: reading rg output: %s", scanErr)
+	}
+
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) && exitErr.ExitCode() == 1 && stdout.Len() == 0 {
+			return tools.OK("No matches found.")
+		}
+		errMsg := runErr.Error()
+		if stderr.Len() > 0 {
+			errMsg = fmt.Sprintf("%s: %s", errMsg, strings.TrimSpace(stderr.String()))
+		}
+		return tools.Errorf("search failed: %s", errMsg)
 	}
 
 	if len(matches) == 0 {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return tools.OK("No matches found.")
-		}
-		if err != nil {
-			return tools.Errorf("search failed: %s", err)
-		}
 		return tools.OK("No matches found.")
 	}
 

--- a/internal/searchfiles/searchfiles_test.go
+++ b/internal/searchfiles/searchfiles_test.go
@@ -1,0 +1,80 @@
+package searchfiles
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSearchFilesToolSuccess(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed")
+	}
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+	if err := writeFile(testFile, "package main\n\nfunc main() {\n\thelloWorld()\n}\n"); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":         tmpDir,
+		"regex":        "helloWorld",
+		"file_pattern": "*.go",
+	})
+
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, "test.go:4:helloWorld") {
+		t.Fatalf("expected match 'test.go:4:helloWorld', got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolNoMatches(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed")
+	}
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+	if err := writeFile(testFile, "package main\n"); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  tmpDir,
+		"regex": "notpresent",
+	})
+
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if result.Output != "No matches found." {
+		t.Fatalf("expected 'No matches found.', got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolWorkspaceEscapeBlocked(t *testing.T) {
+	tool := NewSearchFilesTool(t.TempDir())
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  "/etc",
+		"regex": "root",
+	})
+
+	if !result.Error {
+		t.Fatal("expected error for path outside workspace")
+	}
+	if !strings.Contains(result.Output, "outside workspace") {
+		t.Fatalf("expected outside workspace error, got %q", result.Output)
+	}
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/searchfiles/searchfiles_test.go
+++ b/internal/searchfiles/searchfiles_test.go
@@ -243,6 +243,38 @@ func TestSearchFilesToolInvalidRegexEmptyWorkspace(t *testing.T) {
 	}
 }
 
+func TestSearchFilesToolTruncation(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed")
+	}
+
+	tmpDir := t.TempDir()
+	// Generate enough matches to exceed maxOutput.
+	var b strings.Builder
+	for i := 0; i < 1200; i++ {
+		b.WriteString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n")
+	}
+	if err := writeFile(filepath.Join(tmpDir, "big.txt"), b.String()); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  tmpDir,
+		"regex": "a",
+	})
+
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.HasSuffix(result.Output, "\n...(truncated)") {
+		t.Fatalf("expected truncated output, got %q", result.Output)
+	}
+	if len(result.Output) > maxOutput+len("\n...(truncated)") {
+		t.Fatalf("output length %d exceeds limit", len(result.Output))
+	}
+}
+
 func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/internal/searchfiles/searchfiles_test.go
+++ b/internal/searchfiles/searchfiles_test.go
@@ -205,6 +205,44 @@ func TestSearchFilesToolSymlinkEscapeBlocked(t *testing.T) {
 	}
 }
 
+// Runtime requirement: search_files shells out to ripgrep (rg). Production
+// container images install the ripgrep package; if rg is missing from PATH,
+// Execute returns a clear error.
+func TestSearchFilesToolMissingRipgrep(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool := NewSearchFilesTool(tmpDir)
+
+	// Hide rg from PATH so LookPath cannot find it.
+	t.Setenv("PATH", "")
+
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  ".",
+		"regex": "foo",
+	})
+
+	if !result.Error {
+		t.Fatal("expected error when rg is not available")
+	}
+	if !strings.Contains(result.Output, "ripgrep (rg) is not installed") {
+		t.Fatalf("expected ripgrep missing error, got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolInvalidRegexEmptyWorkspace(t *testing.T) {
+	tool := NewSearchFilesTool("")
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  ".",
+		"regex": "[",
+	})
+
+	if !result.Error {
+		t.Fatal("expected error for invalid regex")
+	}
+	if !strings.Contains(result.Output, "invalid regex") {
+		t.Fatalf("expected invalid regex error, got %q", result.Output)
+	}
+}
+
 func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/internal/searchfiles/searchfiles_test.go
+++ b/internal/searchfiles/searchfiles_test.go
@@ -75,6 +75,36 @@ func TestSearchFilesToolWorkspaceEscapeBlocked(t *testing.T) {
 	}
 }
 
+func TestSearchFilesToolRelativeTraversalBlocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	tool := NewSearchFilesTool(tmpDir)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "parent traversal", path: ".."},
+		{name: "nested traversal escape", path: filepath.Join("subdir", "..", "..", filepath.Base(outsideDir))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tool.Execute(context.Background(), map[string]any{
+				"path":  tc.path,
+				"regex": "secret",
+			})
+			if !result.Error {
+				t.Fatal("expected error for relative path outside workspace")
+			}
+			if !strings.Contains(result.Output, "outside workspace") {
+				t.Fatalf("expected outside workspace error, got %q", result.Output)
+			}
+		})
+	}
+}
+
 func TestSearchFilesToolInvalidRegex(t *testing.T) {
 	tool := NewSearchFilesTool(t.TempDir())
 	result := tool.Execute(context.Background(), map[string]any{

--- a/internal/searchfiles/searchfiles_test.go
+++ b/internal/searchfiles/searchfiles_test.go
@@ -75,6 +75,106 @@ func TestSearchFilesToolWorkspaceEscapeBlocked(t *testing.T) {
 	}
 }
 
+func TestSearchFilesToolInvalidRegex(t *testing.T) {
+	tool := NewSearchFilesTool(t.TempDir())
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  ".",
+		"regex": "[",
+	})
+
+	if !result.Error {
+		t.Fatal("expected error for invalid regex")
+	}
+	if !strings.Contains(result.Output, "invalid regex") {
+		t.Fatalf("expected invalid regex error, got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolFilePattern(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed")
+	}
+
+	tmpDir := t.TempDir()
+	if err := writeFile(filepath.Join(tmpDir, "a.go"), "foo\n"); err != nil {
+		t.Fatalf("failed to write go file: %v", err)
+	}
+	if err := writeFile(filepath.Join(tmpDir, "a.txt"), "foo\n"); err != nil {
+		t.Fatalf("failed to write txt file: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":         tmpDir,
+		"regex":        "foo",
+		"file_pattern": "*.go",
+	})
+
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, "a.go") {
+		t.Fatalf("expected a.go match, got %q", result.Output)
+	}
+	if strings.Contains(result.Output, "a.txt") {
+		t.Fatalf("did not expect a.txt match, got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolRelativePath(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("rg not installed")
+	}
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+	if err := writeFile(filepath.Join(subDir, "test.go"), "helloWorld\n"); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  "subdir",
+		"regex": "helloWorld",
+	})
+
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, "test.go:1:helloWorld") {
+		t.Fatalf("expected relative path to resolve, got %q", result.Output)
+	}
+}
+
+func TestSearchFilesToolSymlinkEscapeBlocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsideDir := t.TempDir()
+	if err := writeFile(filepath.Join(outsideDir, "secret.txt"), "secret\n"); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+
+	linkPath := filepath.Join(tmpDir, "escape")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	tool := NewSearchFilesTool(tmpDir)
+	result := tool.Execute(context.Background(), map[string]any{
+		"path":  linkPath,
+		"regex": "secret",
+	})
+
+	if !result.Error {
+		t.Fatal("expected error for symlink outside workspace")
+	}
+	if !strings.Contains(result.Output, "outside workspace") {
+		t.Fatalf("expected outside workspace error, got %q", result.Output)
+	}
+}
+
 func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/internal/websearch/duckduckgo.go
+++ b/internal/websearch/duckduckgo.go
@@ -1,0 +1,114 @@
+package websearch
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DuckDuckGoBaseURL is the HTML endpoint used by the DuckDuckGo provider.
+const DuckDuckGoBaseURL = "https://html.duckduckgo.com/html/"
+
+const maxResponseBytes = 1 << 20 // 1 MiB
+
+var (
+	titleRe   = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*>(.*?)</a>`)
+	snippetRe = regexp.MustCompile(`<div[^>]*class="result__snippet"[^>]*>(.*?)</div>`)
+	hrefRe    = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*href="([^"]*)"`)
+)
+
+type duckDuckGoProvider struct {
+	client  *http.Client
+	baseURL string
+}
+
+// NewDuckDuckGoProvider creates a DuckDuckGo search provider.
+func NewDuckDuckGoProvider(client *http.Client) Provider {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &duckDuckGoProvider{
+		client:  client,
+		baseURL: DuckDuckGoBaseURL,
+	}
+}
+
+// Search queries DuckDuckGo and returns parsed results.
+func (p *duckDuckGoProvider) Search(ctx context.Context, query string, numResults int) ([]Result, error) {
+	if numResults <= 0 {
+		numResults = 1
+	}
+
+	form := url.Values{}
+	form.Set("q", query)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "DocsClaw web_search tool (https://github.com/redhat-et/docsclaw)")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return parseDDGResults(string(body), numResults), nil
+}
+
+func parseDDGResults(htmlBody string, limit int) []Result {
+	titles := titleRe.FindAllStringSubmatch(htmlBody, -1)
+	snippets := snippetRe.FindAllStringSubmatch(htmlBody, -1)
+	hrefs := hrefRe.FindAllStringSubmatch(htmlBody, -1)
+
+	count := min(len(titles), len(snippets), len(hrefs), limit)
+	results := make([]Result, 0, count)
+	for i := 0; i < count; i++ {
+		results = append(results, Result{
+			Title:   stripHTML(titles[i][1]),
+			Snippet: stripHTML(snippets[i][1]),
+			URL:     resolveDDGURL(hrefs[i][1]),
+		})
+	}
+	return results
+}
+
+func stripHTML(s string) string {
+	s = html.UnescapeString(s)
+	re := regexp.MustCompile("<[^>]*>")
+	s = re.ReplaceAllString(s, "")
+	return strings.TrimSpace(s)
+}
+
+func resolveDDGURL(href string) string {
+	if strings.HasPrefix(href, "//") {
+		href = "https:" + href
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+	if (u.Host == "duckduckgo.com" || u.Host == "html.duckduckgo.com") && u.Path == "/l/" {
+		if uddg := u.Query().Get("uddg"); uddg != "" {
+			return uddg
+		}
+	}
+	return href
+}

--- a/internal/websearch/duckduckgo.go
+++ b/internal/websearch/duckduckgo.go
@@ -18,9 +18,10 @@ const DuckDuckGoBaseURL = "https://html.duckduckgo.com/html/"
 const maxResponseBytes = 1 << 20 // 1 MiB
 
 var (
-	titleRe   = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*>(.*?)</a>`)
-	snippetRe = regexp.MustCompile(`<div[^>]*class="result__snippet"[^>]*>(.*?)</div>`)
-	hrefRe    = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*href="([^"]*)"`)
+	titleRe     = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*>(.*?)</a>`)
+	snippetRe   = regexp.MustCompile(`<div[^>]*class="result__snippet"[^>]*>(.*?)</div>`)
+	hrefRe      = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*href="([^"]*)"`)
+	stripHTMLRe = regexp.MustCompile("<[^>]*>")
 )
 
 type duckDuckGoProvider struct {
@@ -73,6 +74,10 @@ func (p *duckDuckGoProvider) Search(ctx context.Context, query string, numResult
 	return parseDDGResults(string(body), numResults), nil
 }
 
+// parseDDGResults scrapes DuckDuckGo HTML with regexes. This is inherently
+// fragile and tightly coupled to DuckDuckGo's current markup. The Provider
+// interface allows swapping to a more robust backend (e.g., Brave or Tavily)
+// without changing the tool implementation.
 func parseDDGResults(htmlBody string, limit int) []Result {
 	titles := titleRe.FindAllStringSubmatch(htmlBody, -1)
 	snippets := snippetRe.FindAllStringSubmatch(htmlBody, -1)
@@ -92,8 +97,7 @@ func parseDDGResults(htmlBody string, limit int) []Result {
 
 func stripHTML(s string) string {
 	s = html.UnescapeString(s)
-	re := regexp.MustCompile("<[^>]*>")
-	s = re.ReplaceAllString(s, "")
+	s = stripHTMLRe.ReplaceAllString(s, "")
 	return strings.TrimSpace(s)
 }
 

--- a/internal/websearch/duckduckgo.go
+++ b/internal/websearch/duckduckgo.go
@@ -18,10 +18,15 @@ const DuckDuckGoBaseURL = "https://html.duckduckgo.com/html/"
 const maxResponseBytes = 1 << 20 // 1 MiB
 
 var (
-	titleRe     = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*>(.*?)</a>`)
-	snippetRe   = regexp.MustCompile(`<div[^>]*class="result__snippet"[^>]*>(.*?)</div>`)
-	hrefRe      = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*href="([^"]*)"`)
-	stripHTMLRe = regexp.MustCompile("<[^>]*>")
+	// resultStartRe locates the opening tag of a DuckDuckGo result block.
+	// Each result block is then extracted by balancing nested <div> tags so
+	// that title, snippet, and URL are kept aligned per result even when a
+	// field is missing from one result.
+	resultStartRe = regexp.MustCompile(`<div[^>]*class="result[^"]*"`)
+	titleRe       = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*>(.*?)</a>`)
+	snippetRe     = regexp.MustCompile(`<div[^>]*class="result__snippet"[^>]*>(.*?)</div>`)
+	hrefRe        = regexp.MustCompile(`<a[^>]*class="result__a"[^>]*href="([^"]*)"`)
+	stripHTMLRe   = regexp.MustCompile("<[^>]*>")
 )
 
 type duckDuckGoProvider struct {
@@ -79,20 +84,58 @@ func (p *duckDuckGoProvider) Search(ctx context.Context, query string, numResult
 // interface allows swapping to a more robust backend (e.g., Brave or Tavily)
 // without changing the tool implementation.
 func parseDDGResults(htmlBody string, limit int) []Result {
-	titles := titleRe.FindAllStringSubmatch(htmlBody, -1)
-	snippets := snippetRe.FindAllStringSubmatch(htmlBody, -1)
-	hrefs := hrefRe.FindAllStringSubmatch(htmlBody, -1)
-
-	count := min(len(titles), len(snippets), len(hrefs), limit)
-	results := make([]Result, 0, count)
-	for i := 0; i < count; i++ {
+	results := make([]Result, 0, limit)
+	starts := resultStartRe.FindAllStringIndex(htmlBody, -1)
+	for _, start := range starts {
+		if len(results) >= limit {
+			break
+		}
+		block := extractResultBlock(htmlBody, start[0])
+		titleMatch := titleRe.FindStringSubmatch(block)
+		snippetMatch := snippetRe.FindStringSubmatch(block)
+		hrefMatch := hrefRe.FindStringSubmatch(block)
+		if titleMatch == nil || snippetMatch == nil || hrefMatch == nil {
+			continue
+		}
 		results = append(results, Result{
-			Title:   stripHTML(titles[i][1]),
-			Snippet: stripHTML(snippets[i][1]),
-			URL:     resolveDDGURL(hrefs[i][1]),
+			Title:   stripHTML(titleMatch[1]),
+			Snippet: stripHTML(snippetMatch[1]),
+			URL:     resolveDDGURL(hrefMatch[1]),
 		})
 	}
 	return results
+}
+
+// extractResultBlock returns the <div class="result..."> block starting at
+// start, balancing nested <div> tags. If no balanced closing tag is found, it
+// returns the remainder of htmlBody.
+func extractResultBlock(htmlBody string, start int) string {
+	if start >= len(htmlBody) {
+		return ""
+	}
+	tagEnd := strings.Index(htmlBody[start:], ">")
+	if tagEnd == -1 {
+		return htmlBody[start:]
+	}
+	tagEnd += start + 1
+
+	depth := 1
+	pos := tagEnd
+	for pos < len(htmlBody) && depth > 0 {
+		if strings.HasPrefix(htmlBody[pos:], "<div") {
+			depth++
+			pos += 4
+		} else if strings.HasPrefix(htmlBody[pos:], "</div>") {
+			depth--
+			if depth == 0 {
+				return htmlBody[start : pos+6]
+			}
+			pos += 6
+		} else {
+			pos++
+		}
+	}
+	return htmlBody[start:]
 }
 
 func stripHTML(s string) string {

--- a/internal/websearch/duckduckgo.go
+++ b/internal/websearch/duckduckgo.go
@@ -36,12 +36,16 @@ type duckDuckGoProvider struct {
 
 // NewDuckDuckGoProvider creates a DuckDuckGo search provider.
 func NewDuckDuckGoProvider(client *http.Client) Provider {
+	return newDuckDuckGoProvider(client, DuckDuckGoBaseURL)
+}
+
+func newDuckDuckGoProvider(client *http.Client, baseURL string) *duckDuckGoProvider {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &duckDuckGoProvider{
 		client:  client,
-		baseURL: DuckDuckGoBaseURL,
+		baseURL: baseURL,
 	}
 }
 

--- a/internal/websearch/duckduckgo_test.go
+++ b/internal/websearch/duckduckgo_test.go
@@ -2,11 +2,11 @@ package websearch
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -98,6 +98,63 @@ func TestDuckDuckGoProvider_EmptyResults(t *testing.T) {
 	}
 }
 
+func TestStripHTML(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "hello", "hello"},
+		{"nested tags", "<div><b>bold</b> text</div>", "bold text"},
+		{"entities", "Hello &amp; world", "Hello & world"},
+		{"quoted", "&quot;quoted&quot;", `"quoted"`},
+		{"whitespace", "  <b>text</b>  ", "text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripHTML(tt.in); got != tt.want {
+				t.Errorf("stripHTML(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDDGURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "redirect",
+			in:   "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F",
+			want: "https://example.com/",
+		},
+		{
+			name: "protocol relative redirect",
+			in:   "//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F",
+			want: "https://example.com/",
+		},
+		{
+			name: "direct url",
+			in:   "https://example.com/page",
+			want: "https://example.com/page",
+		},
+		{
+			name: "malformed url",
+			in:   "http://%ZZ",
+			want: "http://%ZZ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveDDGURL(tt.in); got != tt.want {
+				t.Errorf("resolveDDGURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDuckDuckGoProvider_DefaultClient(t *testing.T) {
 	provider := NewDuckDuckGoProvider(nil)
 	if provider == nil {
@@ -105,15 +162,60 @@ func TestDuckDuckGoProvider_DefaultClient(t *testing.T) {
 	}
 }
 
+type countingReadCloser struct {
+	io.ReadCloser
+	n *atomic.Int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.ReadCloser.Read(p)
+	c.n.Add(int64(n))
+	return n, err
+}
+
+type countingTransport struct {
+	base http.RoundTripper
+	n    *atomic.Int64
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &countingReadCloser{ReadCloser: resp.Body, n: c.n}
+	return resp, nil
+}
+
 func TestDuckDuckGoProvider_BodySizeCap(t *testing.T) {
-	large := strings.Repeat(" ", 2*1024*1024)
+	// Result markup appears only after the 1 MiB cap. If the entire body
+	// were read, parseDDGResults would find it.
+	padding := strings.Repeat(" ", maxResponseBytes+1024)
+	body := `<html><body>` + padding + `
+<div class="result results_links results_links_deep web-result">
+	<div class="links_main links_deep result__body">
+		<h2 class="result__title">
+			<a class="result__a" href="https://example.com/">Late Result</a>
+		</h2>
+		<div class="result__snippet">Should not appear.</div>
+	</div>
+</div>
+</body></html>`
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprint(w, `<html><body>`+large+`</body></html>`)
+		_, _ = io.WriteString(w, body)
 	}))
 	defer server.Close()
 
-	provider := NewDuckDuckGoProvider(server.Client())
+	var readBytes atomic.Int64
+	transport := &countingTransport{
+		base: &http.Transport{},
+		n:    &readBytes,
+	}
+	client := &http.Client{Transport: transport}
+
+	provider := NewDuckDuckGoProvider(client)
 	ddg := provider.(*duckDuckGoProvider)
 	ddg.baseURL = server.URL
 	results, err := provider.Search(context.Background(), "test", 1)
@@ -122,6 +224,9 @@ func TestDuckDuckGoProvider_BodySizeCap(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Fatalf("expected 0 results from oversized body, got %d", len(results))
+	}
+	if readBytes.Load() >= int64(len(body)) {
+		t.Fatalf("expected body not to be fully read; read %d of %d bytes", readBytes.Load(), len(body))
 	}
 }
 

--- a/internal/websearch/duckduckgo_test.go
+++ b/internal/websearch/duckduckgo_test.go
@@ -155,6 +155,34 @@ func TestResolveDDGURL(t *testing.T) {
 	}
 }
 
+func TestParseDDGResults_MissingSnippetDoesNotCorruptAlignment(t *testing.T) {
+	html := `<!DOCTYPE html>
+<html><body>
+<div class="result results_links results_links_deep web-result">
+	<a class="result__a" href="https://first.com/">First</a>
+	<div class="result__snippet">First snippet.</div>
+</div>
+<div class="result results_links results_links_deep web-result">
+	<a class="result__a" href="https://second.com/">Second</a>
+</div>
+<div class="result results_links results_links_deep web-result">
+	<a class="result__a" href="https://third.com/">Third</a>
+	<div class="result__snippet">Third snippet.</div>
+</div>
+</body></html>`
+
+	results := parseDDGResults(html, 10)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Title != "First" || results[0].Snippet != "First snippet." || results[0].URL != "https://first.com/" {
+		t.Errorf("result 0 = %+v, want First/First snippet./https://first.com/", results[0])
+	}
+	if results[1].Title != "Third" || results[1].Snippet != "Third snippet." || results[1].URL != "https://third.com/" {
+		t.Errorf("result 1 = %+v, want Third/Third snippet./https://third.com/", results[1])
+	}
+}
+
 func TestDuckDuckGoProvider_DefaultClient(t *testing.T) {
 	provider := NewDuckDuckGoProvider(nil)
 	if provider == nil {

--- a/internal/websearch/duckduckgo_test.go
+++ b/internal/websearch/duckduckgo_test.go
@@ -32,10 +32,7 @@ func TestDuckDuckGoProvider_Search(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := server.Client()
-	provider := NewDuckDuckGoProvider(client)
-	ddg := provider.(*duckDuckGoProvider)
-	ddg.baseURL = server.URL
+	provider := newDuckDuckGoProvider(server.Client(), server.URL)
 
 	results, err := provider.Search(context.Background(), "golang", 2)
 	if err != nil {
@@ -70,9 +67,7 @@ func TestDuckDuckGoProvider_SearchErrorStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider := NewDuckDuckGoProvider(server.Client())
-	ddg := provider.(*duckDuckGoProvider)
-	ddg.baseURL = server.URL
+	provider := newDuckDuckGoProvider(server.Client(), server.URL)
 	_, err := provider.Search(context.Background(), "test", 1)
 	if err == nil {
 		t.Fatal("expected error for non-OK status")
@@ -86,9 +81,7 @@ func TestDuckDuckGoProvider_EmptyResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	provider := NewDuckDuckGoProvider(server.Client())
-	ddg := provider.(*duckDuckGoProvider)
-	ddg.baseURL = server.URL
+	provider := newDuckDuckGoProvider(server.Client(), server.URL)
 	results, err := provider.Search(context.Background(), "xyznothing", 5)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -243,9 +236,7 @@ func TestDuckDuckGoProvider_BodySizeCap(t *testing.T) {
 	}
 	client := &http.Client{Transport: transport}
 
-	provider := NewDuckDuckGoProvider(client)
-	ddg := provider.(*duckDuckGoProvider)
-	ddg.baseURL = server.URL
+	provider := newDuckDuckGoProvider(client, server.URL)
 	results, err := provider.Search(context.Background(), "test", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/websearch/duckduckgo_test.go
+++ b/internal/websearch/duckduckgo_test.go
@@ -1,0 +1,160 @@
+package websearch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDuckDuckGoProvider_Search(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if got := r.FormValue("q"); got != "golang" {
+			t.Errorf("expected query golang, got %q", got)
+		}
+
+		ua := r.UserAgent()
+		if !strings.Contains(ua, "DocsClaw") {
+			t.Errorf("expected User-Agent to contain DocsClaw, got %q", ua)
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, fakeDDGHTML)
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	provider := NewDuckDuckGoProvider(client)
+	ddg := provider.(*duckDuckGoProvider)
+	ddg.baseURL = server.URL
+
+	results, err := provider.Search(context.Background(), "golang", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	want := []Result{
+		{
+			Title:   "Go Programming Language",
+			Snippet: "The Go programming language is an open source project.",
+			URL:     "https://go.dev/",
+		},
+		{
+			Title:   "A Tour of Go",
+			Snippet: "Welcome to a tour of the Go programming language.",
+			URL:     "https://go.dev/tour/",
+		},
+	}
+	for i, w := range want {
+		if results[i] != w {
+			t.Errorf("result %d = %+v, want %+v", i, results[i], w)
+		}
+	}
+}
+
+func TestDuckDuckGoProvider_SearchErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	provider := NewDuckDuckGoProvider(server.Client())
+	ddg := provider.(*duckDuckGoProvider)
+	ddg.baseURL = server.URL
+	_, err := provider.Search(context.Background(), "test", 1)
+	if err == nil {
+		t.Fatal("expected error for non-OK status")
+	}
+}
+
+func TestDuckDuckGoProvider_EmptyResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, `<html><body><div class="no-results">No results</div></body></html>`)
+	}))
+	defer server.Close()
+
+	provider := NewDuckDuckGoProvider(server.Client())
+	ddg := provider.(*duckDuckGoProvider)
+	ddg.baseURL = server.URL
+	results, err := provider.Search(context.Background(), "xyznothing", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestDuckDuckGoProvider_DefaultClient(t *testing.T) {
+	provider := NewDuckDuckGoProvider(nil)
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestDuckDuckGoProvider_BodySizeCap(t *testing.T) {
+	large := strings.Repeat(" ", 2*1024*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<html><body>`+large+`</body></html>`)
+	}))
+	defer server.Close()
+
+	provider := NewDuckDuckGoProvider(server.Client())
+	ddg := provider.(*duckDuckGoProvider)
+	ddg.baseURL = server.URL
+	results, err := provider.Search(context.Background(), "test", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results from oversized body, got %d", len(results))
+	}
+}
+
+const fakeDDGHTML = `<!DOCTYPE html>
+<html>
+<head><title>golang at DuckDuckGo</title></head>
+<body>
+<div class="result results_links results_links_deep web-result">
+	<div class="links_main links_deep result__body">
+		<h2 class="result__title">
+			<a class="result__a" href="https://go.dev/">Go Programming Language</a>
+		</h2>
+		<a class="result__url" href="https://go.dev/">go.dev</a>
+		<div class="result__snippet">The Go programming language is an open source project.</div>
+	</div>
+</div>
+<div class="result results_links results_links_deep web-result">
+	<div class="links_main links_deep result__body">
+		<h2 class="result__title">
+			<a class="result__a" href="https://go.dev/tour/">A Tour of Go</a>
+		</h2>
+		<a class="result__url" href="https://go.dev/tour/">go.dev/tour</a>
+		<div class="result__snippet">Welcome to a tour of the Go programming language.</div>
+	</div>
+</div>
+<div class="result results_links results_links_deep web-result">
+	<div class="links_main links_deep result__body">
+		<h2 class="result__title">
+			<a class="result__a" href="https://pkg.go.dev/">Go Packages</a>
+		</h2>
+		<a class="result__url" href="https://pkg.go.dev/">pkg.go.dev</a>
+		<div class="result__snippet">Find, add, and share Go packages.</div>
+	</div>
+</div>
+</body>
+</html>`

--- a/internal/websearch/provider.go
+++ b/internal/websearch/provider.go
@@ -1,0 +1,15 @@
+package websearch
+
+import "context"
+
+// Provider defines the interface for web search backends.
+type Provider interface {
+	Search(ctx context.Context, query string, numResults int) ([]Result, error)
+}
+
+// Result represents a single search result.
+type Result struct {
+	Title   string
+	Snippet string
+	URL     string
+}

--- a/internal/websearch/websearch.go
+++ b/internal/websearch/websearch.go
@@ -23,8 +23,10 @@ func NewWebSearchTool(provider Provider) tools.Tool {
 	return &webSearchTool{provider: provider}
 }
 
-func (t *webSearchTool) Name() string        { return "web_search" }
-func (t *webSearchTool) Description() string { return "Search the web and return a list of relevant results." }
+func (t *webSearchTool) Name() string { return "web_search" }
+func (t *webSearchTool) Description() string {
+	return "Search the web and return a list of relevant results."
+}
 
 func (t *webSearchTool) Parameters() map[string]any {
 	return map[string]any{

--- a/internal/websearch/websearch.go
+++ b/internal/websearch/websearch.go
@@ -1,0 +1,85 @@
+package websearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redhat-et/docsclaw/pkg/tools"
+)
+
+const (
+	defaultNumResults = 5
+	maxNumResults     = 10
+	minNumResults     = 1
+)
+
+type webSearchTool struct {
+	provider Provider
+}
+
+// NewWebSearchTool creates a web_search tool backed by the given provider.
+func NewWebSearchTool(provider Provider) tools.Tool {
+	return &webSearchTool{provider: provider}
+}
+
+func (t *webSearchTool) Name() string        { return "web_search" }
+func (t *webSearchTool) Description() string { return "Search the web and return a list of relevant results." }
+
+func (t *webSearchTool) Parameters() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "The search query",
+			},
+			"num_results": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of results to return (default 5, max 10)",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+func (t *webSearchTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
+	query, ok := args["query"].(string)
+	if !ok || strings.TrimSpace(query) == "" {
+		return tools.Errorf("query is required")
+	}
+
+	numResults := defaultNumResults
+	if v, ok := args["num_results"]; ok {
+		switch n := v.(type) {
+		case int:
+			numResults = n
+		case int64:
+			numResults = int(n)
+		case float64:
+			numResults = int(n)
+		default:
+			return tools.Errorf("num_results must be an integer")
+		}
+	}
+	if numResults > maxNumResults {
+		numResults = maxNumResults
+	}
+	if numResults < minNumResults {
+		numResults = minNumResults
+	}
+
+	results, err := t.provider.Search(ctx, query, numResults)
+	if err != nil {
+		return tools.Errorf("web search failed: %s", err)
+	}
+	if len(results) == 0 {
+		return tools.OK("No results found.")
+	}
+
+	var b strings.Builder
+	for _, r := range results {
+		fmt.Fprintf(&b, "* [%s](%s): %s\n", r.Title, r.URL, r.Snippet)
+	}
+	return tools.OK(strings.TrimSpace(b.String()))
+}

--- a/internal/websearch/websearch.go
+++ b/internal/websearch/websearch.go
@@ -79,6 +79,9 @@ func (t *webSearchTool) Execute(ctx context.Context, args map[string]any) *tools
 		return tools.OK("No results found.")
 	}
 
+	// Titles, URLs, and snippets are inserted raw into markdown. If they
+	// contain characters such as ']', ')', or '"', the resulting markdown may
+	// be malformed. A full markdown escaper is intentionally not included.
 	var b strings.Builder
 	for _, r := range results {
 		fmt.Fprintf(&b, "* [%s](%s): %s\n", r.Title, r.URL, r.Snippet)

--- a/internal/websearch/websearch.go
+++ b/internal/websearch/websearch.go
@@ -3,6 +3,7 @@ package websearch
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/redhat-et/docsclaw/pkg/tools"
@@ -45,6 +46,16 @@ func (t *webSearchTool) Parameters() map[string]any {
 	}
 }
 
+// escapeMarkdown escapes characters that would otherwise be interpreted as
+// markdown formatting so the text renders as plain text.
+func escapeMarkdown(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "[", "\\[")
+	s = strings.ReplaceAll(s, "]", "\\]")
+	s = strings.ReplaceAll(s, "*", "\\*")
+	return s
+}
+
 func (t *webSearchTool) Execute(ctx context.Context, args map[string]any) *tools.ToolResult {
 	query, ok := args["query"].(string)
 	if !ok || strings.TrimSpace(query) == "" {
@@ -75,16 +86,20 @@ func (t *webSearchTool) Execute(ctx context.Context, args map[string]any) *tools
 	if err != nil {
 		return tools.Errorf("web search failed: %s", err)
 	}
+	if len(results) > numResults {
+		results = results[:numResults]
+	}
 	if len(results) == 0 {
 		return tools.OK("No results found.")
 	}
 
-	// Titles, URLs, and snippets are inserted raw into markdown. If they
-	// contain characters such as ']', ')', or '"', the resulting markdown may
-	// be malformed. A full markdown escaper is intentionally not included.
 	var b strings.Builder
 	for _, r := range results {
-		fmt.Fprintf(&b, "* [%s](%s): %s\n", r.Title, r.URL, r.Snippet)
+		u, err := url.Parse(r.URL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			continue
+		}
+		fmt.Fprintf(&b, "* [%s](%s): %s\n", escapeMarkdown(r.Title), r.URL, escapeMarkdown(r.Snippet))
 	}
 	return tools.OK(strings.TrimSpace(b.String()))
 }

--- a/internal/websearch/websearch_test.go
+++ b/internal/websearch/websearch_test.go
@@ -168,6 +168,31 @@ func TestWebSearchTool_NoResults(t *testing.T) {
 	}
 }
 
+func TestWebSearchTool_InvalidNumResultsType(t *testing.T) {
+	tool := NewWebSearchTool(&fakeProvider{})
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": "ten",
+	})
+	if !result.Error {
+		t.Fatal("expected error result for invalid num_results type")
+	}
+	if !strings.Contains(result.Output, "num_results must be an integer") {
+		t.Errorf("expected 'num_results must be an integer', got %q", result.Output)
+	}
+}
+
+func TestWebSearchTool_WhitespaceOnlyQuery(t *testing.T) {
+	tool := NewWebSearchTool(&fakeProvider{})
+	result := tool.Execute(context.Background(), map[string]any{"query": "   "})
+	if !result.Error {
+		t.Fatal("expected error result for whitespace-only query")
+	}
+	if !strings.Contains(result.Output, "query is required") {
+		t.Errorf("expected 'query is required', got %q", result.Output)
+	}
+}
+
 func TestWebSearchTool_OutputFormat(t *testing.T) {
 	fake := &fakeProvider{results: []Result{{
 		Title:   "Example",

--- a/internal/websearch/websearch_test.go
+++ b/internal/websearch/websearch_test.go
@@ -1,0 +1,201 @@
+package websearch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeProvider struct {
+	query      string
+	numResults int
+	results    []Result
+	err        error
+}
+
+func (f *fakeProvider) Search(_ context.Context, query string, numResults int) ([]Result, error) {
+	f.query = query
+	f.numResults = numResults
+	if f.err != nil {
+		return nil, f.err
+	}
+	if numResults > len(f.results) {
+		return f.results, nil
+	}
+	return f.results[:numResults], nil
+}
+
+func TestWebSearchTool_NameDescriptionParameters(t *testing.T) {
+	tool := NewWebSearchTool(&fakeProvider{})
+	if tool.Name() != "web_search" {
+		t.Errorf("name = %q, want web_search", tool.Name())
+	}
+	if tool.Description() == "" {
+		t.Error("description should not be empty")
+	}
+
+	params := tool.Parameters()
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("expected properties map")
+	}
+	if _, ok := props["query"]; !ok {
+		t.Error("expected query property")
+	}
+	if _, ok := props["num_results"]; !ok {
+		t.Error("expected num_results property")
+	}
+	required, ok := params["required"].([]string)
+	if !ok || len(required) != 1 || required[0] != "query" {
+		t.Errorf("expected required [query], got %v", params["required"])
+	}
+}
+
+func TestWebSearchTool_RequiresQuery(t *testing.T) {
+	tool := NewWebSearchTool(&fakeProvider{})
+	result := tool.Execute(context.Background(), map[string]any{})
+	if !result.Error {
+		t.Fatal("expected error result for missing query")
+	}
+	if !strings.Contains(result.Output, "query is required") {
+		t.Errorf("expected 'query is required', got %q", result.Output)
+	}
+}
+
+func TestWebSearchTool_DefaultNumResults(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(10)}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{"query": "go"})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if fake.numResults != 5 {
+		t.Errorf("expected default num_results 5, got %d", fake.numResults)
+	}
+	if strings.Count(result.Output, "* [") != 5 {
+		t.Errorf("expected 5 markdown list items, got:\n%s", result.Output)
+	}
+}
+
+func TestWebSearchTool_ExplicitNumResults(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(10)}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": 3,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if fake.numResults != 3 {
+		t.Errorf("expected num_results 3, got %d", fake.numResults)
+	}
+	if strings.Count(result.Output, "* [") != 3 {
+		t.Errorf("expected 3 markdown list items, got:\n%s", result.Output)
+	}
+}
+
+func TestWebSearchTool_NumResultsFloat64(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(10)}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": float64(2),
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if fake.numResults != 2 {
+		t.Errorf("expected num_results 2, got %d", fake.numResults)
+	}
+}
+
+func TestWebSearchTool_NumResultsMaxCap(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(15)}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": 20,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if fake.numResults != 10 {
+		t.Errorf("expected num_results capped to 10, got %d", fake.numResults)
+	}
+	if strings.Count(result.Output, "* [") != 10 {
+		t.Errorf("expected 10 markdown list items, got:\n%s", result.Output)
+	}
+}
+
+func TestWebSearchTool_NumResultsMinCap(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(10)}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": -3,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if fake.numResults != 1 {
+		t.Errorf("expected num_results clamped to 1, got %d", fake.numResults)
+	}
+}
+
+func TestWebSearchTool_ProviderError(t *testing.T) {
+	fake := &fakeProvider{err: errors.New("search failed")}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{"query": "go"})
+	if !result.Error {
+		t.Fatal("expected error result")
+	}
+	if !strings.Contains(result.Output, "search failed") {
+		t.Errorf("expected error message to contain 'search failed', got %q", result.Output)
+	}
+}
+
+func TestWebSearchTool_NoResults(t *testing.T) {
+	fake := &fakeProvider{results: []Result{}}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{"query": "xyznothing"})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if !strings.Contains(result.Output, "No results") {
+		t.Errorf("expected 'No results' message, got %q", result.Output)
+	}
+}
+
+func TestWebSearchTool_OutputFormat(t *testing.T) {
+	fake := &fakeProvider{results: []Result{{
+		Title:   "Example",
+		Snippet: "An example site.",
+		URL:     "https://example.com/",
+	}}}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "example",
+		"num_results": 1,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	want := "* [Example](https://example.com/): An example site."
+	if !strings.Contains(result.Output, want) {
+		t.Errorf("expected output to contain %q, got:\n%s", want, result.Output)
+	}
+}
+
+func makeResults(n int) []Result {
+	results := make([]Result, n)
+	for i := 0; i < n; i++ {
+		results[i] = Result{
+			Title:   "Result",
+			Snippet: "Snippet",
+			URL:     "https://example.com/",
+		}
+	}
+	return results
+}

--- a/internal/websearch/websearch_test.go
+++ b/internal/websearch/websearch_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 type fakeProvider struct {
-	query      string
-	numResults int
-	results    []Result
-	err        error
+	query       string
+	numResults  int
+	results     []Result
+	err         error
+	ignoreLimit bool
 }
 
 func (f *fakeProvider) Search(_ context.Context, query string, numResults int) ([]Result, error) {
@@ -19,6 +20,9 @@ func (f *fakeProvider) Search(_ context.Context, query string, numResults int) (
 	f.numResults = numResults
 	if f.err != nil {
 		return nil, f.err
+	}
+	if f.ignoreLimit {
+		return f.results, nil
 	}
 	if numResults > len(f.results) {
 		return f.results, nil
@@ -210,6 +214,73 @@ func TestWebSearchTool_OutputFormat(t *testing.T) {
 	want := "* [Example](https://example.com/): An example site."
 	if !strings.Contains(result.Output, want) {
 		t.Errorf("expected output to contain %q, got:\n%s", want, result.Output)
+	}
+}
+
+func TestWebSearchTool_MarkdownEscaping(t *testing.T) {
+	fake := &fakeProvider{results: []Result{{
+		Title:   "[A] B *C*",
+		Snippet: "See [link] and \\backslash.",
+		URL:     "https://example.com/",
+	}}}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "example",
+		"num_results": 1,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	want := `* [\[A\] B \*C\*](https://example.com/)`
+	if !strings.Contains(result.Output, want) {
+		t.Errorf("expected escaped title %q, got:\n%s", want, result.Output)
+	}
+	wantSnippet := `See \[link\] and \\backslash.`
+	if !strings.Contains(result.Output, wantSnippet) {
+		t.Errorf("expected escaped snippet %q, got:\n%s", wantSnippet, result.Output)
+	}
+	if strings.Contains(result.Output, "See [link]") {
+		t.Errorf("expected snippet brackets to be escaped, got:\n%s", result.Output)
+	}
+}
+
+func TestWebSearchTool_SkipsNonHTTPSchemes(t *testing.T) {
+	fake := &fakeProvider{results: []Result{
+		{Title: "Bad", Snippet: "bad scheme", URL: "javascript:alert(1)"},
+		{Title: "Good", Snippet: "good scheme", URL: "https://example.com/"},
+		{Title: "FTP", Snippet: "ftp scheme", URL: "ftp://example.com/"},
+	}}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "example",
+		"num_results": 10,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if strings.Contains(result.Output, "javascript") {
+		t.Errorf("expected javascript URL to be filtered, got:\n%s", result.Output)
+	}
+	if strings.Contains(result.Output, "ftp://") {
+		t.Errorf("expected ftp URL to be filtered, got:\n%s", result.Output)
+	}
+	if !strings.Contains(result.Output, "Good") {
+		t.Errorf("expected https URL to be included, got:\n%s", result.Output)
+	}
+}
+
+func TestWebSearchTool_ResultCapping(t *testing.T) {
+	fake := &fakeProvider{results: makeResults(10), ignoreLimit: true}
+	tool := NewWebSearchTool(fake)
+	result := tool.Execute(context.Background(), map[string]any{
+		"query":       "go",
+		"num_results": 3,
+	})
+	if result.Error {
+		t.Fatalf("unexpected error: %s", result.Output)
+	}
+	if strings.Count(result.Output, "* [") != 3 {
+		t.Errorf("expected 3 markdown list items, got:\n%s", result.Output)
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,9 +1,31 @@
 package workspace
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
+
+// ResolveWorkspacePath resolves path against workspaceDir, returning an
+// absolute path. If workspaceDir is empty, path is resolved against the
+// current working directory. If workspaceDir is non-empty and the resolved
+// path lies outside the workspace, an error is returned.
+func ResolveWorkspacePath(path, workspaceDir string) (string, error) {
+	if workspaceDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(workspaceDir, path)
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	if workspaceDir != "" && !IsInsideWorkspace(absPath, workspaceDir) {
+		return "", fmt.Errorf("path outside workspace: %s", absPath)
+	}
+
+	return absPath, nil
+}
 
 // IsInsideWorkspace checks if path is inside workspace, resolving
 // symlinks to prevent traversal bypasses.

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,63 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveWorkspacePathEmptyWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	resolved, err := ResolveWorkspacePath(path, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != path {
+		t.Fatalf("expected %q, got %q", path, resolved)
+	}
+}
+
+func TestResolveWorkspacePathRelativeInsideWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	resolved, err := ResolveWorkspacePath("file.txt", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(dir, "file.txt")
+	if resolved != expected {
+		t.Fatalf("expected %q, got %q", expected, resolved)
+	}
+}
+
+func TestResolveWorkspacePathAbsoluteInsideWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	resolved, err := ResolveWorkspacePath(path, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != path {
+		t.Fatalf("expected %q, got %q", path, resolved)
+	}
+}
+
+func TestResolveWorkspacePathOutsideWorkspaceBlocked(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "..", "escaped.txt")
+
+	_, err := ResolveWorkspacePath(path, dir)
+	if err == nil {
+		t.Fatal("expected error for path outside workspace")
+	}
+	if !strings.Contains(err.Error(), "path outside workspace") {
+		t.Fatalf("expected outside workspace error, got %q", err)
+	}
+}

--- a/pkg/tools/loop_test.go
+++ b/pkg/tools/loop_test.go
@@ -87,7 +87,7 @@ func TestRunToolLoopWithToolCall(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "test_tool", output: "ok"})
+	mustRegister(t, registry, &mockTool{name: "test_tool", output: "ok"})
 
 	messages := []llm.Message{
 		{Role: "user", Content: "Use the tool"},
@@ -117,7 +117,7 @@ func TestRunToolLoopMaxIterations(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "test_tool", output: "ok"})
+	mustRegister(t, registry, &mockTool{name: "test_tool", output: "ok"})
 
 	cfg := DefaultLoopConfig()
 	cfg.MaxIterations = 3
@@ -184,7 +184,7 @@ func TestRunToolLoopTruncatesLargeOutput(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "big_tool", output: largeOutput})
+	mustRegister(t, registry, &mockTool{name: "big_tool", output: largeOutput})
 
 	cfg := DefaultLoopConfig()
 	cfg.MaxResultBytes = 1000
@@ -275,9 +275,9 @@ func TestRunToolLoopParallelExecution(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&slowMockTool{name: "slow_a", output: "a", delay: delay})
-	registry.Register(&slowMockTool{name: "slow_b", output: "b", delay: delay})
-	registry.Register(&slowMockTool{name: "slow_c", output: "c", delay: delay})
+	mustRegister(t, registry, &slowMockTool{name: "slow_a", output: "a", delay: delay})
+	mustRegister(t, registry, &slowMockTool{name: "slow_b", output: "b", delay: delay})
+	mustRegister(t, registry, &slowMockTool{name: "slow_c", output: "c", delay: delay})
 
 	hook := &mockHook{}
 	cfg := DefaultLoopConfig()
@@ -365,7 +365,7 @@ func TestAfterToolCallHook(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "test_tool", output: "result_value"})
+	mustRegister(t, registry, &mockTool{name: "test_tool", output: "result_value"})
 
 	hook := &mockHook{}
 	cfg := DefaultLoopConfig()
@@ -409,7 +409,7 @@ func TestBeforeToolCallHookDenial(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "blocked_tool", output: "should not see this"})
+	mustRegister(t, registry, &mockTool{name: "blocked_tool", output: "should not see this"})
 
 	hook := &mockHook{denyTool: "blocked_tool"}
 	cfg := DefaultLoopConfig()
@@ -461,7 +461,7 @@ func TestRunToolLoopTracing(t *testing.T) {
 	}
 
 	registry := NewRegistry(nil)
-	registry.Register(&mockTool{name: "test_tool", output: "tool_result"})
+	mustRegister(t, registry, &mockTool{name: "test_tool", output: "tool_result"})
 
 	messages := []llm.Message{
 		{Role: "user", Content: "Use the tool"},

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -12,12 +12,14 @@ type Registry struct {
 	tools         map[string]Tool
 	alwaysAllowed map[string]bool
 	allowedFilter map[string]bool // nil means all allowed
+	aliases       map[string]string
 }
 
 func NewRegistry(allowedTools []string) *Registry {
 	r := &Registry{
 		tools:         make(map[string]Tool),
 		alwaysAllowed: make(map[string]bool),
+		aliases:       make(map[string]string),
 	}
 	if len(allowedTools) > 0 {
 		r.allowedFilter = make(map[string]bool, len(allowedTools))
@@ -41,14 +43,28 @@ func (r *Registry) RegisterAlwaysAllowed(t Tool) {
 	r.alwaysAllowed[t.Name()] = true
 }
 
+func (r *Registry) RegisterAlias(alias, canonical string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.aliases[alias] = canonical
+}
+
+func (r *Registry) resolveLocked(name string) string {
+	if canonical, ok := r.aliases[name]; ok {
+		return canonical
+	}
+	return name
+}
+
 func (r *Registry) Get(name string) (Tool, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	t, exists := r.tools[name]
+	canonical := r.resolveLocked(name)
+	t, exists := r.tools[canonical]
 	if !exists {
 		return nil, false
 	}
-	if r.allowedFilter != nil && !r.allowedFilter[name] && !r.alwaysAllowed[name] {
+	if r.allowedFilter != nil && !r.allowedFilter[canonical] && !r.alwaysAllowed[canonical] {
 		return nil, false
 	}
 	return t, true

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
@@ -43,10 +44,26 @@ func (r *Registry) RegisterAlwaysAllowed(t Tool) {
 	r.alwaysAllowed[t.Name()] = true
 }
 
-func (r *Registry) RegisterAlias(alias, canonical string) {
+// RegisterAlias maps alias to canonical so that Get(alias) resolves to the
+// tool registered under canonical. Aliases are resolved before the allowed
+// filter is applied; therefore allowedTools must list the canonical tool
+// name, not the alias, for the alias to be usable. RegisterAlias returns an
+// error if alias or canonical are empty, or if alias matches a tool name
+// already registered in the registry.
+func (r *Registry) RegisterAlias(alias, canonical string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if alias == "" {
+		return fmt.Errorf("alias cannot be empty")
+	}
+	if canonical == "" {
+		return fmt.Errorf("canonical cannot be empty")
+	}
+	if _, exists := r.tools[alias]; exists {
+		return fmt.Errorf("alias %q conflicts with an existing tool name", alias)
+	}
 	r.aliases[alias] = canonical
+	return nil
 }
 
 func (r *Registry) resolveLocked(name string) string {

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -34,8 +34,8 @@ func NewRegistry(allowedTools []string) *Registry {
 func (r *Registry) Register(t Tool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, exists := r.aliases[t.Name()]; exists {
-		return fmt.Errorf("tool name %q conflicts with an existing alias", t.Name())
+	if err := r.registerCollisionLocked(t.Name()); err != nil {
+		return err
 	}
 	r.tools[t.Name()] = t
 	return nil
@@ -44,11 +44,21 @@ func (r *Registry) Register(t Tool) error {
 func (r *Registry) RegisterAlwaysAllowed(t Tool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, exists := r.aliases[t.Name()]; exists {
-		return fmt.Errorf("tool name %q conflicts with an existing alias", t.Name())
+	if err := r.registerCollisionLocked(t.Name()); err != nil {
+		return err
 	}
 	r.tools[t.Name()] = t
 	r.alwaysAllowed[t.Name()] = true
+	return nil
+}
+
+func (r *Registry) registerCollisionLocked(name string) error {
+	if _, exists := r.aliases[name]; exists {
+		return fmt.Errorf("tool name %q conflicts with an existing alias", name)
+	}
+	if _, exists := r.tools[name]; exists {
+		return fmt.Errorf("tool %q is already registered", name)
+	}
 	return nil
 }
 

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -31,17 +31,25 @@ func NewRegistry(allowedTools []string) *Registry {
 	return r
 }
 
-func (r *Registry) Register(t Tool) {
+func (r *Registry) Register(t Tool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if _, exists := r.aliases[t.Name()]; exists {
+		return fmt.Errorf("tool name %q conflicts with an existing alias", t.Name())
+	}
 	r.tools[t.Name()] = t
+	return nil
 }
 
-func (r *Registry) RegisterAlwaysAllowed(t Tool) {
+func (r *Registry) RegisterAlwaysAllowed(t Tool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if _, exists := r.aliases[t.Name()]; exists {
+		return fmt.Errorf("tool name %q conflicts with an existing alias", t.Name())
+	}
 	r.tools[t.Name()] = t
 	r.alwaysAllowed[t.Name()] = true
+	return nil
 }
 
 // RegisterAlias maps alias to canonical so that Get(alias) resolves to the
@@ -49,7 +57,8 @@ func (r *Registry) RegisterAlwaysAllowed(t Tool) {
 // filter is applied; therefore allowedTools must list the canonical tool
 // name, not the alias, for the alias to be usable. RegisterAlias returns an
 // error if alias or canonical are empty, or if alias matches a tool name
-// already registered in the registry.
+// already registered in the registry. Register and RegisterAlwaysAllowed
+// symmetrically reject a tool whose name matches an existing alias.
 func (r *Registry) RegisterAlias(alias, canonical string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -68,6 +68,9 @@ func (r *Registry) RegisterAlias(alias, canonical string) error {
 	if canonical == "" {
 		return fmt.Errorf("canonical cannot be empty")
 	}
+	if existingCanonical, exists := r.aliases[alias]; exists && existingCanonical != canonical {
+		return fmt.Errorf("alias %q already maps to %q", alias, existingCanonical)
+	}
 	if _, exists := r.tools[alias]; exists {
 		return fmt.Errorf("alias %q conflicts with an existing tool name", alias)
 	}

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -18,9 +18,23 @@ func (m *mockTool) Execute(_ context.Context, _ map[string]any) *ToolResult {
 	return &ToolResult{Output: m.output}
 }
 
+func mustRegister(t *testing.T, r *Registry, tool Tool) {
+	t.Helper()
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("Register(%q) failed: %v", tool.Name(), err)
+	}
+}
+
+func mustRegisterAlwaysAllowed(t *testing.T, r *Registry, tool Tool) {
+	t.Helper()
+	if err := r.RegisterAlwaysAllowed(tool); err != nil {
+		t.Fatalf("RegisterAlwaysAllowed(%q) failed: %v", tool.Name(), err)
+	}
+}
+
 func TestRegistryRegisterAndGet(t *testing.T) {
 	r := NewRegistry(nil)
-	r.Register(&mockTool{name: "test_tool", output: "ok"})
+	mustRegister(t, r, &mockTool{name: "test_tool", output: "ok"})
 
 	tool, ok := r.Get("test_tool")
 	if !ok {
@@ -33,8 +47,8 @@ func TestRegistryRegisterAndGet(t *testing.T) {
 
 func TestRegistryAllowedFilter(t *testing.T) {
 	r := NewRegistry([]string{"allowed_tool"})
-	r.Register(&mockTool{name: "allowed_tool"})
-	r.Register(&mockTool{name: "blocked_tool"})
+	mustRegister(t, r, &mockTool{name: "allowed_tool"})
+	mustRegister(t, r, &mockTool{name: "blocked_tool"})
 
 	if _, ok := r.Get("allowed_tool"); !ok {
 		t.Fatal("allowed_tool should be accessible")
@@ -46,8 +60,8 @@ func TestRegistryAllowedFilter(t *testing.T) {
 
 func TestRegistryDefinitions(t *testing.T) {
 	r := NewRegistry(nil)
-	r.Register(&mockTool{name: "tool_a"})
-	r.Register(&mockTool{name: "tool_b"})
+	mustRegister(t, r, &mockTool{name: "tool_a"})
+	mustRegister(t, r, &mockTool{name: "tool_b"})
 
 	defs := r.Definitions()
 	if len(defs) != 2 {
@@ -57,8 +71,8 @@ func TestRegistryDefinitions(t *testing.T) {
 
 func TestRegistryAlwaysAllowed(t *testing.T) {
 	r := NewRegistry([]string{"only_this"})
-	r.Register(&mockTool{name: "only_this"})
-	r.RegisterAlwaysAllowed(&mockTool{name: "load_skill"})
+	mustRegister(t, r, &mockTool{name: "only_this"})
+	mustRegisterAlwaysAllowed(t, r, &mockTool{name: "load_skill"})
 
 	if _, ok := r.Get("load_skill"); !ok {
 		t.Fatal("load_skill should bypass allowed filter")
@@ -70,7 +84,7 @@ func TestRegistryAlwaysAllowed(t *testing.T) {
 
 func TestRegistryAliasLookup(t *testing.T) {
 	r := NewRegistry(nil)
-	r.Register(&mockTool{name: "read_file"})
+	mustRegister(t, r, &mockTool{name: "read_file"})
 	if err := r.RegisterAlias("read", "read_file"); err != nil {
 		t.Fatalf("RegisterAlias failed: %v", err)
 	}
@@ -86,7 +100,7 @@ func TestRegistryAliasLookup(t *testing.T) {
 
 func TestRegistryDefinitionsExcludeAliases(t *testing.T) {
 	r := NewRegistry(nil)
-	r.Register(&mockTool{name: "read_file"})
+	mustRegister(t, r, &mockTool{name: "read_file"})
 	if err := r.RegisterAlias("read", "read_file"); err != nil {
 		t.Fatalf("RegisterAlias failed: %v", err)
 	}
@@ -102,8 +116,8 @@ func TestRegistryDefinitionsExcludeAliases(t *testing.T) {
 
 func TestRegistryAllowedToolsWithAlias(t *testing.T) {
 	r := NewRegistry([]string{"read_file"})
-	r.Register(&mockTool{name: "read_file"})
-	r.Register(&mockTool{name: "write_file"})
+	mustRegister(t, r, &mockTool{name: "read_file"})
+	mustRegister(t, r, &mockTool{name: "write_file"})
 	if err := r.RegisterAlias("read", "read_file"); err != nil {
 		t.Fatalf("RegisterAlias read failed: %v", err)
 	}
@@ -121,7 +135,7 @@ func TestRegistryAllowedToolsWithAlias(t *testing.T) {
 
 func TestRegistryAllowedToolsUsesCanonicalName(t *testing.T) {
 	r := NewRegistry([]string{"read"})
-	r.Register(&mockTool{name: "read_file"})
+	mustRegister(t, r, &mockTool{name: "read_file"})
 	if err := r.RegisterAlias("read", "read_file"); err != nil {
 		t.Fatalf("RegisterAlias failed: %v", err)
 	}
@@ -141,7 +155,7 @@ func TestRegistryAllowedToolsUsesCanonicalName(t *testing.T) {
 
 func TestRegisterAliasValidation(t *testing.T) {
 	r := NewRegistry(nil)
-	r.Register(&mockTool{name: "existing_tool"})
+	mustRegister(t, r, &mockTool{name: "existing_tool"})
 
 	if err := r.RegisterAlias("", "read_file"); err == nil {
 		t.Fatal("expected error for empty alias")
@@ -151,5 +165,29 @@ func TestRegisterAliasValidation(t *testing.T) {
 	}
 	if err := r.RegisterAlias("existing_tool", "other"); err == nil {
 		t.Fatal("expected error when alias conflicts with existing tool name")
+	}
+}
+
+func TestRegisterRejectsAliasCollision(t *testing.T) {
+	r := NewRegistry(nil)
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias failed: %v", err)
+	}
+
+	if err := r.Register(&mockTool{name: "read"}); err == nil {
+		t.Fatal("expected error when registering a tool whose name matches an existing alias")
+	}
+	if err := r.RegisterAlwaysAllowed(&mockTool{name: "read"}); err == nil {
+		t.Fatal("expected error when RegisterAlwaysAllowed name matches an existing alias")
+	}
+
+	// The alias should still resolve to its canonical target once registered.
+	mustRegister(t, r, &mockTool{name: "read_file"})
+	tool, ok := r.Get("read")
+	if !ok {
+		t.Fatal("expected alias read to still resolve")
+	}
+	if tool.Name() != "read_file" {
+		t.Fatalf("expected read_file, got %q", tool.Name())
 	}
 }

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -71,7 +71,9 @@ func TestRegistryAlwaysAllowed(t *testing.T) {
 func TestRegistryAliasLookup(t *testing.T) {
 	r := NewRegistry(nil)
 	r.Register(&mockTool{name: "read_file"})
-	r.RegisterAlias("read", "read_file")
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias failed: %v", err)
+	}
 
 	tool, ok := r.Get("read")
 	if !ok {
@@ -85,7 +87,9 @@ func TestRegistryAliasLookup(t *testing.T) {
 func TestRegistryDefinitionsExcludeAliases(t *testing.T) {
 	r := NewRegistry(nil)
 	r.Register(&mockTool{name: "read_file"})
-	r.RegisterAlias("read", "read_file")
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias failed: %v", err)
+	}
 
 	defs := r.Definitions()
 	if len(defs) != 1 {
@@ -100,13 +104,52 @@ func TestRegistryAllowedToolsWithAlias(t *testing.T) {
 	r := NewRegistry([]string{"read_file"})
 	r.Register(&mockTool{name: "read_file"})
 	r.Register(&mockTool{name: "write_file"})
-	r.RegisterAlias("read", "read_file")
-	r.RegisterAlias("write", "write_file")
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias read failed: %v", err)
+	}
+	if err := r.RegisterAlias("write", "write_file"); err != nil {
+		t.Fatalf("RegisterAlias write failed: %v", err)
+	}
 
 	if _, ok := r.Get("read"); !ok {
 		t.Fatal("alias read should be allowed because read_file is allowed")
 	}
 	if _, ok := r.Get("write"); ok {
 		t.Fatal("alias write should be blocked because write_file is not allowed")
+	}
+}
+
+func TestRegistryAllowedToolsUsesCanonicalName(t *testing.T) {
+	r := NewRegistry([]string{"read"})
+	r.Register(&mockTool{name: "read_file"})
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias failed: %v", err)
+	}
+
+	// Definitions only include tools whose canonical name is allowed.
+	defs := r.Definitions()
+	if len(defs) != 0 {
+		t.Fatalf("expected 0 definitions because canonical name read_file is not allowed, got %d", len(defs))
+	}
+
+	// Get("read") resolves to read_file before the allowed filter, so it is
+	// blocked because read_file is not in allowedTools.
+	if _, ok := r.Get("read"); ok {
+		t.Fatal("expected Get(read) to be false because canonical name read_file is not allowed")
+	}
+}
+
+func TestRegisterAliasValidation(t *testing.T) {
+	r := NewRegistry(nil)
+	r.Register(&mockTool{name: "existing_tool"})
+
+	if err := r.RegisterAlias("", "read_file"); err == nil {
+		t.Fatal("expected error for empty alias")
+	}
+	if err := r.RegisterAlias("read", ""); err == nil {
+		t.Fatal("expected error for empty canonical")
+	}
+	if err := r.RegisterAlias("existing_tool", "other"); err == nil {
+		t.Fatal("expected error when alias conflicts with existing tool name")
 	}
 }

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -168,6 +168,24 @@ func TestRegisterAliasValidation(t *testing.T) {
 	}
 }
 
+func TestRegisterAliasRejectsOverwrite(t *testing.T) {
+	r := NewRegistry(nil)
+	mustRegister(t, r, &mockTool{name: "read_file"})
+	mustRegister(t, r, &mockTool{name: "write_file"})
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("RegisterAlias failed: %v", err)
+	}
+
+	if err := r.RegisterAlias("read", "write_file"); err == nil {
+		t.Fatal("expected error when overwriting alias with a different canonical")
+	}
+
+	// Re-registering the same alias to the same canonical should succeed.
+	if err := r.RegisterAlias("read", "read_file"); err != nil {
+		t.Fatalf("re-registering alias to same canonical failed: %v", err)
+	}
+}
+
 func TestRegisterRejectsAliasCollision(t *testing.T) {
 	r := NewRegistry(nil)
 	if err := r.RegisterAlias("read", "read_file"); err != nil {

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -67,3 +67,46 @@ func TestRegistryAlwaysAllowed(t *testing.T) {
 		t.Fatal("only_this should be accessible")
 	}
 }
+
+func TestRegistryAliasLookup(t *testing.T) {
+	r := NewRegistry(nil)
+	r.Register(&mockTool{name: "read_file"})
+	r.RegisterAlias("read", "read_file")
+
+	tool, ok := r.Get("read")
+	if !ok {
+		t.Fatal("expected alias read to resolve to read_file")
+	}
+	if tool.Name() != "read_file" {
+		t.Fatalf("expected read_file, got %q", tool.Name())
+	}
+}
+
+func TestRegistryDefinitionsExcludeAliases(t *testing.T) {
+	r := NewRegistry(nil)
+	r.Register(&mockTool{name: "read_file"})
+	r.RegisterAlias("read", "read_file")
+
+	defs := r.Definitions()
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 definition, got %d", len(defs))
+	}
+	if defs[0].Name != "read_file" {
+		t.Fatalf("expected read_file, got %q", defs[0].Name)
+	}
+}
+
+func TestRegistryAllowedToolsWithAlias(t *testing.T) {
+	r := NewRegistry([]string{"read_file"})
+	r.Register(&mockTool{name: "read_file"})
+	r.Register(&mockTool{name: "write_file"})
+	r.RegisterAlias("read", "read_file")
+	r.RegisterAlias("write", "write_file")
+
+	if _, ok := r.Get("read"); !ok {
+		t.Fatal("alias read should be allowed because read_file is allowed")
+	}
+	if _, ok := r.Get("write"); ok {
+		t.Fatal("alias write should be blocked because write_file is not allowed")
+	}
+}

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -186,6 +186,18 @@ func TestRegisterAliasRejectsOverwrite(t *testing.T) {
 	}
 }
 
+func TestRegisterRejectsDuplicateTool(t *testing.T) {
+	r := NewRegistry(nil)
+	mustRegister(t, r, &mockTool{name: "existing_tool"})
+
+	if err := r.Register(&mockTool{name: "existing_tool"}); err == nil {
+		t.Fatal("expected error when registering a duplicate tool")
+	}
+	if err := r.RegisterAlwaysAllowed(&mockTool{name: "existing_tool"}); err == nil {
+		t.Fatal("expected error when RegisterAlwaysAllowed a duplicate tool")
+	}
+}
+
 func TestRegisterRejectsAliasCollision(t *testing.T) {
 	r := NewRegistry(nil)
 	if err := r.RegisterAlias("read", "read_file"); err != nil {


### PR DESCRIPTION
## Summary

Adds tool-name aliases and new tools so agents developed in OpenClaw/Hermes run unchanged on DocsClaw.

- `pkg/tools`: alias support in Registry (`read`→`read_file`, `write`→`write_file`, `terminal`→`exec`); reciprocal alias/tool collision checks.
- `internal/searchfiles`: new `search_files` tool backed by ripgrep, constrained to the workspace.
- `internal/websearch`: new `web_search` tool with a swappable Provider interface and a DuckDuckGo HTML-scraping adapter.
- `internal/applypatch`: new `apply_patch` tool for unified diffs.
- `internal/edit`: new `edit` tool for exact-string replacement.
- `internal/fileutil`: shared atomic file-write helper preserving file mode.
- Container images now install `ripgrep` for `search_files`.

## Test Plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] `make build` passes
- [x] `make build-skill-puller` passes

Design spec: `docs/superpowers/specs/2026-08-22-openclaw-tool-compat-design.md`